### PR TITLE
Filterable header not scrolling

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -149,6 +149,11 @@ var Header = React.createClass({
     var node = this.refs.row.getDOMNode();
     node.scrollLeft = scrollLeft;
     this.refs.row.setScrollLeft(scrollLeft);
+    if (this.refs.filterRow) {
+      var nodeFilters = this.refs.filterRow.getDOMNode();
+      nodeFilters.scrollLeft = scrollLeft;
+      this.refs.filterRow.setScrollLeft(scrollLeft);
+    }
   },
 
   getCombinedHeaderHeights(until: ?number): number {


### PR DESCRIPTION
The header row with the filters is not moving horizontally, see screenshot.

http://d.pr/i/1b4LP

Also there is a warning when opening the filter: Warning: Failed propType: Required prop `column` was not specified in `FilterableHeaderCell`. Check the render method of `ReactDataGrid`.
