### PR TITLE
Missing require('react-dom') in AutoCompleteEditor

### DIFF
--- a/src/addons/editors/AutoCompleteEditor.js
+++ b/src/addons/editors/AutoCompleteEditor.js
@@ -1,4 +1,5 @@
 const React                   = require('react');
+const ReactDOM                = require('react-dom');
 const ReactAutocomplete       = require('ron-react-autocomplete');
 const ExcelColumn             = require('../grids/ExcelColumn');
 


### PR DESCRIPTION
- [x] add ReactDOM to AutoCompleteEditor