### PR TITLE
change module name Immutable to lowercase for linux

### DIFF
--- a/src/__tests__/ColumnMetrics.spec.js
+++ b/src/__tests__/ColumnMetrics.spec.js
@@ -1,6 +1,6 @@
 const rewire = require('rewire');
 const ColumnMetrics = rewire('../ColumnMetrics');
-const Immutable = window.Immutable = require('Immutable');
+const Immutable = window.Immutable = require('immutable');
 Object.assign = require('object-assign');
 
 describe('Column Metrics Tests', () => {


### PR DESCRIPTION
npm run example was not working:

```
12 04 2016 14:29:38.388:INFO [PhantomJS 1.9.8 (Linux 0.0.0)]: Connected on socket /#Z-lQPNxMRCsae3jRAAAA with id 93321705
PhantomJS 1.9.8 (Linux 0.0.0) ERROR
  Error: Cannot find module "Immutable"
  at /home/juanda/react-data-grid/test/unitTests.jsx:22678
```
