### PR TITLE
Add PhantomJS paths for Linux and OSX

### DIFF
--- a/config/karma.js
+++ b/config/karma.js
@@ -76,6 +76,14 @@ module.exports = function (config) {
     return preprocessors;
   }
 
+  function lookupPhantomJS() {
+    try {
+      return require('phantomjs').path;
+    } catch(e){
+      return;
+    }
+  }
+
   config.set({
 
     basePath: path.join(__dirname, '../'),
@@ -163,6 +171,8 @@ module.exports = function (config) {
     phantomjsLauncher: {
       // configure PhantomJS executable for each platform
       cmd: {
+        linux: lookupPhantomJS(),
+        darwin: lookupPhantomJS(),
         win32: path.join(__dirname, '../test/browser/phantomjs.exe')
       }
     }


### PR DESCRIPTION
This adds the PhantomJS paths for linux and OSX so that it's picked up automatically when running `npm run test`.

__Side note:__ Seems a little weird to bundle the windows executable file for PhantomJS with the repo.
Was `karma-phantomjs-launcher` not working? It's still part of the `package.json` file, so will still be installed when running `npm install`.