### PR TITLE
re-render non-selected cells

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -77,7 +77,8 @@ var Cell = React.createClass({
     || this.isDraggedCellChanging(nextProps)
     || this.isCopyCellChanging(nextProps)
     || this.props.isRowSelected !== nextProps.isRowSelected
-    || this.isSelected();
+    || this.isSelected()
+    || this.props.value !== nextProps.value;
   },
 
   getStyle(): {position:string; width: number; height: number; left: number} {

--- a/src/ColumnMetricsMixin.js
+++ b/src/ColumnMetricsMixin.js
@@ -30,7 +30,15 @@ module.exports = {
 
   DOMMetrics: {
     gridWidth(): number {
-      return React.findDOMNode(this).parentElement.offsetWidth;
+      var width = React.findDOMNode(this).parentElement.offsetWidth;
+      if (width == 0) {
+        if (this.isMounted() && this.getDOMNode().parentOffset == null && this.props.columns) {
+          for (var c = 0, cL = this.props.columns.length; c < cL; c++) {
+            width += this.props.columns[c].width;
+          }
+        }
+      }
+      return width;
     }
   },
 
@@ -53,7 +61,9 @@ module.exports = {
 
   getTotalWidth() {
     var totalWidth = 0;
-    if(this.isMounted()){
+    // also check parentOffset to see if element is visible (see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent)
+    // without this check, mounted but invisible grids (ie rendered into a parent with display:none) set their totalWidth incorrectly
+    if(this.isMounted() && this.getDOMNode().parentOffset){
       totalWidth = this.DOMMetrics.gridWidth();
     } else {
       totalWidth = ColumnUtils.getSize(this.props.columns) * this.props.minColumnWidth;


### PR DESCRIPTION
if updating a cell in one column also updates the value of a cell on the same row but in a different column, we need to check that as part of shouldComponentUpdate.

at the moment only the selected cell will re-render, although each cell goes through shouldComponentUpdate.

- [x] fire shouldComponentUpdate if non-selected cell values change

**THIS WAS RELEASED AS v0.12.26 -- THIS IS A DUPLICATE PR SO WE DON'T LOSE THE CHANGE**