### PR TITLE
Cell event bubbling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "description": "Data grid for React",
   "main": "src/index.js",
   "scripts": {

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -181,27 +181,28 @@ var Cell = React.createClass({
   },
 
   onCellClick(e: SyntheticMouseEvent){
-    if (e && typeof e.preventDefault === 'function') {
-      e.preventDefault();
-    }
-    if (e && typeof e.stopPropagation === 'function') {
-      e.stopPropagation();
-    }
     var meta = this.props.cellMetaData;
     if(meta != null && meta.onCellClick != null) {
+      if (e && typeof e.preventDefault === 'function') {
+        e.preventDefault();
+      }
+      if (e && typeof e.stopPropagation === 'function') {
+        e.stopPropagation();
+      }
       meta.onCellClick({rowIdx : this.props.rowIdx, idx : this.props.idx});
     }
   },
 
   onCellDoubleClick(e: SyntheticMouseEvent){
-    if (e && typeof e.preventDefault === 'function') {
-      e.preventDefault();
-    }
-    if (e && typeof e.stopPropagation === 'function') {
-      e.stopPropagation();
-    }
+
     var meta = this.props.cellMetaData;
     if(meta != null && meta.onCellDoubleClick != null) {
+      if (e && typeof e.preventDefault === 'function') {
+        e.preventDefault();
+      }
+      if (e && typeof e.stopPropagation === 'function') {
+        e.stopPropagation();
+      }
       meta.onCellDoubleClick({rowIdx : this.props.rowIdx, idx : this.props.idx});
     }
   },

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -183,11 +183,10 @@ var Cell = React.createClass({
   onCellClick(e: SyntheticMouseEvent){
     var meta = this.props.cellMetaData;
     if(meta != null && meta.onCellClick != null) {
+      //we DONT stopPropogation here - others may want to know about the click
+      //however, if we need to do that, we should do in a specific cell (ie close to the source that needs us to stop propoagation)
       if (e && typeof e.preventDefault === 'function') {
         e.preventDefault();
-      }
-      if (e && typeof e.stopPropagation === 'function') {
-        e.stopPropagation();
       }
       meta.onCellClick({rowIdx : this.props.rowIdx, idx : this.props.idx});
     }


### PR DESCRIPTION
Only prevent events bubbling where we actually handle them
Previously we did preventDefault before checking if this cell had a click event.
It also removes stopPropagation as others may want to grab hold of this event, so unless there is a good reason not to - we should not swallow.
Where a good reason exists, we can swallow at a lower level (or add an option to do that via cellMetaData?)

That means you cant do things like a simple row based onClick in an overriden rowRenderer - This fixes that