### PR TITLE
Introduce new heading row height prop

### DIFF
--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -61,6 +61,7 @@ var ReactDataGrid = React.createClass({
 
   propTypes: {
     rowHeight: React.PropTypes.number.isRequired,
+    headerRowHeight: React.PropTypes.number,
     minHeight: React.PropTypes.number.isRequired,
     enableRowSelect: React.PropTypes.bool,
     onRowUpdated:React.PropTypes.func,
@@ -436,7 +437,7 @@ var ReactDataGrid = React.createClass({
 
 
   getHeaderRows(): Array<{ref: string; height: number;}> {
-    var rows = [{ref:"row", height: this.props.rowHeight}];
+    var rows = [{ref:"row", height: this.props.headerRowHeight || this.props.rowHeight}];
     if(this.state.canFilter === true){
       rows.push({
         ref:"filterRow",


### PR DESCRIPTION
Introduces one new prop, `headerRowHeight` to allow the heading row size to be different from the row height. However, if not provided, this defaults to the row height.