### PR TITLE
Use https links for external resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,15 +9,15 @@
 	<title>ReactData Grid - Excel-like grid component built with React</title>
 
 	<link rel="shortcut icon" href="examples/assets/images/gt_favicon.png">
-	<link rel="stylesheet" media="screen" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700"></link>
+	<link rel="stylesheet" media="screen" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700"></link>
 	<link rel="stylesheet" href="assets/css/bootstrap.min.css"></link>
 
 	<!-- Custom styles for our template -->
 	<link rel="stylesheet" href="assets/css/bootstrap-theme.css" media="screen" ></link>
 	<link rel="stylesheet" href="assets/css/main.css"></link>
 	<link rel="stylesheet" href="build/react-data-grid.css"></link>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-with-addons.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-with-addons.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 
 	<script src="build/libs.js"></script>


### PR DESCRIPTION
The examples do not load correctly in chrome since some resources are included via http.