### PR TITLE
[added] Column resize callback

### DIFF
--- a/examples/scripts/example02-resizable-cols.js
+++ b/examples/scripts/example02-resizable-cols.js
@@ -32,8 +32,8 @@ var columns = [
 {
   key: 'id',
   name: 'ID',
-  resizable : true
-
+  resizable : true,
+  width : 40
 },
 {
   key: 'task',
@@ -81,6 +81,9 @@ module.exports = React.createClass({
       <div>
         <h3>Resizable Columns Example</h3>
         <p>To make a given column resizable, set <code>column.resizable = true</code></p>
+        <p>If you need to know when a column has been resized, use the <code>onColumnResize</code> prop. This will be triggered when a column is
+        resized and will report the column index and its new width. These can be saved on the back-end and used to restore column widths when
+        the component is initialized, by setting <code>width</code> key in each column.</p>
         <ReactPlayground codeText={ResizableExample} />
       </div>
     )

--- a/src/ColumnMetricsMixin.js
+++ b/src/ColumnMetricsMixin.js
@@ -24,7 +24,8 @@ module.exports = {
   propTypes: {
     columns: PropTypes.arrayOf(Column),
     minColumnWidth: PropTypes.number,
-    columnEquality: PropTypes.func
+    columnEquality: PropTypes.func,
+    onColumnResize: PropTypes.func
   },
 
   DOMMetrics: {
@@ -110,5 +111,8 @@ module.exports = {
   onColumnResize(index: number, width: number) {
     let columnMetrics = ColumnMetrics.resizeColumn(this.state.columnMetrics, index, width);
     this.setState({columnMetrics});
+    if (this.props.onColumnResize) {
+      this.props.onColumnResize(index, width);
+    }
   }
 };


### PR DESCRIPTION
Allow grid to report on column resize events so that new column sizes
can be persisted on the back-end.

This exposes an onColumnResize prop for ReactDataGrid.