### PR TITLE
[added] Each column can have its custom header cell renderer

### DIFF
--- a/examples/scripts/example13-all-features.js
+++ b/examples/scripts/example13-all-features.js
@@ -84,7 +84,8 @@ var AllFeaturesExample = `
       name: 'Avartar',
       width : 60,
       formatter : ReactDataGrid.Formatters.ImageFormatter,
-      resizable : true
+      resizable : true,
+      headerRenderer: <ReactDataGrid.Formatters.ImageFormatter value={faker.image.cats()} />
     },
     {
       key: 'county',

--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -70,20 +70,23 @@ const HeaderRow = React.createClass({
   },
 
   getHeaderRenderer(column) {
-    let headerCellType = this.getHeaderCellType(column);
     let renderer;
+    if (typeof column.headerRenderer !== 'undefined') {
+      renderer = column.headerRenderer;
+    } else {
+      let headerCellType = this.getHeaderCellType(column);
 
-    switch (headerCellType) {
-    case HeaderCellType.SORTABLE:
-      renderer = this.getSortableHeaderCell(column);
-      break;
-    case HeaderCellType.FILTERABLE:
-      renderer = this.getFilterableHeaderCell();
-      break;
-    default:
-      break;
+      switch (headerCellType) {
+      case HeaderCellType.SORTABLE:
+        renderer = this.getSortableHeaderCell(column);
+        break;
+      case HeaderCellType.FILTERABLE:
+        renderer = this.getFilterableHeaderCell();
+        break;
+      default:
+        break;
+      }
     }
-
     return renderer;
   },
 

--- a/src/__tests__/HeaderRow.spec.js
+++ b/src/__tests__/HeaderRow.spec.js
@@ -13,6 +13,7 @@ describe('Header Unit Tests', () => {
   let SortableHeaderCellStub = new StubComponent('SortableHeaderCell');
   let HeaderCellStub = new StubComponent('HeaderCell');
   let FilterableHeaderCellStub = new StubComponent('FilterableHeaderCell');
+  let CustomHeaderStub = new StubComponent('CustomHeader');
 
   rewireModule(HeaderRow, {
     SortableHeaderCell: SortableHeaderCellStub,
@@ -107,6 +108,23 @@ describe('Header Unit Tests', () => {
     afterEach(() => {
       testProps.columns[sortableAndFilterableColIdx].sortable = false;
       testProps.columns[sortableAndFilterableColIdx].filterable = false;
+    });
+  });
+
+  describe('When column has a headerRenderer', () => {
+    let customColumnIdx = 1;
+    beforeEach(() => {
+      testProps.columns[customColumnIdx].headerRenderer = <CustomHeaderStub />;
+      headerRow = TestUtils.renderIntoDocument(<HeaderRow {...testProps} />);
+    });
+
+    it('should render custom column header', () => {
+      let headerCells = TestUtils.scryRenderedComponentsWithType(headerRow, HeaderCellStub);
+      expect(TestUtils.isElementOfType(headerCells[customColumnIdx].props.renderer, CustomHeaderStub)).toBe(true);
+    });
+
+    afterEach(() => {
+      testProps.columns[customColumnIdx].headerRenderer = null;
     });
   });
 });


### PR DESCRIPTION
Added `column.headerRenderer` tag processing, so each column may use custom renderer for a header cell.
Added tests.
Added the custom header in the 'All feature' example.