### PR TITLE
Add cell class to header cells

### DIFF
--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -37,7 +37,7 @@ var HeaderCell = React.createClass({
       'react-grid-HeaderCell--resizing': this.state.resizing,
       'react-grid-HeaderCell--locked': this.props.column.locked
     });
-    className = joinClasses(className, this.props.className);
+    className = joinClasses(className, this.props.className, this.props.column.cellClass);
     var cell = this.getCell();
     return (
       <div className={className} style={this.getStyle()}>


### PR DESCRIPTION
This adds the (possibly undocumented, see #97) `cellClass` prop to the column header so that it can be styled as well as data cells.

Headings can then be styled with `.react-grid-HeaderCell.my-custom-cellclass`
and data cells with `.react-grid-cell.my-custom-cellclass`