### PR TITLE
re-render non-selected cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid",
-  "version": "0.13.34",
+  "version": "0.13.35",
   "description": "Data grid for React",
   "main": "src/index.js",
   "scripts": {

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -71,7 +71,8 @@ const Cell = React.createClass({
     || this.isDraggedCellChanging(nextProps)
     || this.isCopyCellChanging(nextProps)
     || this.props.isRowSelected !== nextProps.isRowSelected
-    || this.isSelected();
+    || this.isSelected()
+    || this.props.value !== nextProps.value;
   },
 
   onCellClick() {


### PR DESCRIPTION
this is already in 0.12.x and 0.14.x, but *not* 0.13.x -- see https://github.com/adazzle/react-data-grid/issues/251

- [x] fire shouldComponentUpdate if non-selected cell values change

