### PR TITLE
[changed] Reduce renders by only requesting new rows after scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "classnames": "^1.2.0",
     "es5-shim": "^4.0.3",
+    "lodash": "~3.10.1",
     "object-assign": "^2.0.0",
     "react": "~0.13.3",
     "ron-react-autocomplete": "2.0.1"

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -113,6 +113,8 @@ var Canvas = React.createClass({
   },
 
   renderLoadingRow(position, rowHeight) {
+    if (this.scrollingHighVerticalDistance()) return null;
+
     const LoadingRow = this.props.loadingRowRenderer;
     if (!_.isUndefined(LoadingRow)) {
       return <LoadingRow height={rowHeight} key={position} idx={position} />;
@@ -151,7 +153,7 @@ var Canvas = React.createClass({
 
   _currentRowsLength : 0,
   _currentRowsRange : { start: 0, end: 0 },
-  _scroll : { scrollTop : 0, scrollLeft: 0 },
+  _scroll : { scrollTop : 0, scrollLeft: 0, changeTop: 0, changeLeft: 0 },
 
   getInitialState() {
     return {
@@ -286,10 +288,18 @@ var Canvas = React.createClass({
     return {scrollTop, scrollLeft};
   },
 
+  scrollingHighVerticalDistance() {
+    var numberOfRows = 10;
+    return Math.abs(this._scroll.changeTop) > (numberOfRows * this.props.rowHeight);
+  },
+
   onScroll(e: any) {
     this.appendScrollShim();
     var {scrollTop, scrollLeft} = e.target;
-    var scroll = {scrollTop, scrollLeft};
+    var changeTop = (scrollTop - this._scroll.scrollTop);
+    var changeLeft = (scrollLeft - this._scroll.scrollLeft);
+    var scroll = {scrollTop, scrollLeft, changeTop, changeLeft};
+
     this._scroll = scroll;
     this.props.onScroll(scroll);
   }

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -10,7 +10,7 @@ var React                = require('react');
 var PropTypes            = React.PropTypes;
 var Header               = require('./Header');
 var Viewport             = require('./Viewport');
-var ExcelColumn = require('./addons/grids/ExcelColumn');
+var ExcelColumn          = require('./addons/grids/ExcelColumn');
 var GridScrollMixin      = require('./GridScrollMixin');
 var DOMMetrics           = require('./DOMMetrics');
 
@@ -24,6 +24,7 @@ var Grid = React.createClass({
     rowHeight: PropTypes.number,
     rowRenderer: PropTypes.func,
     emptyRowsView: PropTypes.func,
+    debounceRowRequestWait: PropTypes.number,
     expandedRows: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
     selectedRows: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
     rowsCount: PropTypes.number,
@@ -76,6 +77,8 @@ var Grid = React.createClass({
                   width={this.props.columnMetrics.width}
                   rowHeight={this.props.rowHeight}
                   rowRenderer={this.props.rowRenderer}
+                  debounceRowRequestWait={this.props.debounceRowRequestWait}
+                  loadingRowRenderer={this.props.loadingRowRenderer}
                   rowGetter={this.props.rowGetter}
                   rowsCount={this.props.rowsCount}
                   selectedRows={this.props.selectedRows}

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -8,9 +8,9 @@
 
 var React             = require('react');
 var Canvas            = require('./Canvas');
-var PropTypes            = React.PropTypes;
+var PropTypes         = React.PropTypes;
 
-var ViewportScroll      = require('./ViewportScrollMixin');
+var ViewportScroll    = require('./ViewportScrollMixin');
 
 
 
@@ -25,6 +25,7 @@ var Viewport = React.createClass({
     selectedRows: PropTypes.array,
     expandedRows: PropTypes.array,
     rowRenderer: PropTypes.func,
+    debounceRowRequestWait: PropTypes.number,
     rowsCount: PropTypes.number.isRequired,
     rowHeight: PropTypes.number.isRequired,
     onRows: PropTypes.func,
@@ -55,6 +56,7 @@ var Viewport = React.createClass({
           expandedRows={this.props.expandedRows}
           columns={this.props.columnMetrics.columns}
           rowRenderer={this.props.rowRenderer}
+          debounceRowRequestWait={this.props.debounceRowRequestWait}
           visibleStart={this.state.visibleStart}
           visibleEnd={this.state.visibleEnd}
           displayStart={this.state.displayStart}
@@ -64,6 +66,7 @@ var Viewport = React.createClass({
           rowHeight={this.props.rowHeight}
           onScroll={this.onScroll}
           onRows={this.props.onRows}
+          loadingRowRenderer={this.props.loadingRowRenderer}
           />
       </div>
     );

--- a/src/ViewportScrollMixin.js
+++ b/src/ViewportScrollMixin.js
@@ -4,11 +4,11 @@ var React             = require('react');
 var DOMMetrics        = require('./DOMMetrics');
 var getWindowSize     = require('./getWindowSize');
 
-var PropTypes            = React.PropTypes;
-var min   = Math.min;
-var max   = Math.max;
+var PropTypes = React.PropTypes;
+var min = Math.min;
+var max = Math.max;
 var floor = Math.floor;
-var ceil  = Math.ceil;
+var ceil = Math.ceil;
 
 type ViewportScrollState = {
   displayStart: number;
@@ -48,7 +48,7 @@ module.exports = {
     return {
       displayStart: 0,
       displayEnd: totalRowCount,
-      height: props.minHeight,
+      height: props.minHeight - props.rowHeight,
       scrollTop: 0,
       scrollLeft: 0
     };
@@ -57,15 +57,17 @@ module.exports = {
   updateScroll(scrollTop: number, scrollLeft: number, height: number, rowHeight: number, length: number) {
     var renderedRowsCount = ceil(height / rowHeight);
 
-    var visibleStart = floor(scrollTop / rowHeight);
+    var visibleStart = min(
+        floor(scrollTop / rowHeight),
+        length - renderedRowsCount);
 
     var visibleEnd = min(
         visibleStart + renderedRowsCount,
         length);
 
-    var displayStart = max(
-        0,
-        visibleStart - renderedRowsCount * 2);
+    var displayStart = min(
+        max(0, visibleStart - renderedRowsCount * 2),
+        length);
 
     var displayEnd = min(
         visibleStart + renderedRowsCount * 2,


### PR DESCRIPTION
On each scroll, the canvas is rendered and `this.getRows` is called to retrieve the visible rows. However, much of the time, these rows have already been rendered and are not required. Additionally, users may be scrolling quickly in order to reach another part of the list, and may have no requirement for the intermediary rows to be requested and rendered.

In the examples, row data is retrieved directly from an in memory object with very quick read access. In reality,requesting this data may be more computationally expensive. This leads to stuttered scrolling and an inability to skim down a list, say to the mid point.

To help, this PR reduces the number of requests by caching the row data in state and rendering it on each scroll. Requests for new row data is debounced and completed when scrolling stops. Users can configure the debounce wait and provide a "loading" component to be rendered in place of a populated row.