### PR TITLE
Fix bug that makes text appear when row is selected

### DIFF
--- a/themes/react-data-grid.css
+++ b/themes/react-data-grid.css
@@ -355,7 +355,7 @@ textareaselect.editor-main {
 }
 
 .react-grid-Row.row-selected .react-grid-Cell{
- background-color: rgba(16, 126, 219, 0.15);
+ background-color: #DBECFA;
 }
 
 


### PR DESCRIPTION
Text in the grid appears when selected. Alpha 0.15 on css background is the cause.

![wrong](https://cloud.githubusercontent.com/assets/5275294/14578121/827dff5c-0377-11e6-98df-9b0601b4c866.png)

To fix, just changed to a flat color.

![right](https://cloud.githubusercontent.com/assets/5275294/14578124/89f1d81c-0377-11e6-9c2a-c5b86caf1a7e.png)
