### PR TITLE
Support even and odd row classes.

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -46,7 +46,7 @@ var Row = React.createClass({
   render(): ?ReactElement {
     var className = joinClasses(
       'react-grid-Row',
-      "react-grid-Row--${this.props.idx % 2 === 0 ? 'even' : 'odd'}"
+      'react-grid-Row--' + this.props.idx % 2 === 0 ? 'even' : 'odd'
     );
 
     var style = {


### PR DESCRIPTION
Currently, the `react-grid-Row--even` and `react-grid-Row--odd` classes are not appearing properly due to a quoting bug. Here's a screenshot of the classes that are being rendered before the patch.

![image](https://cloud.githubusercontent.com/assets/104550/11027067/63bc5eb2-8666-11e5-815d-22e58a71007a.png)