### PR TITLE
Pass in table width as prop or default to responsive

### DIFF
--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -619,4 +619,24 @@ describe("Grid", function () {
       })
     });
   })
+
+  describe("Table width", function () {
+    beforeEach(function () {
+      this.tableElement = React.findDOMNode(this.component);
+    });
+
+    it("should generate the width based on the container size", function () {
+      expect(this.tableElement.style.width).toEqual('0px');
+    });
+
+    describe("providing table width as prop", function () {
+      beforeEach(function () {
+        this.component.setProps({ minWidth: 900 });
+      });
+
+      it("should set the width of the table", function () {
+        expect(this.tableElement.style.width).toEqual('900px');
+      });
+    });
+  });
 });

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -63,6 +63,7 @@ var ReactDataGrid = React.createClass({
     rowHeight: React.PropTypes.number.isRequired,
     headerRowHeight: React.PropTypes.number,
     minHeight: React.PropTypes.number.isRequired,
+    minWidth: React.PropTypes.number,
     enableRowSelect: React.PropTypes.bool,
     onRowUpdated:React.PropTypes.func,
     rowGetter: React.PropTypes.func.isRequired,
@@ -140,10 +141,8 @@ var ReactDataGrid = React.createClass({
       handleTerminateDrag : this.handleTerminateDrag
     }
 
-
-
     var toolbar = this.renderToolbar();
-    var containerWidth = this.DOMMetrics.gridWidth();
+    var containerWidth = this.props.minWidth || this.DOMMetrics.gridWidth();
     var gridWidth = containerWidth - this.state.scrollOffset;
 
     return(


### PR DESCRIPTION
This change provides a `minWidth` prop which is used to control the table width. If no prop is provided, the existing `gridWidth` calculation is used.
Our use case is that the we want to be table to trigger a resize of the table when a menu is visible on the left, but the window size remains unchanged. This allows us to fully control the table width.

