### PR TITLE
Add classes to the sortable header cell for sort state

### DIFF
--- a/src/addons/cells/headerCells/SortableHeaderCell.js
+++ b/src/addons/cells/headerCells/SortableHeaderCell.js
@@ -52,8 +52,14 @@ var SortableHeaderCell = React.createClass({
   },
 
   render: function(): ?ReactElement {
+    var className = joinClasses({
+      'react-grid-HeaderCell-sortable': true,
+      'react-grid-HeaderCell-sortable--ascending': this.props.sortDirection === 'ASC',
+      'react-grid-HeaderCell-sortable--descending': this.props.sortDirection === 'DESC'
+    });
+
     return (
-      <div
+      <div className={className}
         onClick={this.onClick}
         style={{cursor: 'pointer'}}>
         {this.props.column.name}


### PR DESCRIPTION
Allow new styles to be attached to the sortable heading cells by providing classes for the different states.

For example, this allows us to use font-awesome icons for the sorting indicators, and use a faded [sort icon](http://fontawesome.io/icon/sort/) to provide affordance to the user on which columns can be sorted.