### PR TITLE
fixing grid width for percentage width containers

### DIFF
--- a/src/DOMMetrics.js
+++ b/src/DOMMetrics.js
@@ -97,6 +97,10 @@ let MetricsComputatorMixin = {
     } else {
       window.attachEvent('resize', this.updateMetrics);
     }
+    // to prevent mis-calculated widths calling updateMetrics one more time async
+    setTimeout(() => {
+      this.updateMetrics();
+    }, 0);
     this.updateMetrics();
   },
 


### PR DESCRIPTION
if the div that own the grid is contained by an element with a percentage container then the grid overflows the width of its container

Example issue:

CSS
```
.left {
  width: 20%;
  float: left;
}
.right {
  width: 80%;
  float: right;
}
.right .grid-container {
  width: 100%;
}
```
HTML
```html
<body>
  <aside class="left">
  <main class="right">
    <div class="grid-container"></div>
  </main>
</body>
```
When the grid gets rendered inside the grid-content tag it overflows its right container.