### PR TITLE
Explicitly allow column.name to render anything React can render 

### DIFF
--- a/src/addons/cells/headerCells/SortableHeaderCell.js
+++ b/src/addons/cells/headerCells/SortableHeaderCell.js
@@ -9,7 +9,7 @@ const DEFINE_SORT = {
 const SortableHeaderCell = React.createClass({
   propTypes: {
     columnKey: React.PropTypes.string.isRequired,
-    column: React.PropTypes.shape({ name: React.PropTypes.string }),
+    column: React.PropTypes.shape({ name: React.PropTypes.node }),
     onSort: React.PropTypes.func.isRequired,
     sortDirection: React.PropTypes.oneOf(['ASC', 'DESC', 'NONE'])
   },

--- a/src/addons/grids/ExcelColumn.js
+++ b/src/addons/grids/ExcelColumn.js
@@ -2,7 +2,7 @@
 const React = require('react');
 
 const ExcelColumnShape = {
-  name: React.PropTypes.string.isRequired,
+  name: React.PropTypes.node.isRequired,
   key: React.PropTypes.string.isRequired,
   width: React.PropTypes.number.isRequired,
   filterable: React.PropTypes.bool


### PR DESCRIPTION
Hey did you guys know you built a kickass datagrid that will allow you to pass a React component through column.name and it will work?!?   

I've been using this for a while for things like checkboxes in the header, custom rendered data, etc.   Maybe worth considering explicitly allowing it?    Might remove the burden of adding a bunch of different prebaked column header types?

PR just removes the React proptype warning when running in debug mode.