### PR TITLE
[fixed] Canvas cdu method to not make extra call to setScrollLeft in always truth condition

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -144,9 +144,6 @@ var Canvas = React.createClass({
   },
 
   componentDidUpdate(nextProps: any) {
-    if (this._scroll !== {start: 0, end: 0}) {
-      this.setScrollLeft(this._scroll.scrollLeft);
-    }
     this.onRows();
   },
 


### PR DESCRIPTION
if (this._scroll !== {start: 0, end: 0}) is always true and it causes extra call to setScrollLeft which iterates through the columns. And when there're huge amount of columns it hits the performance. 

