### PR TITLE
Fix grid width issues

### DIFF
--- a/src/ColumnMetrics.js
+++ b/src/ColumnMetrics.js
@@ -10,6 +10,7 @@ var shallowCloneObject            = require('./shallowCloneObject');
 var isValidElement = require('react').isValidElement;
 var sameColumn = require('./ColumnComparer');
 var ColumnUtils = require('./ColumnUtils');
+var getScrollbarSize  = require('./getScrollbarSize');
 
 type ColumnMetricsType = {
     columns: Array<Column>;
@@ -35,6 +36,7 @@ function recalculate(metrics: ColumnMetricsType): ColumnMetricsType {
     var unallocatedWidth = columns.filter(c => c.width).reduce((w, column) => {
       return w - column.width;
     }, metrics.totalWidth);
+    unallocatedWidth -= getScrollbarSize();
 
     var width = columns.filter(c => c.width).reduce((w, column) => {
       return w + column.width;

--- a/src/ColumnMetricsMixin.js
+++ b/src/ColumnMetricsMixin.js
@@ -30,7 +30,7 @@ module.exports = {
 
   DOMMetrics: {
     gridWidth(): number {
-      return React.findDOMNode(this).offsetWidth - 2;
+      return React.findDOMNode(this).parentElement.offsetWidth;
     }
   },
 

--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -24,7 +24,6 @@ var HeaderCell = React.createClass({
   },
 
   render(): ?ReactElement {
-    debugger;
     var resizeHandle;
     if(this.props.column.resizable){
       resizeHandle = <ResizeHandle

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -105,7 +105,7 @@ describe('Grid', () => {
   it("should be initialized with correct state", () => {
 
     expect(component.state).toEqual({
-      columnMetrics : { columns : [ { key : 'id', name : 'ID', width : 100, left : 0 }, { key : 'title', name : 'Title', width : 100, left : 100 }, { key : 'count', name : 'Count', width : 100, left : 200 } ], width : 300, totalWidth : -2, minColumnWidth : 80 },
+      columnMetrics : { columns : [ { key : 'id', name : 'ID', width : 100, left : 0 }, { key : 'title', name : 'Title', width : 100, left : 100 }, { key : 'count', name : 'Count', width : 100, left : 200 } ], width : 300, totalWidth : 0, minColumnWidth : 80 },
       selectedRows : _selectedRows,
       selected : {rowIdx : 0,  idx : 0},
       copied : null,

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -142,8 +142,8 @@ var ReactDataGrid = React.createClass({
 
 
     var toolbar = this.renderToolbar();
-    var gridWidth = this.DOMMetrics.gridWidth();
-    var containerWidth = gridWidth  + this.state.scrollOffset;
+    var containerWidth = this.DOMMetrics.gridWidth();
+    var gridWidth = containerWidth - this.state.scrollOffset;
 
     return(
       <div className="react-grid-Container" style={{width:containerWidth}}>

--- a/src/getScrollbarSize.js
+++ b/src/getScrollbarSize.js
@@ -9,7 +9,6 @@ function getScrollbarSize() {
     var outer = document.createElement('div');
     outer.style.width = '50px';
     outer.style.height = '50px';
-    outer.style.overflowY = 'scroll';
     outer.style.position = 'absolute';
     outer.style.top = '-200px';
     outer.style.left = '-200px';
@@ -22,6 +21,7 @@ function getScrollbarSize() {
     document.body.appendChild(outer);
 
     var outerWidth = outer.clientWidth;
+    outer.style.overflowY = 'scroll';
     var innerWidth = inner.clientWidth;
 
     document.body.removeChild(outer);


### PR DESCRIPTION
Grid was self-referential and did not adjust properly on window resize.

Also changed grid to occupy width minus scrollbar, so with ample horizontal space there will be no horizontal scroll.

Some of the original settings seemed like weird choices, so maybe I'm missing something and the actual cause of these problems are related to my project that uses the grid.

Note that these changes have only been tested in chrome on osx.