### PR TITLE
re-render non-selected cells

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -77,7 +77,8 @@ var Cell = React.createClass({
     || this.isDraggedCellChanging(nextProps)
     || this.isCopyCellChanging(nextProps)
     || this.props.isRowSelected !== nextProps.isRowSelected
-    || this.isSelected();
+    || this.isSelected()
+    || this.props.value !== nextProps.value;
   },
 
   getStyle(): {position:string; width: number; height: number; left: number} {


### PR DESCRIPTION
if updating a cell in one column also updates the value of a cell on the same row but in a different column, we need to check that as part of shouldComponentUpdate.

at the moment only the selected cell will re-render, although each cell goes through shouldComponentUpdate.

- [x] fire shouldComponentUpdate if non-selected cell values change