### PR TITLE
use babel es6 not jsx

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,218 @@
 {
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "jasmine" : true
+  },
+  "globals" : {
+    "adz": true,
+    jQuery: true
+  },
+  "ecmaFeatures": {
+    "arrowFunctions": true,
+    "blockBindings": true,
+    "classes": true,
+    "defaultParams": true,
+    "destructuring": true,
+    "forOf": true,
+    "generators": false,
+    "modules": true,
+    "objectLiteralComputedProperties": true,
+    "objectLiteralDuplicateProperties": false,
+    "objectLiteralShorthandMethods": true,
+    "objectLiteralShorthandProperties": true,
+    "spread": true,
+    "superInFunctions": true,
+    "templateStrings": true,
+    "jsx": true
   },
   "rules": {
-  
+/**
+ * Strict mode
+ */
+    // babel inserts "use strict"; for us
+    // http://eslint.org/docs/rules/strict
+    "strict": [2, "never"],
+
+/**
+ * ES6
+ */
+    "no-var": 2,                     // http://eslint.org/docs/rules/no-var
+
+/**
+ * Variables
+ */
+    "no-shadow": 2,                  // http://eslint.org/docs/rules/no-shadow
+    "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
+    "no-unused-vars": [2, {          // http://eslint.org/docs/rules/no-unused-vars
+      "vars": "local",
+      "args": "after-used"
+    }],
+    "no-use-before-define": 2,       // http://eslint.org/docs/rules/no-use-before-define
+
+/**
+ * Possible errors
+ */
+    "comma-dangle": [2, "never"],    // http://eslint.org/docs/rules/comma-dangle
+    "no-cond-assign": [2, "always"], // http://eslint.org/docs/rules/no-cond-assign
+    "no-console": 1,                 // http://eslint.org/docs/rules/no-console
+    "no-debugger": 1,                // http://eslint.org/docs/rules/no-debugger
+    "no-alert": 1,                   // http://eslint.org/docs/rules/no-alert
+    "no-constant-condition": 1,      // http://eslint.org/docs/rules/no-constant-condition
+    "no-dupe-keys": 2,               // http://eslint.org/docs/rules/no-dupe-keys
+    "no-duplicate-case": 2,          // http://eslint.org/docs/rules/no-duplicate-case
+    "no-empty": 2,                   // http://eslint.org/docs/rules/no-empty
+    "no-ex-assign": 2,               // http://eslint.org/docs/rules/no-ex-assign
+    "no-extra-boolean-cast": 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
+    "no-extra-semi": 2,              // http://eslint.org/docs/rules/no-extra-semi
+    "no-func-assign": 2,             // http://eslint.org/docs/rules/no-func-assign
+    "no-inner-declarations": 2,      // http://eslint.org/docs/rules/no-inner-declarations
+    "no-invalid-regexp": 2,          // http://eslint.org/docs/rules/no-invalid-regexp
+    "no-irregular-whitespace": 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
+    "no-obj-calls": 2,               // http://eslint.org/docs/rules/no-obj-calls
+    "no-reserved-keys": 2,           // http://eslint.org/docs/rules/no-reserved-keys
+    "no-sparse-arrays": 2,           // http://eslint.org/docs/rules/no-sparse-arrays
+    "no-unreachable": 2,             // http://eslint.org/docs/rules/no-unreachable
+    "use-isnan": 2,                  // http://eslint.org/docs/rules/use-isnan
+    "block-scoped-var": 2,           // http://eslint.org/docs/rules/block-scoped-var
+
+/**
+ * Best practices
+ */
+    "consistent-return": 2,          // http://eslint.org/docs/rules/consistent-return
+    "curly": [2, "multi-line"],      // http://eslint.org/docs/rules/curly
+    "default-case": 2,               // http://eslint.org/docs/rules/default-case
+    "dot-notation": [2, {            // http://eslint.org/docs/rules/dot-notation
+      "allowKeywords": true
+    }],
+    "eqeqeq": 2,                     // http://eslint.org/docs/rules/eqeqeq
+    "guard-for-in": 2,               // http://eslint.org/docs/rules/guard-for-in
+    "no-caller": 2,                  // http://eslint.org/docs/rules/no-caller
+    "no-else-return": 2,             // http://eslint.org/docs/rules/no-else-return
+    "no-eq-null": 2,                 // http://eslint.org/docs/rules/no-eq-null
+    "no-eval": 2,                    // http://eslint.org/docs/rules/no-eval
+    "no-extend-native": 2,           // http://eslint.org/docs/rules/no-extend-native
+    "no-extra-bind": 2,              // http://eslint.org/docs/rules/no-extra-bind
+    "no-fallthrough": 2,             // http://eslint.org/docs/rules/no-fallthrough
+    "no-floating-decimal": 2,        // http://eslint.org/docs/rules/no-floating-decimal
+    "no-implied-eval": 2,            // http://eslint.org/docs/rules/no-implied-eval
+    "no-lone-blocks": 2,             // http://eslint.org/docs/rules/no-lone-blocks
+    "no-loop-func": 2,               // http://eslint.org/docs/rules/no-loop-func
+    "no-multi-str": 2,               // http://eslint.org/docs/rules/no-multi-str
+    "no-native-reassign": 2,         // http://eslint.org/docs/rules/no-native-reassign
+    "no-new": 2,                     // http://eslint.org/docs/rules/no-new
+    "no-new-func": 2,                // http://eslint.org/docs/rules/no-new-func
+    "no-new-wrappers": 2,            // http://eslint.org/docs/rules/no-new-wrappers
+    "no-octal": 2,                   // http://eslint.org/docs/rules/no-octal
+    "no-octal-escape": 2,            // http://eslint.org/docs/rules/no-octal-escape
+    "no-param-reassign": 2,          // http://eslint.org/docs/rules/no-param-reassign
+    "no-proto": 2,                   // http://eslint.org/docs/rules/no-proto
+    "no-redeclare": 2,               // http://eslint.org/docs/rules/no-redeclare
+    "no-return-assign": 2,           // http://eslint.org/docs/rules/no-return-assign
+    "no-script-url": 2,              // http://eslint.org/docs/rules/no-script-url
+    "no-self-compare": 2,            // http://eslint.org/docs/rules/no-self-compare
+    "no-sequences": 2,               // http://eslint.org/docs/rules/no-sequences
+    "no-throw-literal": 2,           // http://eslint.org/docs/rules/no-throw-literal
+    "no-with": 2,                    // http://eslint.org/docs/rules/no-with
+    "radix": 2,                      // http://eslint.org/docs/rules/radix
+    "vars-on-top": 2,                // http://eslint.org/docs/rules/vars-on-top
+    "wrap-iife": [2, "any"],         // http://eslint.org/docs/rules/wrap-iife
+    "yoda": 2,                       // http://eslint.org/docs/rules/yoda
+
+/**
+ * Style
+ */
+    "indent": [2, 2],                // http://eslint.org/docs/rules/
+    "brace-style": [2,               // http://eslint.org/docs/rules/brace-style
+      "1tbs", {
+      "allowSingleLine": true
+    }],
+    "quotes": [
+      2, "single", "avoid-escape"    // http://eslint.org/docs/rules/quotes
+    ],
+    "camelcase": [2, {               // http://eslint.org/docs/rules/camelcase
+      "properties": "never"
+    }],
+    "comma-spacing": [2, {           // http://eslint.org/docs/rules/comma-spacing
+      "before": false,
+      "after": true
+    }],
+    "comma-style": [2, "last"],      // http://eslint.org/docs/rules/comma-style
+    "eol-last": 2,                   // http://eslint.org/docs/rules/eol-last
+    "key-spacing": [2, {             // http://eslint.org/docs/rules/key-spacing
+        "beforeColon": false,
+        "afterColon": true
+    }],
+    "new-cap": [2, {                 // http://eslint.org/docs/rules/new-cap
+      "newIsCap": true,
+      newIsCapExceptions : ['moment']
+    }],
+    "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+      "max": 2
+    }],
+    "no-nested-ternary": 2,          // http://eslint.org/docs/rules/no-nested-ternary
+    "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
+    "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
+    "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
+    "no-wrap-func": 2,               // http://eslint.org/docs/rules/no-wrap-func
+    "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
+    "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
+    "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
+    "semi": [2, "always"],           // http://eslint.org/docs/rules/semi
+    "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
+      "before": false,
+      "after": true
+    }],
+    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
+    "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
+    "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
+    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
+    "spaced-line-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
+
+/**
+ * JSX style
+ */
+    "react/display-name": 0,
+    "react/jsx-boolean-value": 2,
+    "react/jsx-quotes": [2, "double"],
+    "react/jsx-no-undef": 2,
+    "react/jsx-sort-props": 0,
+    "react/jsx-sort-prop-types": 0,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/no-did-mount-set-state": [2, "allow-in-func"],
+    "react/no-did-update-set-state": 2,
+    "react/no-unknown-property": 2,
+    "react/prop-types": 2,
+    "react/react-in-jsx-scope": 2,
+    "react/self-closing-comp": 2,
+    "react/wrap-multilines": 2,
+    "react/sort-comp": [2, {
+      "order": [
+        "displayName",
+        "mixins",
+        "statics",
+        "propTypes",
+        "getDefaultProps",
+        "getInitialState",
+        "componentWillMount",
+        "componentDidMount",
+        "componentWillReceiveProps",
+        "shouldComponentUpdate",
+        "componentWillUpdate",
+        "componentWillUnmount",
+        "componentDidUpdate",
+        "/^on.+$/",
+        "/^handle.+$/",
+        "/^get.+$/",
+        "/^render.+$/",
+        "render"
+      ]
+    }]
   }
 }

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -31,7 +31,11 @@ module.exports = {
   },
   module: {
     loaders: [
-    { test: /\.js$/, loader: 'jsx-loader?stripTypes&harmony' } // loaders can take parameters as a querystring
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader?optional[]=runtime'
+      } 
     ]
   },
   plugins: [

--- a/gulp/tasks/tests.js
+++ b/gulp/tasks/tests.js
@@ -5,11 +5,11 @@ var argv = require('minimist')(process.argv.slice(2));
 var RELEASE = argv.release;
 
 
-gulp.task('test', function (cb) {
+gulp.task('test', function (done) {
   var singleRun = argv.debug ? false : true;
   karma.start({
     configFile:  '../../../config/karma.js',
     singleRun: singleRun,
     debug: argv.debug
-  }, cb);
+  }, function() { done(); });
 });

--- a/src/KeyboardHandlerMixin.js
+++ b/src/KeyboardHandlerMixin.js
@@ -17,7 +17,7 @@ var KeyboardHandlerMixin = {
     if(this.isCtrlKeyHeldDown(e)){
       this.checkAndCall('onPressKeyWithCtrl', e);
     }
-    else if (this.isKeyIdentified(e.key)) {
+    else if (this.isKeyExplicitlyHandled(e.key)) {
       //break up individual keyPress events to have their own specific callbacks
       //this allows multiple mixins to listen to onKeyDown events and somewhat reduces methodName clashing
       var callBack = 'onPress' + e.key;
@@ -40,8 +40,8 @@ var KeyboardHandlerMixin = {
     return valid;
   },
 
-  isKeyIdentified(key: string): boolean{
-    return key !== "Unidentified";
+  isKeyExplicitlyHandled(key: string): boolean{
+    return typeof this['onPress' + key] === 'function';
   },
 
   isCtrlKeyHeldDown(e: SyntheticKeyboardEvent): boolean{

--- a/src/__tests__/ColumnMetrics.spec.js
+++ b/src/__tests__/ColumnMetrics.spec.js
@@ -68,30 +68,30 @@ describe('Column Metrics Tests', () => {
   describe('Comparing Columns', () => {
 
     describe('Using array of object literals', () => {
-
+      let prevColumns,nextColumns;
       beforeEach(() => {
         var helpers = require('./GridPropHelpers');
-        this.prevColumns = helpers.columns;
-        this.nextColumns = helpers.columns.map(c => {
+        prevColumns = helpers.columns;
+        nextColumns = helpers.columns.map(c => {
           return Object.assign({}, c);
         });
       });
 
       it('columns with same properties should be equal', () => {
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(areColumnsEqual).toBe(true);
       });
 
       it('changing a single property in one column will make columns unequal', () => {
-        this.nextColumns[0].width = 101;
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        nextColumns[0].width = 101;
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(areColumnsEqual).toBe(false);
       });
 
       it('should call compareEachColumn when comparing columns', () => {
         var compareEachColumnSpy = jasmine.createSpy();
         ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(compareEachColumnSpy).toHaveBeenCalled();
         expect(compareEachColumnSpy.callCount).toEqual(1);
       });
@@ -99,41 +99,42 @@ describe('Column Metrics Tests', () => {
     });
 
     describe('Using ImmutableJs Lists', () => {
+      let prevColumns,nextColumns;
 
       beforeEach(() => {
         var helpers = require('./GridPropHelpers');
-        this.prevColumns = new Immutable.List(helpers.columns);
-        this.nextColumns = this.prevColumns;
+        prevColumns = new Immutable.List(helpers.columns);
+        nextColumns = prevColumns;
       });
 
       it('columns with same memory reference are equal', () => {
 
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(areColumnsEqual).toBe(true);
       });
 
       it('columns with same properties are not equal when objects have different memory reference', () => {
-        var firstColWidth = this.prevColumns.get(0).width;
+        var firstColWidth = prevColumns.get(0).width;
 
-        this.nextColumns = this.nextColumns.update(0, (c) => {
+        nextColumns = nextColumns.update(0, (c) => {
           c.width = firstColWidth;
         });
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(areColumnsEqual).toBe(false);
       });
 
       it('changing a single property in one column will make columns unequal', () => {
-        this.nextColumns = this.nextColumns.update(0, (c) => {
+        nextColumns = nextColumns.update(0, (c) => {
           c.width = 101;
         });
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(areColumnsEqual).toBe(false);
       });
 
       it('should not call compareEachColumn when comparing columns', () => {
         var compareEachColumnSpy = jasmine.createSpy();
         ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
-        var areColumnsEqual = ColumnMetrics.sameColumns(this.prevColumns, this.nextColumns, ColumnMetrics.sameColumn);
+        var areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
         expect(compareEachColumnSpy).not.toHaveBeenCalled();
         expect(compareEachColumnSpy.callCount).toEqual(0);
       });

--- a/src/addons/__tests__/Grid-integration.spec.js
+++ b/src/addons/__tests__/Grid-integration.spec.js
@@ -113,11 +113,11 @@ class GridRunner {
     return this;
   }
   isNotEditable() {
-    expect(this.getEditor()).toEqual(null);
+    expect(this.getEditor()).toBe(undefined);
     return this;
   }
   isEditable() {
-    expect(this.getEditor()).not.toEqual(null);
+    expect(this.getEditor()).not.toBe(undefined);
     return this;
   }
   hasSelected({rowIdx,cellIdx,expectedClass='selected'}) {
@@ -184,7 +184,7 @@ describe('Grid Integration', () => {
   describe('Editors', () => {
     it("Readonly columns are NOT Editable", () => {
       new GridRunner({})
-      .clickIntoEditor({cellIdx:1,rowIdx:3})
+      .clickIntoEditor({cellIdx:0,rowIdx:3})
       .isNotEditable();
     });
     it("Enter commits an edit", () => {
@@ -236,14 +236,14 @@ describe('Grid Integration', () => {
       })
     });
     it("Arrow Right commits your change when you are at the end of the text", () => {
-      new GridRunner({})
-      //by default, cursor is at the end of the text
-      .changeCell({
-        select: {row:3, cell:5},
-        val:'Test',
-        ev:{key:'ArrowRight'},
-        expectToSelect: {row:3,cell:6}
-      })
+      new GridRunner({renderIntoBody: true})
+        .clickIntoEditor({rowIdx:3, cellIdx:5})
+        .setValue('Test')
+        .setCursor(4)
+        .keyDown({key:'ArrowRight'})
+        .hasCommitted('Test')
+        .hasSelected({rowIdx:3,cellIdx:6})
+        .dispose();
     });
 
     it("Arrow Right doesnt commit your change when you are at the end of the text", () => {

--- a/src/addons/__tests__/Grid-integration.spec.js
+++ b/src/addons/__tests__/Grid-integration.spec.js
@@ -48,6 +48,7 @@ class GridRunner {
     this.row = TestUtils.scryRenderedDOMComponentsWithClass(this.grid,'react-grid-Row')[rowIdx];
     this.cell = TestUtils.scryRenderedDOMComponentsWithClass(this.row,'react-grid-Cell')[cellIdx];
     TestUtils.Simulate.click(this.cell);
+    return this;
   }
   clickIntoEditor({cellIdx,rowIdx}) {
     //activate it
@@ -74,8 +75,8 @@ class GridRunner {
             You need to specify renderIntoBody:true in the constructor for GridRunner`)
     return this;
   }
-  keyDown(ev) {
-    TestUtils.Simulate.keyDown(this.getEditor(),ev);
+  keyDown(ev, element=this.getEditor()) {
+    TestUtils.Simulate.keyDown(element,ev);
     return this;
   }
 
@@ -181,6 +182,14 @@ describe('Grid Integration', () => {
       .hasDragged({from:0,to:4,col:3,cellKey:'title'})
     });
   });
+  describe('Grid Selection', () => {
+    it("Selects on click", () => {
+      new GridRunner({})
+      .selectCell({cellIdx:3,rowIdx:3})
+      .hasSelected({cellIdx:3,rowIdx:3})
+      .dispose();
+    });
+  });
   describe('Editors', () => {
     it("Readonly columns are NOT Editable", () => {
       new GridRunner({})
@@ -197,7 +206,30 @@ describe('Grid Integration', () => {
         })
 
     });
-    it("Can tab out of an Editor", () => {
+
+
+    it("Start editing by pressing a key", () => {
+      let grid=new GridRunner({});
+      grid.selectCell({rowIdx:3, cellIdx:5})
+        .keyDown({
+          keyCode:69 //letter 'e'
+        }, grid.cell )
+        .isEditable()
+        .keyDown({key:'Enter'})
+        .hasCommitted('E') //keydown ALWAYS upper case http://stackoverflow.com/questions/2263889/why-always-uppercase-in-my-code
+        .isNotEditable()
+        .dispose();
+
+    });
+    it("Start editing by pressing enter", () => {
+      let grid=new GridRunner({});
+        grid.selectCell({rowIdx:3, cellIdx:5})
+        .keyDown({key:'Enter'}, grid.cell)
+        .isEditable()
+        .dispose();
+
+    });
+   it("Can tab out of an Editor", () => {
       new GridRunner({})
       .changeCell({
         select: {row:3, cell:5},

--- a/src/addons/__tests__/GridRunner.js
+++ b/src/addons/__tests__/GridRunner.js
@@ -1,0 +1,151 @@
+var React        = require('react');
+var TestUtils    = require('react/lib/ReactTestUtils');
+var ExampleGrid = require('../../../examples/scripts/example14-all-features-immutable');
+
+export default class GridRunner {
+  /* =====
+  SETUP
+  ======== */
+  constructor({renderIntoBody=false}) {
+    this.grid = this._renderGrid(renderIntoBody);
+    this.renderIntoBody=renderIntoBody;
+  }
+
+  _renderGrid(intoBody) {
+    this.handleCellDragSpy =  jasmine.createSpy("handleCellDrag");
+    return intoBody ?
+      React.render(<ExampleGrid handleCellDrag={this.handleCellDragSpy}/>, document.body)
+      : TestUtils.renderIntoDocument(<ExampleGrid handleCellDrag={this.handleCellDragSpy}/>);
+  }
+
+  dispose() {
+    if(this.renderIntoBody) {
+      React.unmountComponentAtNode(document.body);
+    }
+    this.grid = null;
+  }
+
+  /* =====
+  HELPERS
+  ======== */
+  //Helpers - these are just wrappers to run several steps
+  //NOTE: these are 'final' functions, ie they call dispose at the end
+  changeCell({select:{cell:selectCell,row:selectRow},val,ev,expectToSelect:{row:expectRow,cell:expectCell}}) {
+    this
+      .clickIntoEditor({cellIdx:selectCell,rowIdx:selectRow})
+      .setValue(val)
+      .keyDown(ev)
+      .hasCommitted(val)
+      .hasSelected({cellIdx:expectCell,rowIdx:expectRow})
+      .dispose();
+  }
+
+  /* =====
+  ACTIONS
+  ======== */
+  selectCell({cellIdx,rowIdx}) {
+    this.row = TestUtils.scryRenderedDOMComponentsWithClass(this.grid,'react-grid-Row')[rowIdx];
+    this.cell = TestUtils.scryRenderedDOMComponentsWithClass(this.row,'react-grid-Cell')[cellIdx];
+    TestUtils.Simulate.click(this.cell);
+    return this;
+  }
+  clickIntoEditor({cellIdx,rowIdx}) {
+    //activate it
+    // have to do click then doubleClick as thast what the browser would actually emit
+    this.selectCell({cellIdx,rowIdx})
+    TestUtils.Simulate.doubleClick(this.cell);
+    return this;
+  }
+  getEditor() {
+    return TestUtils.scryRenderedDOMComponentsWithTag(this.cell,'input')[0];
+  }
+  setValue(val) {
+    this.getEditor().getDOMNode().value = val;
+    //remember to set the value via the dom node, not the component!
+    return this;
+  }
+  //you MUST have set the grid to render into body to use this
+  //chrome (et al) dont do cursor positions unless you are properly visibile
+  setCursor(start,end=start) {
+    const input = this.getEditor().getDOMNode();
+    input.setSelectionRange(start,end);
+    expect(input.selectionStart).toEqual(start,`Couldnt set the cursor.
+            You probably havent rendered the grid into the *actual* dom.
+            You need to specify renderIntoBody:true in the constructor for GridRunner`)
+    return this;
+  }
+  keyDown(ev, element=this.getEditor()) {
+    TestUtils.Simulate.keyDown(element,ev);
+    return this;
+  }
+
+  drag({from, to, col,beforeDragEnter=null,beforeDragEnd=null}) {
+    this.selectCell({cellIdx:col,rowIdx:from})
+
+    const rows = TestUtils.scryRenderedDOMComponentsWithClass(this.grid,'react-grid-Row');
+    let over = [];
+    over.push(this.row);
+    for(let i=from++;i<to;i++) {
+      over.push(TestUtils.scryRenderedDOMComponentsWithClass(rows[i],'react-grid-Cell')[col])
+    }
+    const toCell = TestUtils.scryRenderedDOMComponentsWithClass(rows[to],'react-grid-Cell')[col];
+    over.push(toCell);
+
+    //Act
+    //do the drag
+    //Important: we need dragStart / dragEnter / dragEnd
+    TestUtils.Simulate.dragStart(this.row.getDOMNode());
+    if(beforeDragEnter) {beforeDragEnter();}
+
+    over.forEach((r) => {
+      TestUtils.Simulate.dragEnter(r.getDOMNode())
+    });
+    if(beforeDragEnd) {beforeDragEnd();}
+    TestUtils.Simulate.dragEnd(toCell.getDOMNode());
+
+    return this;
+  }
+  /* =====
+  ASSERTS
+  ======== */
+  hasCommitted(val) {
+    expect(this.cell.props.value).toEqual(val);
+    return this;
+  }
+  isNotEditable() {
+    expect(this.getEditor()).toBe(undefined);
+    return this;
+  }
+  isEditable() {
+    expect(this.getEditor()).not.toBe(undefined);
+    return this;
+  }
+  hasSelected({rowIdx,cellIdx,expectedClass='selected'}) {
+    //and should move to the appropriate cell/row
+    const selectedRow = TestUtils.scryRenderedDOMComponentsWithClass(this.grid,'react-grid-Row')[rowIdx];
+    const selected = TestUtils.scryRenderedDOMComponentsWithClass(selectedRow,expectedClass);
+    expect(selected.length).toEqual(1);
+    expect(selected[0].props.rowIdx).toEqual(rowIdx);
+    expect(selected[0].props.idx).toEqual(cellIdx + 1);
+    //note - idx is 1 based, not 0 based.
+    //We make that more sensible by adding 1, so your test cell idx matches up
+    return this;
+  }
+  hasDragged({from,to,col,cellKey}) {
+    //check onCellDrag called with correct data
+    expect(this.handleCellDragSpy).toHaveBeenCalled();
+    //Note - fake date is random, so need to test vs the assigned value as it WILL change (and bust the test)
+    var expected= this.cell.props.value;
+    //chek our event returns the right data
+    expect(this.handleCellDragSpy.argsForCall[0][0]).toEqual({cellKey: cellKey, fromRow: from, toRow: to, value: expected});
+    //and the component
+    const rows = TestUtils.scryRenderedDOMComponentsWithClass(this.grid,'react-grid-Row');
+    const toCell = TestUtils.scryRenderedDOMComponentsWithClass(rows[to],'react-grid-Cell')[col];
+
+    expect(toCell.props.value).toEqual(expected);
+    //and finally the rendered data
+    //use trim as we are reading from the dom so get some whitespace at the end
+    expect(TestUtils.findRenderedDOMComponentWithClass(toCell,'react-grid-Cell__value').getDOMNode().textContent.trim()).toEqual(expected.trim());
+  }
+
+}

--- a/src/addons/editors/__tests__/AutoCompleteEditor.spec.js
+++ b/src/addons/editors/__tests__/AutoCompleteEditor.spec.js
@@ -127,7 +127,6 @@ describe('AutoCompleteEditor', () => {
 
       describe('Input Events', () => {
         it('clicking on an item should trigger commit', () => {
-          debugger;
           var Autocomplete = TestUtils.findRenderedComponentWithType(component, AutoCompleteEditor);
           var textInputEle = Autocomplete.getInputNode();
           // Click on input


### PR DESCRIPTION
babel-loader not deprecated jsx (also means we get es6 sugar)
fix some issues with column metrics transpiling (cant use this inside a jasmine spec)
create a GridRunner class that encapsulates a bunch of test logic to make new integration tests way easier