### PR TITLE
Introduce new can scroll props to prevent grid scrolling

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -29,6 +29,8 @@ var Canvas = React.createClass({
       PropTypes.array.isRequired
     ]),
     onRows: PropTypes.func,
+    canScrollX: PropTypes.bool,
+    canScrollY: PropTypes.bool,
     columns: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired
   },
 
@@ -62,20 +64,16 @@ var Canvas = React.createClass({
         this.renderPlaceholder('bottom', (length - displayEnd) * rowHeight));
     }
 
-
-
-
     var style = {
       position: 'absolute',
       top: 0,
       left: 0,
-      overflowX: 'auto',
-      overflowY: 'scroll',
+      overflowX: this.props.canScrollX === false ? 'hidden' : 'auto',
+      overflowY: this.props.canScrollY === false ? 'hidden' : 'scroll',
       width: this.props.totalWidth + this.state.scrollbarWidth,
       height: this.props.height,
       transform: 'translate3d(0, 0, 0)'
     };
-
 
     return (
       <div

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -28,6 +28,8 @@ var Grid = React.createClass({
     selectedRows: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
     rowsCount: PropTypes.number,
     onRows: PropTypes.func,
+    canScrollX: PropTypes.bool,
+    canScrollY: PropTypes.bool,
     sortColumn : React.PropTypes.string,
     sortDirection : React.PropTypes.oneOf(['ASC', 'DESC', 'NONE']),
     rowOffsetHeight: PropTypes.number.isRequired,
@@ -83,6 +85,8 @@ var Grid = React.createClass({
                   columnMetrics={this.props.columnMetrics}
                   totalWidth={this.props.totalWidth}
                   onScroll={this.onScroll}
+                  canScrollX={this.props.canScrollX}
+                  canScrollY={this.props.canScrollY}
                   onRows={this.props.onRows}
                   cellMetaData={this.props.cellMetaData}
                   rowOffsetHeight={this.props.rowOffsetHeight || this.props.rowHeight * headerRows.length}

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -78,6 +78,10 @@ var Viewport = React.createClass({
   },
 
   onScroll(scroll: {scrollTop: number; scrollLeft: number}) {
+    if (this.props.canScrollX === false) {
+      scroll.scrollLeft = 0;
+    }
+
     this.updateScroll(
       scroll.scrollTop, scroll.scrollLeft,
       this.state.height,

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -29,6 +29,8 @@ var Viewport = React.createClass({
     rowHeight: PropTypes.number.isRequired,
     onRows: PropTypes.func,
     onScroll: PropTypes.func,
+    canScrollX: PropTypes.bool,
+    canScrollY: PropTypes.bool,
     minHeight : PropTypes.number
   },
   render(): ?ReactElement {
@@ -63,6 +65,8 @@ var Viewport = React.createClass({
           height={this.state.height}
           rowHeight={this.props.rowHeight}
           onScroll={this.onScroll}
+          canScrollX={this.props.canScrollX}
+          canScrollY={this.props.canScrollY}
           onRows={this.props.onRows}
           />
       </div>


### PR DESCRIPTION
Introduces two new props, `canScrollX` and `canScrollY` to allow the horizontal and vertical scroll to be disabled independently.
Our use case for this is when the grid is the same size as the window, but at the bottom of the page and must be scrolled to. Locking the y scroll until the bottom of the page has been reached provides a much nicer user experience.