### PR TITLE
Allow columns to be removed and added after initial render

### DIFF
--- a/config/karma.js
+++ b/config/karma.js
@@ -134,7 +134,10 @@ module.exports = function (config) {
 
     autoWatch: false,
 
-    frameworks: ['jasmine'],
+    frameworks: [
+      'jasmine',
+      'jasmine-matchers'
+    ],
 
     browsers: getBrowsers(),
 
@@ -144,6 +147,7 @@ module.exports = function (config) {
     'karma-phantomjs-launcher-nonet',
     'karma-ie-launcher',
     'karma-jasmine',
+    'karma-jasmine-matchers',
     'karma-webpack',
     'karma-junit-reporter',
     'karma-coverage'

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-ie-launcher": "^0.1.5",
     "karma-jasmine": "^0.1.5",
+    "karma-jasmine-matchers": "^0.1.3",
     "karma-junit-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-phantomjs-launcher-nonet": "^0.1.3",

--- a/src/ColumnMetricsMixin.js
+++ b/src/ColumnMetricsMixin.js
@@ -45,7 +45,7 @@ module.exports = {
   componentWillReceiveProps(nextProps: ColumnMetricsType) {
     if (nextProps.columns) {
       if (!ColumnMetrics.sameColumns(this.props.columns, nextProps.columns, this.props.columnEquality)) {
-        var columnMetrics = this.createColumnMetrics();
+        var columnMetrics = this.createColumnMetrics(nextProps);
         this.setState({columnMetrics: columnMetrics});
       }
     }
@@ -95,9 +95,9 @@ module.exports = {
     this.setState({columnMetrics});
   },
 
-  createColumnMetrics(initialRun){
-    var gridColumns = this.setupGridColumns();
-    return this.getColumnMetricsType({columns:gridColumns, minColumnWidth: this.props.minColumnWidth}, initialRun);
+  createColumnMetrics(props = this.props){
+    var gridColumns = this.setupGridColumns(props);
+    return this.getColumnMetricsType({columns:gridColumns, minColumnWidth: this.props.minColumnWidth});
   },
 
   onColumnResize(index: number, width: number) {

--- a/src/Row.js
+++ b/src/Row.js
@@ -46,7 +46,7 @@ var Row = React.createClass({
   render(): ?ReactElement {
     var className = joinClasses(
       'react-grid-Row',
-      'react-grid-Row--' + this.props.idx % 2 === 0 ? 'even' : 'odd'
+      `react-grid-Row--${this.props.idx % 2 === 0 ? 'even' : 'odd'}`
     );
 
     var style = {
@@ -73,7 +73,7 @@ var Row = React.createClass({
       var CellRenderer = this.props.cellRenderer;
       var cell = <CellRenderer
                     ref={i}
-                    key={i}
+                    key={`${column.key}-${i}`}
                     idx={i}
                     rowIdx={this.props.idx}
                     value={this.getCellValue(column.key || i)}
@@ -167,13 +167,13 @@ var Row = React.createClass({
 
   shouldComponentUpdate(nextProps: any, nextState: any): boolean {
     return !(ColumnMetrics.sameColumns(this.props.columns, nextProps.columns, ColumnMetrics.sameColumn)) ||
-    this.doesRowContainSelectedCell(this.props)          ||
-    this.doesRowContainSelectedCell(nextProps)           ||
-    this.willRowBeDraggedOver(nextProps)                 ||
-    nextProps.row !== this.props.row                     ||
-    this.hasRowBeenCopied()                              ||
-    this.props.isSelected !== nextProps.isSelected       ||
-    nextProps.height !== this.props.height;
+           this.doesRowContainSelectedCell(this.props)                                                   ||
+           this.doesRowContainSelectedCell(nextProps)                                                    ||
+           this.willRowBeDraggedOver(nextProps)                                                          ||
+           nextProps.row !== this.props.row                                                              ||
+           this.hasRowBeenCopied()                                                                       ||
+           this.props.isSelected !== nextProps.isSelected                                                ||
+           nextProps.height !== this.props.height;
   },
 
   handleDragEnter(){

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -1,51 +1,47 @@
 'use strict';
-var React        = require('react');
-var rewire       = require('rewire');
-var Grid         =  rewire('../grids/ReactDataGrid.js');
-var TestUtils    = require('react/lib/ReactTestUtils');
-var rewireModule = require("../../../test/rewireModule");
+var React         = require('react');
+var rewire        = require('rewire');
+var Grid          =  rewire('../grids/ReactDataGrid.js');
+var TestUtils     = require('react/lib/ReactTestUtils');
+var rewireModule  = require("../../../test/rewireModule");
 var StubComponent = require("../../../test/StubComponent");
 
 var columns = [
-{
-  key   : 'id',
-  name  : 'ID',
-  width : 100
-},
-{
-  key: 'title',
-  name: 'Title',
-  width : 100
-},
-{
-  key: 'count',
-  name: 'Count',
-  width : 100
-},
-]
-
+  {
+    key   : 'id',
+    name  : 'ID',
+    width : 100
+  },
+  {
+    key: 'title',
+    name: 'Title',
+    width : 100
+  },
+  {
+    key: 'count',
+    name: 'Count',
+    width : 100
+  }
+];
 
 var _rows = [];
 var _selectedRows = [];
+var rowGetter = (i) => _rows[i];
 
 for (var i = 0; i < 1000; i++) {
   _rows.push({
     id: i,
-    title: 'Title ' + i,
+    title: `Title ${i}`,
     count: i * 1000
   });
 
   _selectedRows.push(false);
 }
 
-var rowGetter = function(i){
-  return _rows[i];
-}
-
-describe('Grid', () => {
-  var component;
+describe('Grid', function () {
   var BaseGridStub = StubComponent('BaseGrid');
   var CheckboxEditorStub = StubComponent('CheckboxEditor');
+
   // Configure local variable replacements for the module.
   rewireModule(Grid, {
     BaseGrid : BaseGridStub,
@@ -64,47 +60,43 @@ describe('Grid', () => {
     onGridSort : function(){}
   }
 
-  beforeEach(() => {
-    var rowsCount = 1000;
-    component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
+  beforeEach(function () {
+    this.component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
   });
 
-  it('should create a new instance of Grid', () => {
-    expect(component).toBeDefined();
+  it('should create a new instance of Grid', function () {
+    expect(this.component).toBeDefined();
   });
 
-  it('should render a BaseGrid stub', () => {
-    var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+  it('should render a BaseGrid stub', function () {
+    var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
     expect(baseGrid).toBeDefined();
   });
 
-
-  it('should render a Toolbar if passed in as props to grid', () => {
+  it('should render a Toolbar if passed in as props to grid', function () {
     var Toolbar = StubComponent('Toolbar');
-    component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
-    var toolbarInstance = TestUtils.findRenderedComponentWithType(component, Toolbar);
+    this.component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
+    var toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, Toolbar);
     expect(toolbarInstance).toBeDefined();
   });
 
-  it('onToggleFilter trigger of Toolbar should set filter state of grid and render a filterable header row', () => {
+  it('onToggleFilter trigger of Toolbar should set filter state of grid and render a filterable header row', function () {
     //arrange
     var Toolbar = StubComponent('Toolbar');
-    component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
-    var toolbarInstance = TestUtils.findRenderedComponentWithType(component, Toolbar);
+    this.component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
+    var toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, Toolbar);
     //act
     toolbarInstance.props.onToggleFilter();
     //assert
-    var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-    expect(component.state.canFilter).toBe(true);
+    var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
+    expect(this.component.state.canFilter).toBe(true);
     expect(baseGrid.props.headerRows.length).toEqual(2);
     var filterableHeaderRow = baseGrid.props.headerRows[1];
     expect(filterableHeaderRow.ref).toEqual("filterRow");
   });
 
-
-  it("should be initialized with correct state", () => {
-
-    expect(component.state).toEqual({
+  it("should be initialized with correct state", function () {
+    expect(this.component.state).toEqual({
       columnMetrics : { columns : [ { key : 'id', name : 'ID', width : 100, left : 0 }, { key : 'title', name : 'Title', width : 100, left : 100 }, { key : 'count', name : 'Count', width : 100, left : 200 } ], width : 300, totalWidth : 0, minColumnWidth : 80 },
       selectedRows : _selectedRows,
       selected : {rowIdx : 0,  idx : 0},
@@ -119,16 +111,16 @@ describe('Grid', () => {
     });
   });
 
-  describe("When cell selection disabled", () => {
+  describe("When cell selection disabled", function () {
 
-    it("grid should be initialized with selected state of {rowIdx : -1, idx : -1}", () => {
-      component = TestUtils.renderIntoDocument(<Grid
+    it("grid should be initialized with selected state of {rowIdx : -1, idx : -1}", function () {
+      this.component = TestUtils.renderIntoDocument(<Grid
         enableCellSelect={false}
         columns={columns}
         rowGetter={rowGetter}
         rowsCount={_rows.length}
         width={300}/>);
-      expect(component.state.selected).toEqual({
+      expect(this.component.state.selected).toEqual({
         rowIdx : -1,
         idx : -1
       });
@@ -136,27 +128,26 @@ describe('Grid', () => {
 
   });
 
-  describe("When row selection enabled", () => {
-
-    beforeEach(() => {
-      component = TestUtils.renderIntoDocument(<Grid {...testProps} enableRowSelect={true} />);
+  describe("When row selection enabled", function () {
+    beforeEach(function () {
+      this.component = TestUtils.renderIntoDocument(<Grid {...testProps} enableRowSelect={true} />);
     });
 
-    afterEach(() => {
-      component.setState({selectedRows : []});
+    afterEach(function () {
+      this.component.setState({selectedRows : []});
     });
 
-    it("should render an additional Select Row column", () => {
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+    it("should render an additional Select Row column", function () {
+      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var selectRowCol = baseGrid.props.columnMetrics.columns[0];
       expect(baseGrid.props.columnMetrics.columns.length).toEqual(columns.length + 1);
       expect(selectRowCol.key).toEqual('select-row');
       expect(TestUtils.isElementOfType(selectRowCol.formatter, CheckboxEditorStub)).toBe(true);
     });
 
-    it("clicking header checkbox should toggle select all rows", () => {
+    it("clicking header checkbox should toggle select all rows", function () {
       //arrange
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var selectRowCol = baseGrid.props.columnMetrics.columns[0];
       var headerCheckbox = selectRowCol.headerRenderer;
       var checkbox = document.createElement('input');
@@ -167,7 +158,7 @@ describe('Grid', () => {
       //act
       headerCheckbox.props.onChange(fakeEvent);
       //assert
-      var selectedRows = component.state.selectedRows;
+      var selectedRows = this.component.state.selectedRows;
       expect(selectedRows.length).toEqual(_rows.length);
       selectedRows.forEach(function(selected){
         expect(selected).toBe(true);
@@ -175,44 +166,43 @@ describe('Grid', () => {
       //trigger unselect
       checkbox.checked = false;
       headerCheckbox.props.onChange(fakeEvent);
-      component.state.selectedRows.forEach(function(selected){
+      this.component.state.selectedRows.forEach(function(selected){
         expect(selected).toBe(false);
       });
     });
 
-    it("should be able to select an individual row when selected = false", () => {
-      component.setState({selectedRows : [false, false, false, false]});
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+    it("should be able to select an individual row when selected = false", function () {
+      this.component.setState({selectedRows : [false, false, false, false]});
+      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var selectRowCol = baseGrid.props.columnMetrics.columns[0];
       var fakeEvent = {stopPropagation : function(){}};
       selectRowCol.onCellChange(3, 'select-row', fakeEvent);
-      expect(component.state.selectedRows[3]).toBe(true);
+      expect(this.component.state.selectedRows[3]).toBe(true);
     });
 
-    it("should be able to select an individual row when selected = null", () => {
-      component.setState({selectedRows : [null, null, null, null]});
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+    it("should be able to select an individual row when selected = null", function () {
+      this.component.setState({selectedRows : [null, null, null, null]});
+      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var selectRowCol = baseGrid.props.columnMetrics.columns[0];
       var fakeEvent = {stopPropagation : function(){}};
       selectRowCol.onCellChange(2, 'select-row', fakeEvent);
-      expect(component.state.selectedRows[2]).toBe(true);
+      expect(this.component.state.selectedRows[2]).toBe(true);
     });
 
-    it("should be able to unselect an individual row ", () => {
-      component.setState({selectedRows : [null, true, true, true]});
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+    it("should be able to unselect an individual row ", function () {
+      this.component.setState({selectedRows : [null, true, true, true]});
+      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var selectRowCol = baseGrid.props.columnMetrics.columns[0];
       var fakeEvent = {stopPropagation : function(){}};
       selectRowCol.onCellChange(3, 'select-row', fakeEvent);
-      expect(component.state.selectedRows[3]).toBe(false);
+      expect(this.component.state.selectedRows[3]).toBe(false);
     });
   });
 
 
-  describe("User Interaction",() => {
-
-    afterEach(() => {
-      component.setState({selected  : {idx : 0, rowIdx : 0}});
+  describe("User Interaction",function () {
+    afterEach(function () {
+      this.component.setState({ selected: { idx: 0, rowIdx: 0 } });
     });
 
     function SimulateGridKeyDown(component, key, ctrlKey){
@@ -221,31 +211,30 @@ describe('Grid', () => {
       baseGrid.props.onViewportKeydown(fakeEvent);
     }
 
-    it("hitting TAB should decrement selected cell index by 1", () => {
-      SimulateGridKeyDown(component, 'Tab');
-      expect(component.state.selected).toEqual({
+    it("hitting TAB should decrement selected cell index by 1", function () {
+      SimulateGridKeyDown(this.component, 'Tab');
+      expect(this.component.state.selected).toEqual({
         idx : 1,
         rowIdx : 0
       });
     });
 
-    describe("When selected cell is in top corner of grid", () => {
-
-      beforeEach(() => {
-        component.setState({selected  : {idx : 0, rowIdx : 0}});
+    describe("When selected cell is in top corner of grid", function () {
+      beforeEach(function () {
+        this.component.setState({selected  : {idx : 0, rowIdx : 0}});
       });
 
-      it("on ArrowUp keyboard event should not change selected index", () => {
-        SimulateGridKeyDown(component, 'ArrowUp');
-        expect(component.state.selected).toEqual({
+      it("on ArrowUp keyboard event should not change selected index", function () {
+        SimulateGridKeyDown(this.component, 'ArrowUp');
+        expect(this.component.state.selected).toEqual({
           idx : 0,
           rowIdx : 0
         });
       });
 
-      it("on ArrowLeft keyboard event should not change selected index", () => {
-        SimulateGridKeyDown(component, 'ArrowLeft');
-        expect(component.state.selected).toEqual({
+      it("on ArrowLeft keyboard event should not change selected index", function () {
+        SimulateGridKeyDown(this.component, 'ArrowLeft');
+        expect(this.component.state.selected).toEqual({
           idx : 0,
           rowIdx : 0
         });
@@ -253,176 +242,171 @@ describe('Grid', () => {
 
     });
 
-    describe("When selected cell has adjacent cells on all sides", () => {
-
-
-      beforeEach(() => {
-        component.setState({selected  : {idx : 1, rowIdx : 1}});
+    describe("When selected cell has adjacent cells on all sides", function () {
+      beforeEach(function () {
+        this.component.setState({selected  : {idx : 1, rowIdx : 1}});
       });
 
-      it("on ArrowRight keyboard event should increment selected cell index by 1", () => {
-        SimulateGridKeyDown(component, 'ArrowRight');
-        expect(component.state.selected).toEqual({
+      it("on ArrowRight keyboard event should increment selected cell index by 1", function () {
+        SimulateGridKeyDown(this.component, 'ArrowRight');
+        expect(this.component.state.selected).toEqual({
           idx : 2,
           rowIdx : 1
         });
       });
 
-      it("on ArrowDown keyboard event should increment selected row index by 1", () => {
-        SimulateGridKeyDown(component, 'ArrowDown');
-        expect(component.state.selected).toEqual({
+      it("on ArrowDown keyboard event should increment selected row index by 1", function () {
+        SimulateGridKeyDown(this.component, 'ArrowDown');
+        expect(this.component.state.selected).toEqual({
           idx : 1,
           rowIdx : 2
         });
       });
 
-      it("on ArrowLeft keyboard event should decrement selected row index by 1", () => {
-        SimulateGridKeyDown(component, 'ArrowLeft');
-        expect(component.state.selected).toEqual({
+      it("on ArrowLeft keyboard event should decrement selected row index by 1", function () {
+        SimulateGridKeyDown(this.component, 'ArrowLeft');
+        expect(this.component.state.selected).toEqual({
           idx : 0,
           rowIdx : 1
         });
       });
 
-      it("on ArrowUp keyboard event should decrement selected row index by 1", () => {
-        SimulateGridKeyDown(component, 'ArrowUp');
-        expect(component.state.selected).toEqual({
+      it("on ArrowUp keyboard event should decrement selected row index by 1", function () {
+        SimulateGridKeyDown(this.component, 'ArrowUp');
+        expect(this.component.state.selected).toEqual({
           idx : 1,
           rowIdx : 0
         });
       });
     });
 
-    describe("When column is editable", () => {
-
-      beforeEach(() => {
+    describe("When column is editable", function () {
+      beforeEach(function () {
         columns[1].editable = true;
-        component = TestUtils.renderIntoDocument(<Grid {...testProps} />);
+        this.component = TestUtils.renderIntoDocument(<Grid {...testProps} />);
       });
 
-
-
-      it("double click on grid should activate current selected cell", () => {
-        component.setState({selected : {idx : 1, rowIdx : 1}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+      it("double click on grid should activate current selected cell", function () {
+        this.component.setState({selected : {idx : 1, rowIdx : 1}});
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         baseGrid.props.onViewportDoubleClick();
-        expect(component.state.selected).toEqual({
+        expect(this.component.state.selected).toEqual({
           idx : 1,
           rowIdx : 1,
           active : true
         })
       });
 
-      it("copy a cell value should store the value in grid state", () => {
+      it("copy a cell value should store the value in grid state", function () {
         //arrange
         var selectedCellIndex = 1, selectedRowIndex = 1;
-        component.setState({selected  : {idx : selectedCellIndex, rowIdx : selectedRowIndex}});
+        this.component.setState({selected  : {idx : selectedCellIndex, rowIdx : selectedRowIndex}});
         var keyCode_c = '99';
         var expectedCellValue = _rows[selectedRowIndex].title;
         //act
-        SimulateGridKeyDown(component, keyCode_c, true);
+        SimulateGridKeyDown(this.component, keyCode_c, true);
         //assert
-        expect(component.state.textToCopy).toEqual(expectedCellValue);
-        expect(component.state.copied).toEqual({idx : selectedCellIndex, rowIdx : selectedRowIndex});
+        expect(this.component.state.textToCopy).toEqual(expectedCellValue);
+        expect(this.component.state.copied).toEqual({idx : selectedCellIndex, rowIdx : selectedRowIndex});
       });
 
-      it("paste a cell value should call onCellCopyPaste of component with correct params", () => {
+      it("paste a cell value should call onCellCopyPaste of component with correct params", function () {
         //arrange
         spyOn(testProps, 'onCellCopyPaste');
-        component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-        component.setState({
+        this.component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
+        this.component.setState({
           textToCopy : 'banana',
           selected   : {idx : 1, rowIdx : 5},
           copied     : {idx : 1, rowIdx : 1}
         });
         var keyCode_v = '118';
-        SimulateGridKeyDown(component, keyCode_v, true);
+        SimulateGridKeyDown(this.component, keyCode_v, true);
         expect(testProps.onCellCopyPaste).toHaveBeenCalled();
         expect(testProps.onCellCopyPaste.mostRecentCall.args[0]).toEqual({cellKey: "title", rowIdx: 5, value: "banana", fromRow: 1, toRow: 5})
       });
 
-      it("cell commit cancel should set grid state inactive", () =>{
-        component.setState({selected : {idx : 1, rowIdx:1, active : true}})
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+      it("cell commit cancel should set grid state inactive", function () {
+        this.component.setState({selected : {idx : 1, rowIdx:1, active : true}})
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         var meta = baseGrid.props.cellMetaData;
         meta.onCommitCancel();
-        expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
+        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
       });
 
-      it("pressing escape should set grid state inactive", () =>{
-        component.setState({selected : {idx : 1, rowIdx:1, active : true}})
-        SimulateGridKeyDown(component, 'Escape');
-        expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
+      it("pressing escape should set grid state inactive", function () {
+        this.component.setState({selected : {idx : 1, rowIdx:1, active : true}})
+        SimulateGridKeyDown(this.component, 'Escape');
+        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
       });
 
-      it("pressing enter should set grid state active", () =>{
-        component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        SimulateGridKeyDown(component, 'Enter');
-        expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Enter' });
+      it("pressing enter should set grid state active", function () {
+        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
+        SimulateGridKeyDown(this.component, 'Enter');
+        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Enter' });
       });
 
-      it("pressing delete should set grid state active", () =>{
-        component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        SimulateGridKeyDown(component, 'Delete');
-        expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Delete' });
+      it("pressing delete should set grid state active", function () {
+        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
+        SimulateGridKeyDown(this.component, 'Delete');
+        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Delete' });
       });
 
-      it("pressing backspace should set grid state active", () =>{
-        component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        SimulateGridKeyDown(component, 'Backspace');
-        expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Backspace' });
+      it("pressing backspace should set grid state active", function () {
+        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
+        SimulateGridKeyDown(this.component, 'Backspace');
+        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Backspace' });
       });
 
-      it("typing a char should set grid state active and store the typed value", () =>{
-        component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+      it("typing a char should set grid state active and store the typed value", function () {
+        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         var fakeEvent = {keyCode : 66, key :"Unidentified", preventDefault : function(){}, stopPropagation : function(){}};
         baseGrid.props.onViewportKeydown(fakeEvent);
-        expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 66 });
+        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 66 });
       });
 
     });
 
-    describe("When column is not editable", () => {
-      beforeEach(() => {
+    describe("When column is not editable", function () {
+      beforeEach(function () {
         columns[1].editable = false;
-        component = TestUtils.renderIntoDocument(<Grid {...testProps} />);
+        this.component = TestUtils.renderIntoDocument(<Grid {...testProps} />);
       });
 
-      it("double click on grid should not activate current selected cell", () => {
-        component.setState({selected : {idx : 1, rowIdx : 1}});
+      it("double click on grid should not activate current selected cell", function () {
+        this.component.setState({selected : {idx : 1, rowIdx : 1}});
         columns[1].editable = false;
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         baseGrid.props.onViewportDoubleClick();
-        expect(component.state.selected).toEqual({
+        expect(this.component.state.selected).toEqual({
           idx : 1,
           rowIdx : 1
         })
       });
     });
 
-    describe("Drag events", () => {
+    describe("Drag events", function () {
 
-      it("dragging in grid will store drag rowIdx, idx and value of cell in state", () => {
-        component.setState({selected : {idx : 1, rowIdx : 2}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+      it("dragging in grid will store drag rowIdx, idx and value of cell in state", function () {
+        this.component.setState({selected : {idx : 1, rowIdx : 2}});
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         baseGrid.props.onViewportDragStart();
-        expect(component.state.dragged).toEqual({
+        expect(this.component.state.dragged).toEqual({
           idx : 1,
           rowIdx : 2,
           value : _rows[2].title
         })
       });
 
-      it("dragging over a row will store the current rowIdx in grid state", () => {
+      it("dragging over a row will store the current rowIdx in grid state", function () {
         //arrange
-        component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+        this.component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         var meta = baseGrid.props.cellMetaData;
         //act
         meta.handleDragEnterRow(4)
         //assert
-        expect(component.state.dragged).toEqual({
+        expect(this.component.state.dragged).toEqual({
           idx : 1,
           rowIdx : 2,
           value : 'apple',
@@ -430,50 +414,45 @@ describe('Grid', () => {
         })
       });
 
-      it("finishing drag will trigger onCellsDragged event and call it with correct params", () => {
+      it("finishing drag will trigger onCellsDragged event and call it with correct params", function () {
         spyOn(testProps, 'onCellsDragged');
-        component = TestUtils.renderIntoDocument(<Grid {...testProps}  />);
-        component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+        this.component = TestUtils.renderIntoDocument(<Grid {...testProps}  />);
+        this.component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         baseGrid.props.onViewportDragEnd();
         expect(testProps.onCellsDragged).toHaveBeenCalled();
         expect(testProps.onCellsDragged.argsForCall[0][0]).toEqual({cellKey: "title", fromRow: 2, toRow: 6, value: "apple"});
       });
 
-      it("terminating drag will clear drag state", () => {
-        component = TestUtils.renderIntoDocument(<Grid {...testProps}  />);
-        component.setState({ dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+      it("terminating drag will clear drag state", function () {
+        this.component = TestUtils.renderIntoDocument(<Grid {...testProps}  />);
+        this.component.setState({ dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
+        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         var meta = baseGrid.props.cellMetaData;
         meta.handleTerminateDrag()
-        expect(component.state.dragged).toBe(null);
+        expect(this.component.state.dragged).toBe(null);
       });
-
     });
 
-    it("Adding a new row will set the selected cell to be on the last row", () =>{
+    it("Adding a new row will set the selected cell to be on the last row", function () {
       var newRow = {id: 1000, title: 'Title 1000', count: 1000};
       _rows.push(newRow);
-      component.setProps({rowsCount:_rows.length});
-      expect(component.state.selected).toEqual({
+      this.component.setProps({rowsCount:_rows.length});
+      expect(this.component.state.selected).toEqual({
         idx : 1,
         rowIdx : 1000
       });
     });
+  });
 
-  })
-
-  describe("Cell Meta Data", () => {
-
+  describe("Cell Meta Data", function () {
     function getCellMetaData(component){
-
       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-
       return baseGrid.props.cellMetaData;
     }
 
-    it('creates a cellMetaData object and passes to baseGrid as props', () => {
-      var meta = getCellMetaData(component)
+    it('creates a cellMetaData object and passes to baseGrid as props', function () {
+      var meta = getCellMetaData(this.component)
       expect(meta).toEqual(jasmine.objectContaining({
         selected : {rowIdx : 0, idx : 0},
         dragged  : null,
@@ -486,18 +465,18 @@ describe('Grid', () => {
       expect(typeof meta.handleTerminateDrag === 'function').toBe(true);
     });
 
-    it("Changing Grid state should update cellMetaData", () => {
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
+    it("Changing Grid state should update cellMetaData", function () {
+      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var newState = {selected  : {idx : 2, rowIdx : 2}, dragged : {idx : 2, rowIdx : 2}}
-      component.setState(newState);
+      this.component.setState(newState);
       var meta = baseGrid.props.cellMetaData;
       expect(meta).toEqual(jasmine.objectContaining(newState));
     });
 
-    it("cell commit should trigger onRowUpdated with correct params", () => {
+    it("cell commit should trigger onRowUpdated with correct params", function () {
       spyOn(testProps, 'onRowUpdated');
-      component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-      var meta = getCellMetaData(component);
+      this.component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
+      var meta = getCellMetaData(this.component);
       var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
       meta.onCommit(fakeCellUpdate);
       expect(testProps.onRowUpdated.callCount).toEqual(1);
@@ -506,56 +485,46 @@ describe('Grid', () => {
       })
     });
 
-    it("cell commit should deactivate selected cell", () => {
-      component.setState({selected : {idx : 3, rowIdx : 3, active : true}});
-      var meta = getCellMetaData(component);
+    it("cell commit should deactivate selected cell", function () {
+      this.component.setState({selected : {idx : 3, rowIdx : 3, active : true}});
+      var meta = getCellMetaData(this.component);
       var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
       meta.onCommit(fakeCellUpdate);
-      expect(component.state.selected).toEqual({
+      expect(this.component.state.selected).toEqual({
           idx : 3,
           rowIdx : 3,
           active : false
         });
     });
 
-    it("cell commit after TAB should select next cell", () => {
-      component.setState({selected : {idx : 1, rowIdx : 1, active : true}});
-      var meta = getCellMetaData(component);
+    it("cell commit after TAB should select next cell", function () {
+      this.component.setState({selected : {idx : 1, rowIdx : 1, active : true}});
+      var meta = getCellMetaData(this.component);
       var fakeCellUpdate = {cellKey: "title", rowIdx: 1, updated: {title : 'some new title'}, key: "Tab"}
       meta.onCommit(fakeCellUpdate);
-      expect(component.state.selected).toEqual({
+      expect(this.component.state.selected).toEqual({
         idx : 2,
         rowIdx : 1,
         active : false
       });
     });
 
-
-    it("Cell click should set selected state of grid", () =>{
-      var meta = getCellMetaData(component);
+    it("Cell click should set selected state of grid", function () {
+      var meta = getCellMetaData(this.component);
       meta.onCellClick({idx : 2, rowIdx : 2 });
-      expect(component.state.selected).toEqual({idx : 2, rowIdx : 2 });
+      expect(this.component.state.selected).toEqual({idx : 2, rowIdx : 2 });
     });
-
-
   });
 
-  it("changes to non metric column data should keep original metric information", () => {
-    var newColumns = columns.slice(0).map(c => {
-      return Object.assign({}, c);
-    });
+  it("changes to non metric column data should keep original metric information", function () {
+    var newColumns = columns.slice(0).map(column => Object.assign({}, column));
     newColumns[0].editable = true;
-    var originalMetrics = Object.assign({}, component.state.columnMetrics);
-    component.setProps({columns : newColumns});
-    var columnMetrics = component.state.columnMetrics;
+    var originalMetrics = Object.assign({}, this.component.state.columnMetrics);
+    this.component.setProps({columns : newColumns});
+    var columnMetrics = this.component.state.columnMetrics;
     columnMetrics.columns.forEach((m, i) => {
       expect(m.width).toEqual(originalMetrics.columns[i].width);
       expect(m.left).toEqual(originalMetrics.columns[i].left);
     })
   });
-
-
-
-
-
 });

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -1,14 +1,15 @@
-'use strict';
-var React         = require('react');
-var rewire        = require('rewire');
-var Grid          = rewire('../grids/ReactDataGrid.js');
-var TestUtils     = require('react/lib/ReactTestUtils');
-var rewireModule  = require("../../../test/rewireModule");
+"use strict";
+var React = require("react");
+var rewire = require("rewire");
+var Grid = rewire("../grids/ReactDataGrid.js");
+var TestUtils = require("react/lib/ReactTestUtils");
+var rewireModule = require("../../../test/rewireModule");
 var StubComponent = require("../../../test/StubComponent");
+var mockStateObject = require("./data/MockStateObject");
 
-describe('Grid', function () {
-  var BaseGridStub = StubComponent('BaseGrid');
-  var CheckboxEditorStub = StubComponent('CheckboxEditor');
+describe("Grid", function () {
+  var BaseGridStub = StubComponent("BaseGrid");
+  var CheckboxEditorStub = StubComponent("CheckboxEditor");
 
   // Configure local variable replacements for the module.
   rewireModule(Grid, {
@@ -18,21 +19,9 @@ describe('Grid', function () {
 
   beforeEach(function () {
     this.columns = [
-      {
-        key   : 'id',
-        name  : 'ID',
-        width : 100
-      },
-      {
-        key: 'title',
-        name: 'Title',
-        width : 100
-      },
-      {
-        key: 'count',
-        name: 'Count',
-        width : 100
-      }
+      { key: "id", name: "ID", width: 100 },
+      { key: "title", name: "Title", width: 100 },
+      { key: "count", name: "Count", width: 100 }
     ];
 
     this._rows = [];
@@ -49,483 +38,544 @@ describe('Grid', function () {
       this._selectedRows.push(false);
     }
 
-    var noop = function(){};
+    this.noop = function(){};
     this.testProps = {
       enableCellSelect: true,
       columns: this.columns,
       rowGetter: this.rowGetter,
       rowsCount: this._rows.length,
       width: 300,
-      onRowUpdated: noop,
-      onCellCopyPaste: noop,
-      onCellsDragged: noop,
-      onGridSort: noop
+      onRowUpdated: this.noop,
+      onCellCopyPaste: this.noop,
+      onCellsDragged: this.noop,
+      onGridSort: this.noop
     };
 
-    this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}/>);
+    this.buildFakeEvent = (addedData) => {
+      return Object.assign({}, {
+        preventDefault: this.noop,
+        stopPropagation: this.noop
+      }, addedData);
+    };
+
+    this.buildFakeCellUodate = (addedData) => {
+      return Object.assign({}, {
+        cellKey: "title",
+        rowIdx: 0,
+        updated: { title: "some new title" },
+        key: "Enter"
+      }, addedData);
+    };
+
+    this.getBaseGrid = () => TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
+    this.getCellMetaData = () => this.getBaseGrid().props.cellMetaData;
+
+    this.simulateGridKeyDown = (key, ctrlKey) => {
+      var fakeEvent = this.buildFakeEvent({
+        key: key,
+        keyCode: key,
+        ctrlKey: ctrlKey
+      });
+      this.getBaseGrid().props.onViewportKeydown(fakeEvent);
+    }
+
+    var buildProps = (addedProps) => Object.assign({}, this.testProps, addedProps);
+    this.createComponent = (addedProps) => {
+      return TestUtils.renderIntoDocument(<Grid {...buildProps(addedProps)}/>);
+    };
+
+    this.component = this.createComponent();
   });
 
-  it('should create a new instance of Grid', function () {
+  it("should create a new instance of Grid", function () {
     expect(this.component).toBeDefined();
   });
 
-  it('should render a BaseGrid stub', function () {
-    var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-    expect(baseGrid).toBeDefined();
-  });
-
-  it('should render a Toolbar if passed in as props to grid', function () {
-    var Toolbar = StubComponent('Toolbar');
-    this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} toolbar={<Toolbar/>} />);
-    var toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, Toolbar);
-    expect(toolbarInstance).toBeDefined();
-  });
-
-  it('onToggleFilter trigger of Toolbar should set filter state of grid and render a filterable header row', function () {
-    //arrange
-    var Toolbar = StubComponent('Toolbar');
-    this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} toolbar={<Toolbar/>} />);
-    var toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, Toolbar);
-    //act
-    toolbarInstance.props.onToggleFilter();
-    //assert
-    var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-    expect(this.component.state.canFilter).toBe(true);
-    expect(baseGrid.props.headerRows.length).toEqual(2);
-    var filterableHeaderRow = baseGrid.props.headerRows[1];
-    expect(filterableHeaderRow.ref).toEqual("filterRow");
+  it("should render a BaseGrid stub", function () {
+    expect(this.getBaseGrid()).toBeDefined();
   });
 
   it("should be initialized with correct state", function () {
-    expect(this.component.state).toEqual({
-      columnMetrics : { columns : [ { key : 'id', name : 'ID', width : 100, left : 0 }, { key : 'title', name : 'Title', width : 100, left : 100 }, { key : 'count', name : 'Count', width : 100, left : 200 } ], width : 300, totalWidth : 0, minColumnWidth : 80 },
-      selectedRows : this._selectedRows,
-      selected : {rowIdx : 0,  idx : 0},
-      copied : null,
-      canFilter : false,
-      expandedRows : [],
-      columnFilters : {},
-      sortDirection : null,
-      sortColumn : null,
-      dragged : null,
-      scrollOffset: 0
+    expect(this.component.state).toEqual(mockStateObject({
+      selectedRows : this._selectedRows
+    }));
+  });
+
+  describe("if passed in as props to grid", function () {
+    beforeEach(function () {
+      const ToolBarStub = StubComponent("Toolbar");
+      this.component = this.createComponent({ toolbar: <ToolBarStub /> });
+      this.toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, ToolBarStub);
+    });
+
+    it("should render a Toolbar", function () {
+      expect(this.toolbarInstance).toBeDefined();
+    });
+
+    describe("onToggleFilter trigger of Toolbar", function () {
+      beforeEach(function () {
+        this.toolbarInstance.props.onToggleFilter();
+        this.baseGrid = this.getBaseGrid();
+      });
+
+      it("should set filter state of grid and render a filterable header row", function () {
+        var filterableHeaderRow = this.baseGrid.props.headerRows[1];
+        expect(this.component.state.canFilter).toBe(true);
+        expect(this.baseGrid.props.headerRows.length).toEqual(2);
+        expect(filterableHeaderRow.ref).toEqual("filterRow");
+      });
     });
   });
 
   describe("When cell selection disabled", function () {
-
-    it("grid should be initialized with selected state of {rowIdx : -1, idx : -1}", function () {
-      this.component = TestUtils.renderIntoDocument(<Grid
-        enableCellSelect={false}
-        columns={this.columns}
-        rowGetter={this.rowGetter}
-        rowsCount={this._rows.length}
-        width={300}/>);
-      expect(this.component.state.selected).toEqual({
-        rowIdx : -1,
-        idx : -1
+    beforeEach(function () {
+      this.component = this.createComponent({
+        enableCellSelect: false,
+        columns: this.columns,
+        rowGetter: this.rowGetter,
+        rowsCount: this._rows.length,
+        width: 300
       });
     });
 
+    it("grid should be initialized with selected state of {rowIdx : -1, idx : -1}", function () {
+      expect(this.component.state.selected).toEqual({ rowIdx : -1, idx : -1 });
+    });
   });
 
   describe("When row selection enabled", function () {
     beforeEach(function () {
-      this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} enableRowSelect={true} />);
-    });
-
-    afterEach(function () {
-      this.component.setState({selectedRows : []});
+      this.component = this.createComponent({ enableRowSelect: true });
+      this.baseGrid = this.getBaseGrid();
+      this.selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
     });
 
     it("should render an additional Select Row column", function () {
-      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-      var selectRowCol = baseGrid.props.columnMetrics.columns[0];
-      expect(baseGrid.props.columnMetrics.columns.length).toEqual(this.columns.length + 1);
-      expect(selectRowCol.key).toEqual('select-row');
-      expect(TestUtils.isElementOfType(selectRowCol.formatter, CheckboxEditorStub)).toBe(true);
+      expect(this.baseGrid.props.columnMetrics.columns.length).toEqual(this.columns.length + 1);
+      expect(this.selectRowCol.key).toEqual("select-row");
+      expect(TestUtils.isElementOfType(this.selectRowCol.formatter, CheckboxEditorStub)).toBe(true);
     });
 
-    it("clicking header checkbox should toggle select all rows", function () {
-      //arrange
-      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-      var selectRowCol = baseGrid.props.columnMetrics.columns[0];
-      var headerCheckbox = selectRowCol.headerRenderer;
-      var checkbox = document.createElement('input');
-      checkbox.type = "checkbox";
-      checkbox.value = "value";
-      checkbox.checked = true;
-      var fakeEvent = {currentTarget : checkbox};
-      //act
-      headerCheckbox.props.onChange(fakeEvent);
-      //assert
-      var selectedRows = this.component.state.selectedRows;
-      expect(selectedRows.length).toEqual(this._rows.length);
-      selectedRows.forEach(function(selected){
-        expect(selected).toBe(true);
+    describe("checking header checkbox", function () {
+      beforeEach(function () {
+        var checkboxWrapper = document.createElement("div");
+        checkboxWrapper.innerHTML = "<input type='checkbox' value='value' checked='true' />";
+        this.checkbox = checkboxWrapper.querySelector('input');
+
+        this.headerCheckbox = this.selectRowCol.headerRenderer;
+        this.fakeEvent = this.buildFakeEvent({ currentTarget : this.checkbox });
+        this.headerCheckbox.props.onChange(this.fakeEvent);
       });
-      //trigger unselect
-      checkbox.checked = false;
-      headerCheckbox.props.onChange(fakeEvent);
-      this.component.state.selectedRows.forEach(function(selected){
-        expect(selected).toBe(false);
+
+      it("should select all rows", function () {
+        var selectedRows = this.component.state.selectedRows;
+        expect(selectedRows.length).toEqual(this._rows.length);
+
+        expect(selectedRows.length).toBeGreaterThan(1)
+        selectedRows.forEach((selected) => expect(selected).toBe(true));
+      });
+
+      describe("and then unchecking header checkbox", function () {
+        beforeEach(function () {
+          this.checkbox.checked = false;
+          this.headerCheckbox.props.onChange(this.fakeEvent);
+        });
+
+        it("should deselect all rows", function () {
+          var selectedRows = this.component.state.selectedRows;
+
+          expect(selectedRows.length).toBeGreaterThan(1)
+          selectedRows.forEach((selected) => expect(selected).toBe(false));
+        });
       });
     });
 
-    it("should be able to select an individual row when selected = false", function () {
-      this.component.setState({selectedRows : [false, false, false, false]});
-      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-      var selectRowCol = baseGrid.props.columnMetrics.columns[0];
-      var fakeEvent = {stopPropagation : function(){}};
-      selectRowCol.onCellChange(3, 'select-row', fakeEvent);
-      expect(this.component.state.selectedRows[3]).toBe(true);
+    describe("when selected = false", function () {
+      beforeEach(function () {
+        this.component.setState({ selectedRows: [false, false, false, false] });
+        var selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
+        selectRowCol.onCellChange(3, "select-row", this.buildFakeEvent());
+      });
+
+      it("should be able to select an individual row", function () {
+        expect(this.component.state.selectedRows[3]).toBe(true);
+      });
     });
 
-    it("should be able to select an individual row when selected = null", function () {
-      this.component.setState({selectedRows : [null, null, null, null]});
-      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-      var selectRowCol = baseGrid.props.columnMetrics.columns[0];
-      var fakeEvent = {stopPropagation : function(){}};
-      selectRowCol.onCellChange(2, 'select-row', fakeEvent);
-      expect(this.component.state.selectedRows[2]).toBe(true);
+    describe("when selected = null", function () {
+      beforeEach(function () {
+        this.component.setState({ selectedRows: [null, null, null, null] });
+        var selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
+        selectRowCol.onCellChange(2, "select-row", this.buildFakeEvent());
+      });
+
+      it("should be able to select an individual row", function () {
+        expect(this.component.state.selectedRows[2]).toBe(true);
+      });
     });
 
-    it("should be able to unselect an individual row ", function () {
-      this.component.setState({selectedRows : [null, true, true, true]});
-      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-      var selectRowCol = baseGrid.props.columnMetrics.columns[0];
-      var fakeEvent = {stopPropagation : function(){}};
-      selectRowCol.onCellChange(3, 'select-row', fakeEvent);
-      expect(this.component.state.selectedRows[3]).toBe(false);
+    describe("when selected = true", function () {
+      beforeEach(function () {
+        this.component.setState({ selectedRows: [null, true, true, true] });
+        var selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
+        selectRowCol.onCellChange(3, "select-row", this.buildFakeEvent());
+      });
+
+      it("should be able to unselect an individual row ", function () {
+        expect(this.component.state.selectedRows[3]).toBe(false);
+      });
     });
   });
 
-
   describe("User Interaction",function () {
-    afterEach(function () {
-      this.component.setState({ selected: { idx: 0, rowIdx: 0 } });
-    });
-
-    function SimulateGridKeyDown(component, key, ctrlKey){
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-      var fakeEvent = {key : key, keyCode :key, ctrlKey: ctrlKey, preventDefault : function(){}, stopPropagation : function(){}};
-      baseGrid.props.onViewportKeydown(fakeEvent);
-    }
-
     it("hitting TAB should decrement selected cell index by 1", function () {
-      SimulateGridKeyDown(this.component, 'Tab');
-      expect(this.component.state.selected).toEqual({
-        idx : 1,
-        rowIdx : 0
-      });
+      this.simulateGridKeyDown("Tab");
+      expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 0 });
     });
 
     describe("When selected cell is in top corner of grid", function () {
       beforeEach(function () {
-        this.component.setState({selected  : {idx : 0, rowIdx : 0}});
+        this.component.setState({ selected: { idx: 0, rowIdx: 0 } });
       });
 
       it("on ArrowUp keyboard event should not change selected index", function () {
-        SimulateGridKeyDown(this.component, 'ArrowUp');
-        expect(this.component.state.selected).toEqual({
-          idx : 0,
-          rowIdx : 0
-        });
+        this.simulateGridKeyDown("ArrowUp");
+        expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 0 });
       });
 
       it("on ArrowLeft keyboard event should not change selected index", function () {
-        SimulateGridKeyDown(this.component, 'ArrowLeft');
-        expect(this.component.state.selected).toEqual({
-          idx : 0,
-          rowIdx : 0
-        });
+        this.simulateGridKeyDown("ArrowLeft");
+        expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 0 });
       });
-
     });
 
     describe("When selected cell has adjacent cells on all sides", function () {
       beforeEach(function () {
-        this.component.setState({selected  : {idx : 1, rowIdx : 1}});
+        this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
       });
 
       it("on ArrowRight keyboard event should increment selected cell index by 1", function () {
-        SimulateGridKeyDown(this.component, 'ArrowRight');
-        expect(this.component.state.selected).toEqual({
-          idx : 2,
-          rowIdx : 1
-        });
+        this.simulateGridKeyDown("ArrowRight");
+        expect(this.component.state.selected).toEqual({ idx: 2, rowIdx: 1 });
       });
 
       it("on ArrowDown keyboard event should increment selected row index by 1", function () {
-        SimulateGridKeyDown(this.component, 'ArrowDown');
-        expect(this.component.state.selected).toEqual({
-          idx : 1,
-          rowIdx : 2
-        });
+        this.simulateGridKeyDown("ArrowDown");
+        expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 2 });
       });
 
       it("on ArrowLeft keyboard event should decrement selected row index by 1", function () {
-        SimulateGridKeyDown(this.component, 'ArrowLeft');
-        expect(this.component.state.selected).toEqual({
-          idx : 0,
-          rowIdx : 1
-        });
+        this.simulateGridKeyDown("ArrowLeft");
+        expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
       });
 
       it("on ArrowUp keyboard event should decrement selected row index by 1", function () {
-        SimulateGridKeyDown(this.component, 'ArrowUp');
-        expect(this.component.state.selected).toEqual({
-          idx : 1,
-          rowIdx : 0
-        });
+        this.simulateGridKeyDown("ArrowUp");
+        expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 0 });
       });
     });
 
     describe("When column is editable", function () {
       beforeEach(function () {
-        this.columns[1].editable = true;
-        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} />);
+        const editableColumn = Object.assign({ editable: true }, this.columns[1]);
+        this.columns[1] = editableColumn;
+        this.component = this.createComponent({ columns: this.columns });
       });
 
-      it("double click on grid should activate current selected cell", function () {
-        this.component.setState({selected : {idx : 1, rowIdx : 1}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        baseGrid.props.onViewportDoubleClick();
-        expect(this.component.state.selected).toEqual({
-          idx : 1,
-          rowIdx : 1,
-          active : true
-        })
-      });
-
-      it("copy a cell value should store the value in grid state", function () {
-        //arrange
-        var selectedCellIndex = 1, selectedRowIndex = 1;
-        this.component.setState({selected  : {idx : selectedCellIndex, rowIdx : selectedRowIndex}});
-        var keyCode_c = '99';
-        var expectedCellValue = this._rows[selectedRowIndex].title;
-        //act
-        SimulateGridKeyDown(this.component, keyCode_c, true);
-        //assert
-        expect(this.component.state.textToCopy).toEqual(expectedCellValue);
-        expect(this.component.state.copied).toEqual({idx : selectedCellIndex, rowIdx : selectedRowIndex});
-      });
-
-      it("paste a cell value should call onCellCopyPaste of component with correct params", function () {
-        //arrange
-        spyOn(this.testProps, 'onCellCopyPaste');
-        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}/>);
-        this.component.setState({
-          textToCopy : 'banana',
-          selected   : {idx : 1, rowIdx : 5},
-          copied     : {idx : 1, rowIdx : 1}
+      describe("double click on grid", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
+          this.getBaseGrid().props.onViewportDoubleClick();
         });
-        var keyCode_v = '118';
-        SimulateGridKeyDown(this.component, keyCode_v, true);
-        expect(this.testProps.onCellCopyPaste).toHaveBeenCalled();
-        expect(this.testProps.onCellCopyPaste.mostRecentCall.args[0]).toEqual({cellKey: "title", rowIdx: 5, value: "banana", fromRow: 1, toRow: 5})
+
+        it("should activate current selected cell", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: true });
+        });
       });
 
-      it("cell commit cancel should set grid state inactive", function () {
-        this.component.setState({selected : {idx : 1, rowIdx:1, active : true}})
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        var meta = baseGrid.props.cellMetaData;
-        meta.onCommitCancel();
-        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
+      describe("copy a cell value", function () {
+        beforeEach(function () {
+          const cCharacterKeyCode = 99;
+          this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
+          this.simulateGridKeyDown(cCharacterKeyCode, true);
+        });
+
+        it("should store the value in grid state", function () {
+          var expectedCellValue = this._rows[1].title;
+          expect(this.component.state.textToCopy).toEqual(expectedCellValue);
+          expect(this.component.state.copied).toEqual({ idx: 1, rowIdx: 1 });
+        });
       });
 
-      it("pressing escape should set grid state inactive", function () {
-        this.component.setState({selected : {idx : 1, rowIdx:1, active : true}})
-        SimulateGridKeyDown(this.component, 'Escape');
-        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
+      describe("paste a cell value", function () {
+        beforeEach(function () {
+          const vCharacterKeyCode = 118;
+          spyOn(this.testProps, "onCellCopyPaste");
+          this.component.setProps({ onCellCopyPaste: this.testProps.onCellCopyPaste });
+          this.component.setState({
+            textToCopy: "banana",
+            selected: { idx: 1, rowIdx: 5 },
+            copied: { idx: 1, rowIdx: 1 }
+          });
+          this.simulateGridKeyDown(vCharacterKeyCode, true);
+        });
+
+        it("should call onCellCopyPaste of component with correct params", function () {
+          expect(this.component.props.onCellCopyPaste).toHaveBeenCalled();
+          expect(this.component.props.onCellCopyPaste.mostRecentCall.args[0]).toEqual({
+            cellKey: "title",
+            rowIdx: 5,
+            value: "banana",
+            fromRow: 1,
+            toRow: 5
+          });
+        });
       });
 
-      it("pressing enter should set grid state active", function () {
-        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        SimulateGridKeyDown(this.component, 'Enter');
-        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Enter' });
+      describe("cell commit cancel", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1, active: true } });
+          this.getCellMetaData().onCommitCancel();
+        });
+
+        it("should set grid state inactive", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: false });
+        });
       });
 
-      it("pressing delete should set grid state active", function () {
-        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        SimulateGridKeyDown(this.component, 'Delete');
-        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Delete' });
+      describe("pressing escape", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1, active: true } });
+          this.simulateGridKeyDown("Escape");
+        });
+
+        it("should set grid state inactive", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: false });
+        });
       });
 
-      it("pressing backspace should set grid state active", function () {
-        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        SimulateGridKeyDown(this.component, 'Backspace');
-        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Backspace' });
+      describe("pressing enter", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1, active: false } });
+          this.simulateGridKeyDown("Enter");
+        });
+
+        it("should set grid state active", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: true, initialKeyCode: "Enter" });
+        });
       });
 
-      it("typing a char should set grid state active and store the typed value", function () {
-        this.component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        var fakeEvent = {keyCode : 66, key :"Unidentified", preventDefault : function(){}, stopPropagation : function(){}};
-        baseGrid.props.onViewportKeydown(fakeEvent);
-        expect(this.component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 66 });
+      describe("pressing delete", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1, active: false } });
+          this.simulateGridKeyDown("Delete");
+        });
+
+        it("should set grid state active", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: true, initialKeyCode: "Delete" });
+        });
       });
 
+      describe("pressing backspace", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1, active: false } });
+          this.simulateGridKeyDown("Backspace");
+        });
+
+        it("should set grid state active", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: true, initialKeyCode: "Backspace" });
+        });
+      });
+
+      describe("typing a char", function () {
+        beforeEach(function () {
+          const fakeEvent = this.buildFakeEvent({ keyCode: 66, key: "Unidentified" });
+          this.component.setState({ selected: { idx: 1, rowIdx: 1, active: false } });
+          this.getBaseGrid().props.onViewportKeydown(fakeEvent);
+        });
+
+        it("should set grid state active and store the typed value", function () {
+          expect(this.component.state.selected).toEqual({ idx : 1, rowIdx : 1, active : true, initialKeyCode : 66 });
+        });
+      });
     });
 
     describe("When column is not editable", function () {
       beforeEach(function () {
-        this.columns[1].editable = false;
-        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} />);
+        const uneditableColumn = Object.assign({ editable: false }, this.columns[1]);
+        this.columns[1] = uneditableColumn;
+        this.component = this.createComponent({ columns: this.columns });
       });
 
-      it("double click on grid should not activate current selected cell", function () {
-        this.component.setState({selected : {idx : 1, rowIdx : 1}});
-        this.columns[1].editable = false;
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        baseGrid.props.onViewportDoubleClick();
-        expect(this.component.state.selected).toEqual({
-          idx : 1,
-          rowIdx : 1
-        })
+      describe("double click on grid ", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
+          this.getBaseGrid().props.onViewportDoubleClick();
+        });
+
+        it("should not activate current selected cell", function () {
+          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1 });
+        });
       });
     });
 
     describe("Drag events", function () {
 
-      it("dragging in grid will store drag rowIdx, idx and value of cell in state", function () {
-        this.component.setState({selected : {idx : 1, rowIdx : 2}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        baseGrid.props.onViewportDragStart();
-        expect(this.component.state.dragged).toEqual({
-          idx : 1,
-          rowIdx : 2,
-          value : this._rows[2].title
-        })
+      describe("dragging in grid", function () {
+        beforeEach(function () {
+          this.component.setState({ selected: { idx: 1, rowIdx: 2 } });
+          this.getBaseGrid().props.onViewportDragStart();
+        });
+
+        it("should store drag rowIdx, idx and value of cell in state", function () {
+          const thirdRowTitle = this._rows[2].title;
+          expect(this.component.state.dragged).toEqual({ idx: 1, rowIdx: 2, value: thirdRowTitle });
+        });
       });
 
-      it("dragging over a row will store the current rowIdx in grid state", function () {
-        //arrange
-        this.component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        var meta = baseGrid.props.cellMetaData;
-        //act
-        meta.handleDragEnterRow(4)
-        //assert
-        expect(this.component.state.dragged).toEqual({
-          idx : 1,
-          rowIdx : 2,
-          value : 'apple',
-          overRowIdx : 4
-        })
+      describe("dragging over a row", function () {
+        beforeEach(function () {
+          this.component.setState({
+            selected: { idx: 1, rowIdx: 2 },
+            dragged: { idx: 1, rowIdx: 2, value: "apple", overRowIdx: 6 }
+          });
+          this.getCellMetaData().handleDragEnterRow(4)
+        });
+
+        it("should store the current rowIdx in grid state", function () {
+          expect(this.component.state.dragged).toEqual({ idx: 1, rowIdx: 2, value: "apple", overRowIdx: 4 });
+        });
       });
 
-      it("finishing drag will trigger onCellsDragged event and call it with correct params", function () {
-        spyOn(this.testProps, 'onCellsDragged');
-        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}  />);
-        this.component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        baseGrid.props.onViewportDragEnd();
-        expect(this.testProps.onCellsDragged).toHaveBeenCalled();
-        expect(this.testProps.onCellsDragged.argsForCall[0][0]).toEqual({cellKey: "title", fromRow: 2, toRow: 6, value: "apple"});
+      describe("finishing drag", function () {
+        beforeEach(function () {
+          spyOn(this.testProps, "onCellsDragged");
+          this.component.setProps({ onCellsDragged: this.testProps.onCellsDragged });
+          this.component.setState({
+            selected: { idx: 1, rowIdx: 2 },
+            dragged: { idx: 1, rowIdx: 2, value: "apple", overRowIdx: 6 }
+          });
+          this.getBaseGrid().props.onViewportDragEnd();
+        });
+
+        it("should trigger onCellsDragged event and call it with correct params", function () {
+          expect(this.component.props.onCellsDragged).toHaveBeenCalled();
+          expect(this.component.props.onCellsDragged.argsForCall[0][0]).toEqual({ cellKey: "title", fromRow: 2, toRow: 6, value: "apple" });
+        });
       });
 
-      it("terminating drag will clear drag state", function () {
-        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}  />);
-        this.component.setState({ dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
-        var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-        var meta = baseGrid.props.cellMetaData;
-        meta.handleTerminateDrag()
-        expect(this.component.state.dragged).toBe(null);
+      describe("terminating drag", function () {
+        beforeEach(function () {
+          this.component.setState({ dragged: { idx: 1, rowIdx: 2, value: "apple", overRowIdx: 6 } });
+          this.getCellMetaData().handleTerminateDrag()
+        });
+
+        it("should clear drag state", function () {
+          expect(this.component.state.dragged).toBe(null);
+        });
       });
     });
 
-    it("Adding a new row will set the selected cell to be on the last row", function () {
-      var newRow = {id: 1000, title: 'Title 1000', count: 1000};
-      this._rows.push(newRow);
-      this.component.setProps({rowsCount: this._rows.length});
-      expect(this.component.state.selected).toEqual({
-        idx : 1,
-        rowIdx : 1000
+    describe("Adding a new row", function () {
+      it("should set the selected cell to be on the last row", function () {
+        var newRow = {id: 1000, title: "Title 1000", count: 1000};
+        this._rows.push(newRow);
+        this.component.setProps({ rowsCount: this._rows.length });
+        expect(this.component.state.selected).toEqual({
+          idx : 1,
+          rowIdx : 1000
+        });
       });
     });
   });
 
   describe("Cell Meta Data", function () {
-    function getCellMetaData(component){
-      var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-      return baseGrid.props.cellMetaData;
-    }
-
-    it('creates a cellMetaData object and passes to baseGrid as props', function () {
-      var meta = getCellMetaData(this.component)
+    it("should create a cellMetaData object and pass to baseGrid as props", function () {
+      var meta = this.getCellMetaData();
       expect(meta).toEqual(jasmine.objectContaining({
-        selected : {rowIdx : 0, idx : 0},
+        selected : { rowIdx: 0, idx: 0 },
         dragged  : null,
         copied   : null
       }));
-      expect(typeof meta.onCellClick === 'function').toBe(true);
-      expect(typeof meta.onCommit === 'function').toBe(true);
-      expect(typeof meta.onCommitCancel === 'function').toBe(true);
-      expect(typeof meta.handleDragEnterRow === 'function').toBe(true);
-      expect(typeof meta.handleTerminateDrag === 'function').toBe(true);
+      expect(typeof meta.onCellClick === "function").toBe(true);
+      expect(typeof meta.onCommit === "function").toBe(true);
+      expect(typeof meta.onCommitCancel === "function").toBe(true);
+      expect(typeof meta.handleDragEnterRow === "function").toBe(true);
+      expect(typeof meta.handleTerminateDrag === "function").toBe(true);
     });
 
-    it("Changing Grid state should update cellMetaData", function () {
-      var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
-      var newState = {selected  : {idx : 2, rowIdx : 2}, dragged : {idx : 2, rowIdx : 2}}
-      this.component.setState(newState);
-      var meta = baseGrid.props.cellMetaData;
-      expect(meta).toEqual(jasmine.objectContaining(newState));
-    });
+    describe("Changing Grid state", function () {
+      beforeEach(function () {
+        var newState = {
+          selected: { idx: 2, rowIdx: 2 },
+          dragged: { idx: 2, rowIdx: 2 }
+        };
+        this.component.setState(newState);
+      });
 
-    it("cell commit should trigger onRowUpdated with correct params", function () {
-      spyOn(this.testProps, 'onRowUpdated');
-      this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}/>);
-      var meta = getCellMetaData(this.component);
-      var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
-      meta.onCommit(fakeCellUpdate);
-      expect(this.testProps.onRowUpdated.callCount).toEqual(1);
-      expect(this.testProps.onRowUpdated.argsForCall[0][0]).toEqual({
-        cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"
-      })
-    });
-
-    it("cell commit should deactivate selected cell", function () {
-      this.component.setState({selected : {idx : 3, rowIdx : 3, active : true}});
-      var meta = getCellMetaData(this.component);
-      var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
-      meta.onCommit(fakeCellUpdate);
-      expect(this.component.state.selected).toEqual({
-          idx : 3,
-          rowIdx : 3,
-          active : false
-        });
-    });
-
-    it("cell commit after TAB should select next cell", function () {
-      this.component.setState({selected : {idx : 1, rowIdx : 1, active : true}});
-      var meta = getCellMetaData(this.component);
-      var fakeCellUpdate = {cellKey: "title", rowIdx: 1, updated: {title : 'some new title'}, key: "Tab"}
-      meta.onCommit(fakeCellUpdate);
-      expect(this.component.state.selected).toEqual({
-        idx : 2,
-        rowIdx : 1,
-        active : false
+      it(" should update cellMetaData", function () {
+        expect(this.getCellMetaData()).toEqual(jasmine.objectContaining({
+          selected: { idx: 2, rowIdx: 2 },
+          dragged: { idx: 2, rowIdx: 2 }
+        }));
       });
     });
 
-    it("Cell click should set selected state of grid", function () {
-      var meta = getCellMetaData(this.component);
-      meta.onCellClick({idx : 2, rowIdx : 2 });
-      expect(this.component.state.selected).toEqual({idx : 2, rowIdx : 2 });
+    describe("cell commit", function () {
+      beforeEach(function () {
+        spyOn(this.testProps, "onRowUpdated");
+        this.component.setProps({ onRowUpdated: this.testProps.onRowUpdated });
+        this.component.setState({ selected: { idx: 3, rowIdx: 3, active: true } });
+        this.getCellMetaData().onCommit(this.buildFakeCellUodate());
+      });
+
+      it("should trigger onRowUpdated with correct params", function () {
+        const onRowUpdated = this.component.props.onRowUpdated;
+        expect(onRowUpdated.callCount).toEqual(1);
+        expect(onRowUpdated.argsForCall[0][0]).toEqual(this.buildFakeCellUodate());
+      });
+
+      it("should deactivate selected cell", function () {
+        expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 3, active: false });
+      });
+    });
+
+    describe("cell commit after 'Tab'", function () {
+      beforeEach(function () {
+        this.component.setState({ selected: { idx: 1, rowIdx: 1, active: true } });
+        this.getCellMetaData().onCommit(this.buildFakeCellUodate({ key: 'Tab' }));
+      });
+
+      it("should select next cell", function () {
+        expect(this.component.state.selected).toEqual({ idx: 2, rowIdx: 1, active: false });
+      });
+    });
+
+    describe("Cell click", function () {
+      beforeEach(function () {
+        this.getCellMetaData().onCellClick({ idx: 2, rowIdx: 2 });
+      });
+
+      it("should set selected state of grid", function () {
+        expect(this.component.state.selected).toEqual({ idx: 2, rowIdx: 2 });
+      });
     });
   });
 
-  it("changes to non metric column data should keep original metric information", function () {
-    var newColumns = this.columns.slice(0).map(column => Object.assign({}, column));
-    newColumns[0].editable = true;
-    var originalMetrics = Object.assign({}, this.component.state.columnMetrics);
-    this.component.setProps({columns : newColumns});
-    var columnMetrics = this.component.state.columnMetrics;
-    columnMetrics.columns.forEach((m, i) => {
-      expect(m.width).toEqual(originalMetrics.columns[i].width);
-      expect(m.left).toEqual(originalMetrics.columns[i].left);
-    })
-  });
+  describe("changes to non metric column data", function () {
+    beforeEach(function () {
+      this.originalMetrics = Object.assign({}, this.component.state.columnMetrics);
+      const editableColumn = Object.assign({ editable: true }, this.columns[0]);
+      this.columns[0] = editableColumn;
+      this.component.setProps({ columns: this.columns });
+    });
+
+    it("should keep original metric information", function () {
+      var columnMetrics = this.component.state.columnMetrics;
+      columnMetrics.columns.forEach((column, index) => {
+        expect(column.width).toEqual(this.originalMetrics.columns[index].width);
+        expect(column.left).toEqual(this.originalMetrics.columns[index].left);
+      })
+    });
+  })
 });

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -38,7 +38,7 @@ describe("Grid", function () {
       this._selectedRows.push(false);
     }
 
-    this.noop = function(){};
+    this.noop = function () {};
     this.testProps = {
       enableCellSelect: true,
       columns: this.columns,
@@ -478,12 +478,12 @@ describe("Grid", function () {
 
     describe("Adding a new row", function () {
       it("should set the selected cell to be on the last row", function () {
-        var newRow = {id: 1000, title: "Title 1000", count: 1000};
+        var newRow = { id: 1000, title: "Title 1000", count: 1000 };
         this._rows.push(newRow);
         this.component.setProps({ rowsCount: this._rows.length });
         expect(this.component.state.selected).toEqual({
-          idx : 1,
-          rowIdx : 1000
+          idx: 1,
+          rowIdx: 1000
         });
       });
     });
@@ -493,15 +493,15 @@ describe("Grid", function () {
     it("should create a cellMetaData object and pass to baseGrid as props", function () {
       var meta = this.getCellMetaData();
       expect(meta).toEqual(jasmine.objectContaining({
-        selected : { rowIdx: 0, idx: 0 },
-        dragged  : null,
-        copied   : null
+        selected: { rowIdx: 0, idx: 0 },
+        dragged: null,
+        copied: null
       }));
-      expect(typeof meta.onCellClick === "function").toBe(true);
-      expect(typeof meta.onCommit === "function").toBe(true);
-      expect(typeof meta.onCommitCancel === "function").toBe(true);
-      expect(typeof meta.handleDragEnterRow === "function").toBe(true);
-      expect(typeof meta.handleTerminateDrag === "function").toBe(true);
+      expect(meta.onCellClick).toBeFunction();
+      expect(meta.onCommit).toBeFunction();
+      expect(meta.onCommitCancel).toBeFunction();
+      expect(meta.handleDragEnterRow).toBeFunction();
+      expect(meta.handleTerminateDrag).toBeFunction();
     });
 
     describe("Changing Grid state", function () {
@@ -572,6 +572,7 @@ describe("Grid", function () {
 
     it("should keep original metric information", function () {
       var columnMetrics = this.component.state.columnMetrics;
+      expect(columnMetrics.columns.length).toBeGreaterThan(1);
       columnMetrics.columns.forEach((column, index) => {
         expect(column.width).toEqual(this.originalMetrics.columns[index].width);
         expect(column.left).toEqual(this.originalMetrics.columns[index].left);

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -32,7 +32,8 @@ describe("Grid", function () {
       this._rows.push({
         id: i,
         title: `Title ${i}`,
-        count: i * 1000
+        count: i * 1000,
+        isOdd: !!(i % 2)
       });
 
       this._selectedRows.push(false);
@@ -190,7 +191,7 @@ describe("Grid", function () {
       });
     });
 
-    describe("when selected = false", function () {
+    describe("when selected is false", function () {
       beforeEach(function () {
         this.component.setState({ selectedRows: [false, false, false, false] });
         var selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
@@ -202,7 +203,7 @@ describe("Grid", function () {
       });
     });
 
-    describe("when selected = null", function () {
+    describe("when selected is null", function () {
       beforeEach(function () {
         this.component.setState({ selectedRows: [null, null, null, null] });
         var selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
@@ -214,7 +215,7 @@ describe("Grid", function () {
       });
     });
 
-    describe("when selected = true", function () {
+    describe("when selected is true", function () {
       beforeEach(function () {
         this.component.setState({ selectedRows: [null, true, true, true] });
         var selectRowCol = this.baseGrid.props.columnMetrics.columns[0];
@@ -477,14 +478,53 @@ describe("Grid", function () {
     });
 
     describe("Adding a new row", function () {
-      it("should set the selected cell to be on the last row", function () {
+      beforeEach(function () {
         var newRow = { id: 1000, title: "Title 1000", count: 1000 };
         this._rows.push(newRow);
         this.component.setProps({ rowsCount: this._rows.length });
+      });
+
+      it("should set the selected cell to be on the last row", function () {
         expect(this.component.state.selected).toEqual({
           idx: 1,
           rowIdx: 1000
         });
+      });
+    });
+
+    describe("Adding a new column", function () {
+      beforeEach(function () {
+        const newColumn = { key: "isodd", name: "Is Odd", width: 100 };
+        const newColumns = Object.assign([], this.columns);
+        newColumns.splice(2, 0, newColumn);
+        this.component.setProps({ columns: newColumns });
+        this.columns = this.component.state.columnMetrics.columns;
+      });
+
+      it("should add column", function () {
+        expect(this.columns.length).toEqual(4);
+      });
+
+      it("should calculate column metrics for added column", function () {
+        expect(this.columns[2]).toEqual(jasmine.objectContaining({ key: "isodd", name: "Is Odd", width: 100 }));
+      });
+    });
+
+    describe("Remove a column", function () {
+      beforeEach(function() {
+        const newColumns = Object.assign([], this.columns);
+        newColumns.splice(1, 1);
+        this.component.setProps({ columns: newColumns });
+        this.columns = this.component.state.columnMetrics.columns;
+      });
+
+      it("should remove column", function () {
+        expect(this.columns.length).toEqual(2);
+      });
+
+      it("should no longer include metrics for removed column", function () {
+        expect(this.columns[0]).toEqual(jasmine.objectContaining({ key: "id", name: "ID", width: 100 }));
+        expect(this.columns[1]).toEqual(jasmine.objectContaining({ key: "count", name: "Count", width: 100 }));
       });
     });
   });

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -1,42 +1,10 @@
 'use strict';
 var React         = require('react');
 var rewire        = require('rewire');
-var Grid          =  rewire('../grids/ReactDataGrid.js');
+var Grid          = rewire('../grids/ReactDataGrid.js');
 var TestUtils     = require('react/lib/ReactTestUtils');
 var rewireModule  = require("../../../test/rewireModule");
 var StubComponent = require("../../../test/StubComponent");
-
-var columns = [
-  {
-    key   : 'id',
-    name  : 'ID',
-    width : 100
-  },
-  {
-    key: 'title',
-    name: 'Title',
-    width : 100
-  },
-  {
-    key: 'count',
-    name: 'Count',
-    width : 100
-  }
-];
-
-var _rows = [];
-var _selectedRows = [];
-var rowGetter = (i) => _rows[i];
-
-for (var i = 0; i < 1000; i++) {
-  _rows.push({
-    id: i,
-    title: `Title ${i}`,
-    count: i * 1000
-  });
-
-  _selectedRows.push(false);
-}
 
 describe('Grid', function () {
   var BaseGridStub = StubComponent('BaseGrid');
@@ -48,20 +16,53 @@ describe('Grid', function () {
     CheckboxEditor : CheckboxEditorStub
   });
 
-  var testProps = {
-    enableCellSelect: true,
-    columns:columns,
-    rowGetter:rowGetter,
-    rowsCount: _rows.length,
-    width:300,
-    onRowUpdated : function(update){},
-    onCellCopyPaste : function(){},
-    onCellsDragged : function(){},
-    onGridSort : function(){}
-  }
-
   beforeEach(function () {
-    this.component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
+    this.columns = [
+      {
+        key   : 'id',
+        name  : 'ID',
+        width : 100
+      },
+      {
+        key: 'title',
+        name: 'Title',
+        width : 100
+      },
+      {
+        key: 'count',
+        name: 'Count',
+        width : 100
+      }
+    ];
+
+    this._rows = [];
+    this._selectedRows = [];
+    this.rowGetter = (i) => this._rows[i];
+
+    for (var i = 0; i < 1000; i++) {
+      this._rows.push({
+        id: i,
+        title: `Title ${i}`,
+        count: i * 1000
+      });
+
+      this._selectedRows.push(false);
+    }
+
+    var noop = function(){};
+    this.testProps = {
+      enableCellSelect: true,
+      columns: this.columns,
+      rowGetter: this.rowGetter,
+      rowsCount: this._rows.length,
+      width: 300,
+      onRowUpdated: noop,
+      onCellCopyPaste: noop,
+      onCellsDragged: noop,
+      onGridSort: noop
+    };
+
+    this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}/>);
   });
 
   it('should create a new instance of Grid', function () {
@@ -75,7 +76,7 @@ describe('Grid', function () {
 
   it('should render a Toolbar if passed in as props to grid', function () {
     var Toolbar = StubComponent('Toolbar');
-    this.component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
+    this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} toolbar={<Toolbar/>} />);
     var toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, Toolbar);
     expect(toolbarInstance).toBeDefined();
   });
@@ -83,7 +84,7 @@ describe('Grid', function () {
   it('onToggleFilter trigger of Toolbar should set filter state of grid and render a filterable header row', function () {
     //arrange
     var Toolbar = StubComponent('Toolbar');
-    this.component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
+    this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} toolbar={<Toolbar/>} />);
     var toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, Toolbar);
     //act
     toolbarInstance.props.onToggleFilter();
@@ -98,7 +99,7 @@ describe('Grid', function () {
   it("should be initialized with correct state", function () {
     expect(this.component.state).toEqual({
       columnMetrics : { columns : [ { key : 'id', name : 'ID', width : 100, left : 0 }, { key : 'title', name : 'Title', width : 100, left : 100 }, { key : 'count', name : 'Count', width : 100, left : 200 } ], width : 300, totalWidth : 0, minColumnWidth : 80 },
-      selectedRows : _selectedRows,
+      selectedRows : this._selectedRows,
       selected : {rowIdx : 0,  idx : 0},
       copied : null,
       canFilter : false,
@@ -116,9 +117,9 @@ describe('Grid', function () {
     it("grid should be initialized with selected state of {rowIdx : -1, idx : -1}", function () {
       this.component = TestUtils.renderIntoDocument(<Grid
         enableCellSelect={false}
-        columns={columns}
-        rowGetter={rowGetter}
-        rowsCount={_rows.length}
+        columns={this.columns}
+        rowGetter={this.rowGetter}
+        rowsCount={this._rows.length}
         width={300}/>);
       expect(this.component.state.selected).toEqual({
         rowIdx : -1,
@@ -130,7 +131,7 @@ describe('Grid', function () {
 
   describe("When row selection enabled", function () {
     beforeEach(function () {
-      this.component = TestUtils.renderIntoDocument(<Grid {...testProps} enableRowSelect={true} />);
+      this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} enableRowSelect={true} />);
     });
 
     afterEach(function () {
@@ -140,7 +141,7 @@ describe('Grid', function () {
     it("should render an additional Select Row column", function () {
       var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
       var selectRowCol = baseGrid.props.columnMetrics.columns[0];
-      expect(baseGrid.props.columnMetrics.columns.length).toEqual(columns.length + 1);
+      expect(baseGrid.props.columnMetrics.columns.length).toEqual(this.columns.length + 1);
       expect(selectRowCol.key).toEqual('select-row');
       expect(TestUtils.isElementOfType(selectRowCol.formatter, CheckboxEditorStub)).toBe(true);
     });
@@ -159,7 +160,7 @@ describe('Grid', function () {
       headerCheckbox.props.onChange(fakeEvent);
       //assert
       var selectedRows = this.component.state.selectedRows;
-      expect(selectedRows.length).toEqual(_rows.length);
+      expect(selectedRows.length).toEqual(this._rows.length);
       selectedRows.forEach(function(selected){
         expect(selected).toBe(true);
       });
@@ -282,8 +283,8 @@ describe('Grid', function () {
 
     describe("When column is editable", function () {
       beforeEach(function () {
-        columns[1].editable = true;
-        this.component = TestUtils.renderIntoDocument(<Grid {...testProps} />);
+        this.columns[1].editable = true;
+        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} />);
       });
 
       it("double click on grid should activate current selected cell", function () {
@@ -302,7 +303,7 @@ describe('Grid', function () {
         var selectedCellIndex = 1, selectedRowIndex = 1;
         this.component.setState({selected  : {idx : selectedCellIndex, rowIdx : selectedRowIndex}});
         var keyCode_c = '99';
-        var expectedCellValue = _rows[selectedRowIndex].title;
+        var expectedCellValue = this._rows[selectedRowIndex].title;
         //act
         SimulateGridKeyDown(this.component, keyCode_c, true);
         //assert
@@ -312,8 +313,8 @@ describe('Grid', function () {
 
       it("paste a cell value should call onCellCopyPaste of component with correct params", function () {
         //arrange
-        spyOn(testProps, 'onCellCopyPaste');
-        this.component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
+        spyOn(this.testProps, 'onCellCopyPaste');
+        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}/>);
         this.component.setState({
           textToCopy : 'banana',
           selected   : {idx : 1, rowIdx : 5},
@@ -321,8 +322,8 @@ describe('Grid', function () {
         });
         var keyCode_v = '118';
         SimulateGridKeyDown(this.component, keyCode_v, true);
-        expect(testProps.onCellCopyPaste).toHaveBeenCalled();
-        expect(testProps.onCellCopyPaste.mostRecentCall.args[0]).toEqual({cellKey: "title", rowIdx: 5, value: "banana", fromRow: 1, toRow: 5})
+        expect(this.testProps.onCellCopyPaste).toHaveBeenCalled();
+        expect(this.testProps.onCellCopyPaste.mostRecentCall.args[0]).toEqual({cellKey: "title", rowIdx: 5, value: "banana", fromRow: 1, toRow: 5})
       });
 
       it("cell commit cancel should set grid state inactive", function () {
@@ -369,13 +370,13 @@ describe('Grid', function () {
 
     describe("When column is not editable", function () {
       beforeEach(function () {
-        columns[1].editable = false;
-        this.component = TestUtils.renderIntoDocument(<Grid {...testProps} />);
+        this.columns[1].editable = false;
+        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps} />);
       });
 
       it("double click on grid should not activate current selected cell", function () {
         this.component.setState({selected : {idx : 1, rowIdx : 1}});
-        columns[1].editable = false;
+        this.columns[1].editable = false;
         var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         baseGrid.props.onViewportDoubleClick();
         expect(this.component.state.selected).toEqual({
@@ -394,7 +395,7 @@ describe('Grid', function () {
         expect(this.component.state.dragged).toEqual({
           idx : 1,
           rowIdx : 2,
-          value : _rows[2].title
+          value : this._rows[2].title
         })
       });
 
@@ -415,17 +416,17 @@ describe('Grid', function () {
       });
 
       it("finishing drag will trigger onCellsDragged event and call it with correct params", function () {
-        spyOn(testProps, 'onCellsDragged');
-        this.component = TestUtils.renderIntoDocument(<Grid {...testProps}  />);
+        spyOn(this.testProps, 'onCellsDragged');
+        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}  />);
         this.component.setState({selected : {idx : 1, rowIdx : 2}, dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
         var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         baseGrid.props.onViewportDragEnd();
-        expect(testProps.onCellsDragged).toHaveBeenCalled();
-        expect(testProps.onCellsDragged.argsForCall[0][0]).toEqual({cellKey: "title", fromRow: 2, toRow: 6, value: "apple"});
+        expect(this.testProps.onCellsDragged).toHaveBeenCalled();
+        expect(this.testProps.onCellsDragged.argsForCall[0][0]).toEqual({cellKey: "title", fromRow: 2, toRow: 6, value: "apple"});
       });
 
       it("terminating drag will clear drag state", function () {
-        this.component = TestUtils.renderIntoDocument(<Grid {...testProps}  />);
+        this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}  />);
         this.component.setState({ dragged : {idx : 1, rowIdx : 2, value : 'apple', overRowIdx : 6}});
         var baseGrid = TestUtils.findRenderedComponentWithType(this.component, BaseGridStub);
         var meta = baseGrid.props.cellMetaData;
@@ -436,8 +437,8 @@ describe('Grid', function () {
 
     it("Adding a new row will set the selected cell to be on the last row", function () {
       var newRow = {id: 1000, title: 'Title 1000', count: 1000};
-      _rows.push(newRow);
-      this.component.setProps({rowsCount:_rows.length});
+      this._rows.push(newRow);
+      this.component.setProps({rowsCount: this._rows.length});
       expect(this.component.state.selected).toEqual({
         idx : 1,
         rowIdx : 1000
@@ -474,13 +475,13 @@ describe('Grid', function () {
     });
 
     it("cell commit should trigger onRowUpdated with correct params", function () {
-      spyOn(testProps, 'onRowUpdated');
-      this.component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
+      spyOn(this.testProps, 'onRowUpdated');
+      this.component = TestUtils.renderIntoDocument(<Grid {...this.testProps}/>);
       var meta = getCellMetaData(this.component);
       var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
       meta.onCommit(fakeCellUpdate);
-      expect(testProps.onRowUpdated.callCount).toEqual(1);
-      expect(testProps.onRowUpdated.argsForCall[0][0]).toEqual({
+      expect(this.testProps.onRowUpdated.callCount).toEqual(1);
+      expect(this.testProps.onRowUpdated.argsForCall[0][0]).toEqual({
         cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"
       })
     });
@@ -517,7 +518,7 @@ describe('Grid', function () {
   });
 
   it("changes to non metric column data should keep original metric information", function () {
-    var newColumns = columns.slice(0).map(column => Object.assign({}, column));
+    var newColumns = this.columns.slice(0).map(column => Object.assign({}, column));
     newColumns[0].editable = true;
     var originalMetrics = Object.assign({}, this.component.state.columnMetrics);
     this.component.setProps({columns : newColumns});

--- a/src/addons/__tests__/data/MockStateObject.js
+++ b/src/addons/__tests__/data/MockStateObject.js
@@ -1,0 +1,38 @@
+module.exports = function (stateValues) {
+  return Object.assign({
+    columnMetrics: {
+      columns: [{
+        key: 'id',
+        name: 'ID',
+        width: 100,
+        left: 0
+      }, {
+        key: 'title',
+        name: 'Title',
+        width: 100,
+        left: 100
+      }, {
+        key: 'count',
+        name: 'Count',
+        width: 100,
+        left: 200
+      }],
+      width: 300,
+      totalWidth: 0,
+      minColumnWidth: 80
+    },
+    selectedRows: [],
+    selected: {
+      rowIdx: 0,
+      idx: 0
+    },
+    copied: null,
+    canFilter: false,
+    expandedRows: [],
+    columnFilters: {},
+    sortDirection: null,
+    sortColumn: null,
+    dragged: null,
+    scrollOffset: 0
+  }, stateValues);
+};

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -93,7 +93,7 @@ var ReactDataGrid = React.createClass({
   },
 
   getInitialState: function(): {selected: SelectedType; copied: ?{idx: number; rowIdx: number}; selectedRows: Array<Row>; expandedRows: Array<Row>; canFilter: boolean; columnFilters: any; sortDirection: ?SortType; sortColumn: ?ExcelColumn; dragged: ?DraggedType;  } {
-    var columnMetrics = this.createColumnMetrics(true);
+    var columnMetrics = this.createColumnMetrics();
     var initialState = {columnMetrics, selectedRows : this.getInitialSelectedRows(), copied : null, expandedRows : [], canFilter : false, columnFilters : {}, sortDirection: null, sortColumn: null, dragged : null, scrollOffset: 0}
     if(this.props.enableCellSelect){
       initialState.selected = {rowIdx: 0, idx: 0};
@@ -344,9 +344,9 @@ var ReactDataGrid = React.createClass({
 
   },
 
-  setupGridColumns : function(): Array<any>{
-    var cols = this.props.columns.slice(0);
-    if(this.props.enableRowSelect){
+  setupGridColumns : function(props = this.props): Array<any>{
+    var cols = props.columns.slice(0);
+    if(props.enableRowSelect){
       var selectColumn = {
           key: 'select-row',
           name: '',


### PR DESCRIPTION
This updated to have `createColumnMetrics` use the current props from `componentWillReceiveProps` so that columns can be added and removed. In tandem with this is an update to the cell key, which now needs to make reference to the column id so that it is re-rendered when a column is removed.

Row also gets updated to use backticks so that the odd / even classes are set as expected.