### PR TITLE
[changed] this.getDOMNode() replaced by findDOMNode(this)

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -106,7 +106,7 @@ const Canvas = React.createClass({
   },
 
   onScroll(e: any) {
-    if (this.getDOMNode() !== e.target) {
+    if (ReactDOM.findDOMNode(this) !== e.target) {
       return;
     }
     this.appendScrollShim();


### PR DESCRIPTION
getDOMNode removed as of V0.15
[https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#new-deprecations-introduced-with-a-warning](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#new-deprecations-introduced-with-a-warning)