### PR TITLE
Fix dropdowneditor not setting value on blur

### DIFF
--- a/src/addons/editors/DropDownEditor.js
+++ b/src/addons/editors/DropDownEditor.js
@@ -25,7 +25,7 @@ class DropDownEditor extends EditorBase {
 
   render(): ?ReactElement{
     return (
-      <select style={this.getStyle()} defaultValue={this.props.value} onChange={this.onChange} >
+      <select style={this.getStyle()} defaultValue={this.props.value} onBlur={this.props.onBlur} onChange={this.onChange} >
         {this.renderOptions()}
       </select>);
   }


### PR DESCRIPTION
Select an option from a dropdown, then click outside the cell, the new value is not showed.