### PR TITLE
fix example

### DIFF
--- a/examples/components/Navbar.js
+++ b/examples/components/Navbar.js
@@ -38,7 +38,7 @@ module.exports = React.createClass({
                     <li><a href="examples.html#/immutable-data">Immutable Data Grid</a></li>
                     <li><a href="examples.html#/all-the-features">All-The-Features Grid</a></li>
                     <li><a href="examples.html#/custom-row-renderer">Custom Row Render</a></li>
-                    <li><a href="examples.html#/custom-row-renderer">Empty Rows</a></li>
+                    <li><a href="examples.html#/empty-rows">Empty Rows</a></li>
                     <li>
                       <a href="examples.html#/all-features-immutable">All-The-Features with Immutable Data</a>
                     </li>

--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -11,7 +11,7 @@
 	<link rel="shortcut icon" href="examples/assets/images/gt_favicon.png">
 
 	<link rel="stylesheet" media="screen" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
-	<script src="https://code.jquery.com/jquery-1.11.2.min.js"/>
+	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 
 
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">

--- a/examples/examples.html
+++ b/examples/examples.html
@@ -9,7 +9,7 @@
 <title>React Data Grid - Excel-like grid component built with React</title>
 <link rel="shortcut icon" href="examples/assets/images/gt_favicon.png">
 <link rel="stylesheet" media="screen" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
-<script src="https://code.jquery.com/jquery-1.11.2.min.js"/>
+<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 <script src="assets/js/affix.js"></script>

--- a/examples/scripts/example12-customRowRenderer.js
+++ b/examples/scripts/example12-customRowRenderer.js
@@ -83,11 +83,11 @@ var RowRenderer = React.createClass({
   },
  getRowStyle: function() {
    return {
-     backgroundColor: this.getRowBackground()
+     color: this.getRowColor()
    }
  },
- getRowBackground: function() {
-   return this.props.idx % 2 ?  'green' : 'white'
+ getRowColor: function() {
+   return this.props.idx % 2 ?  'red' : 'black'
  },
  render: function() {
    //here we are just changing the style
@@ -117,7 +117,7 @@ module.exports = React.createClass({
       <div>
         <h3>Overriding the row renderer</h3>
         <p>This shows how you can easily override the default row renderer</p>
-        <p>Here we are just using that to wrap the default renderer, and then going back into the 'normal' flow, just changing some backgrounds</p>
+        <p>Here we are just using that to wrap the default renderer, and then going back into the 'normal' flow, just changing the text color</p>
         <p>NOTE: if you want to use fixed columns as well, make sure you implement and pass through the call to setScrollLeft</p>
         <ReactPlayground codeText={SimpleExample} />
       </div>


### PR DESCRIPTION
- [x] point Empty Rows nav to the right place
- [x] changing the row render example to do text color instead
- [x] terminate `<script>` tags properly because FontAwesome wasn't being downloaded which i want for **no apparent reason** :wink: 

(row renderer does background color at the moment, which would work except the css style for `react-grid-Cell` has it's own background color so it wasn't clear what was actually being formatted)

Before
--------
![image](https://cloud.githubusercontent.com/assets/2393035/12551604/a36743a8-c363-11e5-82cb-c1c20d2cca97.png)

After
------
![image](https://cloud.githubusercontent.com/assets/2393035/12551607/a9fa594e-c363-11e5-863c-80b21acaf59a.png)