### PR TITLE
Remove object wrapper from component

### DIFF
--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -42,7 +42,7 @@ var HeaderCell = React.createClass({
     return (
       <div className={className} style={this.getStyle()}>
         {cell}
-        {{resizeHandle}}
+        {resizeHandle}
       </div>
     );
   },


### PR DESCRIPTION
The object wrapper on this component caused React to output a warning about keyed objects:
```
Any use of a keyed object should be wrapped in React.addons.createFragment(object) before being passed as a child
```