### PR TITLE
Update viewport on min height change

### DIFF
--- a/src/ViewportScrollMixin.js
+++ b/src/ViewportScrollMixin.js
@@ -98,7 +98,8 @@ module.exports = {
   },
 
   componentWillReceiveProps(nextProps: { rowHeight: number; rowsCount: number }) {
-    if (this.props.rowHeight !== nextProps.rowHeight) {
+    if (this.props.rowHeight !== nextProps.rowHeight ||
+        this.props.minHeight !== nextProps.minHeight) {
       this.setState(this.getGridState(nextProps));
     } else if (this.props.rowsCount !== nextProps.rowsCount) {
       this.updateScroll(


### PR DESCRIPTION
This change allows the table `minHeight` to be updated after the initial render.
Our use case is that the we want the table to be the full size of the window; if the window size changes, the table should reflect this.

__Note:__ I have a few PRs I'm putting up, but I was unable to get the tests to run. Is there a particular node environment I should use? The command hangs for me without running the tests; I cancel it after ~2 minutes.