### PR TITLE
Add column events

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Features
 - [Context Menu] (http://adazzle.github.io/react-data-grid/examples.html#/context-menu)
 - Copy and Paste values into other cells
 - [Multiple cell updates using cell dragdown] (http://adazzle.github.io/react-data-grid/examples.html#/cell-drag-down)
+- [Association of events of individual columns] (http://adazzle.github.io/react-data-grid/examples.html#/column-events)
 
 
 Check out the `examples` directory to see how simple previously complex UI

--- a/examples/scripts/example13-all-features.js
+++ b/examples/scripts/example13-all-features.js
@@ -189,8 +189,10 @@ var AllFeaturesExample = `
     getColumns: function() {
       var clonedColumns = columns.slice();
       clonedColumns[2].events = {
-        onClick: function() {
-          this.refs.grid.setActive('Enter');
+        onClick: function(ev, args) {
+          var idx = args.idx;
+          var rowIdx = args.rowIdx;
+          this.refs.grid.openCellEditor(rowIdx, idx);
         }.bind(this)
       }
 

--- a/examples/scripts/example13-all-features.js
+++ b/examples/scripts/example13-all-features.js
@@ -99,7 +99,12 @@ var AllFeaturesExample = `
       name: 'Title',
       editor : <DropDownEditor options={titles}/>,
       width : 200,
-      resizable: true
+      resizable: true,
+      events: {
+        onDoubleClick: function() {
+           console.log("The user double clicked on title column");
+        }
+      }
     },
     {
       key: 'firstName',
@@ -181,6 +186,17 @@ var AllFeaturesExample = `
       return {rows :fakeRows};
     },
 
+    getColumns: function() {
+      var clonedColumns = columns.slice();
+      clonedColumns[2].events = {
+        onClick: function() {
+          this.refs.grid.setActive('Enter');
+        }.bind(this)
+      }
+
+      return clonedColumns;
+    },
+
     handleGridRowsUpdated : function(updatedRowData) {
       var rows = this.state.rows;
 
@@ -217,8 +233,9 @@ var AllFeaturesExample = `
     render : function() {
       return (
             <ReactDataGrid
+              ref='grid'
               enableCellSelect={true}
-              columns={columns}
+              columns={this.getColumns()}
               rowGetter={this.getRowAt}
               rowsCount={this.getSize()}
               onGridRowsUpdated={this.handleGridRowsUpdated}

--- a/examples/scripts/example19-column-events.js
+++ b/examples/scripts/example19-column-events.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import ReactPlayground from '../assets/js/ReactPlayground';
+
+let example = `
+var Editors             = ReactDataGrid.Editors;
+var DropDownEditor      = Editors.DropDownEditor;
+
+var titles = ['Dr.', 'Mr.', 'Mrs.', 'Miss', 'Ms.'];
+
+var _rows = [];
+for (var i = 1; i < 1000; i++) {
+  _rows.push({
+    id: i,
+    title: titles[Math.floor((Math.random() * 4))],
+    name: "Name " + i,
+    age: Math.floor((Math.random() * 100) + 1)
+  });
+};
+
+var columns = [
+  {
+    key: 'id',
+    name: 'ID',
+    resizable: true
+  },
+  {
+    key: 'title',
+    name: 'Title',
+    editor : <DropDownEditor options={titles}/>,
+    resizable: true,
+    events: {
+      onDoubleClick: function(ev, args) {
+          console.log("The user entered edit mode on title column with rowId: " + args.rowIdx);
+      },
+    }
+  },
+  {
+    key: 'name',
+    name: 'Name',
+    editable:true,
+    resizable: true,
+    events: {
+      onKeyDown: function(ev) {
+        if (ev.key === 'Enter') {
+          alert('Thanks for commiting a result with Enter');
+        }
+      }
+    }
+  },
+  {
+    key: 'age',
+    name: 'Age',
+    editable:true,
+    resizable: true
+  }
+];
+
+// Create the React Data Grid and pass your context menu to the contextMenu prop.
+var Example = React.createClass({
+  getInitialState: function() {
+    return {rows: _rows};
+  },
+
+  rowGetter: function(rowIdx) {
+    return this.state.rows[rowIdx];
+  },
+
+  handleGridRowsUpdated : function(updatedRowData) {
+    var rows = this.state.rows;
+
+    for (var i = updatedRowData.fromRow; i <= updatedRowData.toRow; i++) {
+      var rowToUpdate = rows[i];
+      var updatedRow = React.addons.update(rowToUpdate, {$merge: updatedRowData.updated});
+      rows[i] = updatedRow;
+    }
+
+    this.setState({rows: rows});
+  },
+
+  cellEditWithOneClick: function(ev, args) {
+    var idx = args.idx;
+    var rowIdx = args.rowIdx;
+    this.refs.grid.openCellEditor(rowIdx, idx);
+  },
+
+  getColumns: function() {
+    var clonedColumns = columns.slice();
+    clonedColumns[1].events = {
+      onClick: this.cellEditWithOneClick.bind(this)
+    };
+    clonedColumns[3].events = {
+      onClick: this.cellEditWithOneClick.bind(this)
+    };
+
+    return clonedColumns;
+  },
+
+  render: function() {
+    return (
+      <ReactDataGrid
+        ref="grid"
+        columns={this.getColumns()}
+        enableCellSelect={true}
+        rowGetter={this.rowGetter}
+        onGridRowsUpdated={this.handleGridRowsUpdated}
+        rowsCount={this.state.rows.length}
+        minHeight={500} />
+    );
+  }
+});
+
+ReactDOM.render(<Example />, mountNode);
+`;
+
+class ColumnEventsExample extends React.Component {
+  render() {
+    return (
+      <div>
+        <h3>Column Events Example</h3>
+        <p>
+          By adding an <code>event</code> object with callbacks for the native react events you can bind events to a specific column. That will not break the default behaviour of the grid
+          and will run only for the specified column.
+        </p>
+        <p>
+          Every event callback must respect this standard in order to work correctly: <code>function onXxx(ev :SyntheticEvent, (rowIdx, idx, column): args)</code>
+        </p>
+        <ReactPlayground codeText={example} />
+      </div>
+    );
+  }
+}
+
+module.exports = ColumnEventsExample;

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -331,9 +331,16 @@ const Cell = React.createClass({
     return (this.props.column.editor != null) || this.props.column.editable;
   },
 
-  createEventCallBack(onColumnEvent, info) {
+  createColumEventCallBack(onColumnEvent, info) {
     return (e) => {
       onColumnEvent(e, info);
+    };
+  },
+
+  createCellEventCallBack(gridEvent, columnEvent) {
+    return (e) => {
+      gridEvent(e);
+      columnEvent(e);
     };
   },
 
@@ -344,14 +351,11 @@ const Cell = React.createClass({
       if (columnEvents.hasOwnProperty(eventKey)) {
         let event = columnEvents[event];
         let eventInfo = {rowIdx: this.props.rowIdx, idx: this.props.idx, name: eventKey};
-        let eventCallback = this.createEventCallBack(onColumnEvent, eventInfo);
+        let eventCallback = this.createColumEventCallBack(onColumnEvent, eventInfo);
 
         if (allEvents.hasOwnProperty(eventKey)) {
           let currentEvent = allEvents[eventKey];
-          allEvents[eventKey] = (e) => {
-            currentEvent(e);
-            eventCallback(e);
-          };
+          allEvents[eventKey] = this.createCellEventCallBack(currentEvent, eventCallback);
         } else {
           allEvents[eventKey] = eventCallback;
         }

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -75,17 +75,17 @@ const Cell = React.createClass({
     || this.props.value !== nextProps.value;
   },
 
-  onCellClick() {
+  onCellClick(e) {
     let meta = this.props.cellMetaData;
     if (meta != null && meta.onCellClick != null) {
-      meta.onCellClick({rowIdx: this.props.rowIdx, idx: this.props.idx});
+      meta.onCellClick({rowIdx: this.props.rowIdx, idx: this.props.idx}, e);
     }
   },
 
-  onCellDoubleClick() {
+  onCellDoubleClick(e) {
     let meta = this.props.cellMetaData;
     if (meta != null && meta.onCellDoubleClick != null) {
-      meta.onCellDoubleClick({rowIdx: this.props.rowIdx, idx: this.props.idx});
+      meta.onCellDoubleClick({rowIdx: this.props.rowIdx, idx: this.props.idx}, e);
     }
   },
 

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -318,8 +318,8 @@ const Cell = React.createClass({
     return (this.props.column.editor != null) || this.props.column.editable;
   },
 
-  createEventCallBack(e, onColumnEvent, info) {
-    return () => {
+  createEventCallBack(onColumnEvent, info) {
+    return (e) => {
       onColumnEvent(e, info);
     };
   },
@@ -331,7 +331,7 @@ const Cell = React.createClass({
       if (columnEvents.hasOwnProperty(eventKey)) {
         let event = columnEvents[event];
         let eventInfo = {rowIdx: this.props.rowIdx, idx: this.props.idx, name: eventKey};
-        let eventCallback = this.createEventCallBack(e, onColumnEvent, eventInfo);
+        let eventCallback = this.createEventCallBack(onColumnEvent, eventInfo);
 
         if (allEvents.hasOwnProperty(eventKey)) {
           let currentEvent = allEvents[eventKey];

--- a/src/__tests__/Cell.spec.js
+++ b/src/__tests__/Cell.spec.js
@@ -27,7 +27,8 @@ describe('Cell Tests', () => {
     onCommitCancel: function() {},
     copied: null,
     handleDragEnterRow: function() {},
-    handleTerminateDrag: function() {}
+    handleTerminateDrag: function() {},
+    onColumnEvent: function() {}
   };
 
   let testProps = {
@@ -109,6 +110,69 @@ describe('Cell Tests', () => {
       cellInstance.setProps({rowData: {}, selectedColumn: testProps.column});
       let cellHasUpdateClass = ReactDOM.findDOMNode(cellInstance).getAttribute('class').indexOf(updateClass) > -1;
       expect(cellHasUpdateClass).toBe(true);
+    });
+
+    describe('Default events', () => {
+      let cellEvents;
+
+      beforeEach(() => {
+        let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps}/>);
+        cellEvents = cellInstance.getEvents();
+      });
+
+      it('should have a onClick event associated', () => {
+        expect(cellEvents.hasOwnProperty('onClick')).toBe(true);
+      });
+
+      it('should have a onDoubleClick event associated', () => {
+        expect(cellEvents.hasOwnProperty('onDoubleClick')).toBe(true);
+      });
+
+      it('should have a onDragOver event associated', () => {
+        expect(cellEvents.hasOwnProperty('onDragOver')).toBe(true);
+      });
+    });
+
+    describe('Column events', () => {
+      let cellEvents;
+      const COLUMN_ON_KEY_PRESS_EVENT_KEY = 'onKeyPress';
+
+      beforeEach(() => {
+        testProps.column.events = {
+          [COLUMN_ON_KEY_PRESS_EVENT_KEY]: () => {},
+          onClick: () => {},
+          onDragOver: () => {}
+        };
+
+        let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
+        cellEvents = cellInstance.getEvents();
+      });
+
+      it('should contain the default grid events', () => {
+        expect(cellEvents.hasOwnProperty('onClick')).toBe(true);
+        expect(cellEvents.hasOwnProperty('onDoubleClick')).toBe(true);
+        expect(cellEvents.hasOwnProperty('onDragOver')).toBe(true);
+      });
+
+      it('should add the column events to cell events', () => {
+        expect(cellEvents.hasOwnProperty(COLUMN_ON_KEY_PRESS_EVENT_KEY)).toBe(true);
+      });
+
+      it('should not add any extra keys', () => {
+        expect(Object.keys(cellEvents).length).toBe(4);
+      });
+
+      it('should support cell and column events at the same time', () => {
+        // Arrange.
+        let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
+        cellInstance.createCellEventCallBack = jasmine.createSpy();
+
+        // Act.
+        cellEvents = cellInstance.getEvents();
+
+        // Assert.
+        expect(cellInstance.createCellEventCallBack).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -22,7 +22,8 @@ describe('Grid', function() {
     this.columns = [
       { key: 'id', name: 'ID', width: 100 },
       { key: 'title', name: 'Title', width: 100 },
-      { key: 'count', name: 'Count', width: 100 }
+      { key: 'count', name: 'Count', width: 100 },
+      { key: 'country', name: 'Country', width: 100, events: { onClick: () => {}, onDoubleClick: () => {}}}
     ];
 
     this._rows = [];
@@ -100,7 +101,7 @@ describe('Grid', function() {
   it('should be initialized with correct state', function() {
     expect(this.component.state).toEqual(mockStateObject({
       selectedRows: this._selectedRows
-    }));
+    }, this.columns[3].events));
   });
 
   describe('if passed in as props to grid', function() {
@@ -487,7 +488,7 @@ describe('Grid', function() {
       });
 
       it('should add column', function() {
-        expect(this.columns.length).toEqual(4);
+        expect(this.columns.length).toEqual(5);
       });
 
       it('should calculate column metrics for added column', function() {
@@ -504,7 +505,7 @@ describe('Grid', function() {
       });
 
       it('should remove column', function() {
-        expect(this.columns.length).toEqual(2);
+        expect(this.columns.length).toEqual(3);
       });
 
       it('should no longer include metrics for removed column', function() {
@@ -583,6 +584,43 @@ describe('Grid', function() {
 
       it('should set selected state of grid', function() {
         expect(this.component.state.selected).toEqual({ idx: 2, rowIdx: 2 });
+      });
+    });
+
+    describe('Column events', function() {
+      let columnWithEvent;
+      const eventColumnIdx = 3;
+      const eventColumnRowIdx = 2;
+
+      beforeEach(function() {
+        columnWithEvent = this.component.state.columnMetrics.columns[3];
+        let events = this.testProps.columns[3].events;
+        spyOn(events, 'onClick');
+        spyOn(events, 'onDoubleClick');
+        this.getCellMetaData().onCellClick({idx: eventColumnIdx, rowIdx: eventColumnRowIdx});
+      });
+
+      it('should call an event when there is one', function() {
+        expect(columnWithEvent.events.onClick).toHaveBeenCalled();
+      });
+
+      it('should call the correct event', function() {
+        expect(columnWithEvent.events.onClick).toHaveBeenCalled();
+        expect(columnWithEvent.events.onDoubleClick).not.toHaveBeenCalled();
+      });
+
+      it('should call double click event on double click', function() {
+        this.getCellMetaData().onCellDoubleClick({idx: eventColumnIdx, rowIdx: eventColumnRowIdx});
+
+        expect(columnWithEvent.events.onDoubleClick).toHaveBeenCalled();
+      });
+
+      it('should call click event on click', function() {
+        expect(columnWithEvent.events.onClick).toHaveBeenCalled();
+      });
+
+      it('should call the event when there is one with the correct args', function() {
+        expect(columnWithEvent.events.onClick.mostRecentCall.args).toEqual([undefined, {column: columnWithEvent, idx: eventColumnIdx, rowIdx: eventColumnRowIdx }]);
       });
     });
   });

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -23,7 +23,7 @@ describe('Grid', function() {
       { key: 'id', name: 'ID', width: 100 },
       { key: 'title', name: 'Title', width: 100 },
       { key: 'count', name: 'Count', width: 100 },
-      { key: 'country', name: 'Country', width: 100, events: { onClick: () => {}, onDoubleClick: () => {}}}
+      { key: 'country', name: 'Country', width: 100, events: { onClick: () => {}, onDoubleClick: () => {}, onDragOver: () => {}}}
     ];
 
     this._rows = [];
@@ -597,30 +597,35 @@ describe('Grid', function() {
         let events = this.testProps.columns[3].events;
         spyOn(events, 'onClick');
         spyOn(events, 'onDoubleClick');
-        this.getCellMetaData().onCellClick({idx: eventColumnIdx, rowIdx: eventColumnRowIdx});
+        spyOn(events, 'onDragOver');
       });
 
       it('should call an event when there is one', function() {
+        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, name: 'onClick'});
         expect(columnWithEvent.events.onClick).toHaveBeenCalled();
       });
 
       it('should call the correct event', function() {
+        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, name: 'onClick'});
         expect(columnWithEvent.events.onClick).toHaveBeenCalled();
         expect(columnWithEvent.events.onDoubleClick).not.toHaveBeenCalled();
       });
 
       it('should call double click event on double click', function() {
-        this.getCellMetaData().onCellDoubleClick({idx: eventColumnIdx, rowIdx: eventColumnRowIdx});
+        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, name: 'onDoubleClick'});
 
         expect(columnWithEvent.events.onDoubleClick).toHaveBeenCalled();
       });
 
-      it('should call click event on click', function() {
-        expect(columnWithEvent.events.onClick).toHaveBeenCalled();
+      it('should call drag over event on drag over click', function() {
+        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, name: 'onDragOver'});
+
+        expect(columnWithEvent.events.onDragOver).toHaveBeenCalled();
       });
 
       it('should call the event when there is one with the correct args', function() {
-        expect(columnWithEvent.events.onClick.mostRecentCall.args).toEqual([undefined, {column: columnWithEvent, idx: eventColumnIdx, rowIdx: eventColumnRowIdx }]);
+        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, name: 'onClick'});
+        expect(columnWithEvent.events.onClick.mostRecentCall.args).toEqual([{}, {column: columnWithEvent, idx: eventColumnIdx, rowIdx: eventColumnRowIdx }]);
       });
     });
   });

--- a/src/addons/__tests__/data/MockStateObject.js
+++ b/src/addons/__tests__/data/MockStateObject.js
@@ -1,4 +1,4 @@
-module.exports = function(stateValues) {
+module.exports = function(stateValues, events) {
   return Object.assign({
     columnMetrics: {
       columns: [{
@@ -16,8 +16,14 @@ module.exports = function(stateValues) {
         name: 'Count',
         width: 100,
         left: 200
+      }, {
+        key: 'country',
+        name: 'Country',
+        width: 100,
+        left: 300,
+        events: events
       }],
-      width: 300,
+      width: 400,
       totalWidth: 0,
       minColumnWidth: 80
     },

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -470,6 +470,10 @@ const ReactDataGrid = React.createClass({
   },
 
   openCellEditor(rowIdx, idx) {
+    if (!this.canEdit(idx)) {
+      return;
+    }
+
     let selected = {rowIdx, idx};
     if (this.hasSelectedCellChanged(selected)) {
       this.setState({selected}, () => {

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -130,15 +130,13 @@ const ReactDataGrid = React.createClass({
     }
   },
 
-  onCellClick: function(cell: SelectedType, e: SyntheticEvent) {
+  onCellClick: function(cell: SelectedType) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
-    this.onColumnEvent(e, {rowIdx: cell.rowIdx, idx: cell.idx, name: 'onClick'});
   },
 
-  onCellDoubleClick: function(cell: SelectedType, e: SyntheticEvent) {
+  onCellDoubleClick: function(cell: SelectedType) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
     this.setActive('Enter');
-    this.onColumnEvent(e, {rowIdx: cell.rowIdx, idx: cell.idx, name: 'onDoubleClick'});
   },
 
   onViewportDoubleClick: function() {
@@ -562,7 +560,8 @@ const ReactDataGrid = React.createClass({
       copied: this.state.copied,
       handleDragEnterRow: this.handleDragEnter,
       handleTerminateDrag: this.handleTerminateDrag,
-      onDragHandleDoubleClick: this.onDragHandleDoubleClick
+      onDragHandleDoubleClick: this.onDragHandleDoubleClick,
+      onColumnEvent: this.onColumnEvent
     };
 
     let toolbar = this.renderToolbar();


### PR DESCRIPTION
<h2>Motivation</h2>
It's useful and necessary to allow different columns to have different behaviours based on the native React events. This can have a huge number of benefits like logging, statistic gather, fast editor opening...

<h2>Technical Side</h2>

- <h3>Bound one or more events to a column</h3>
This should be simple and work by convention, my suggestion in this one is to use the same [convention used by react](https://facebook.github.io/react/docs/events.html#supported-events) for the naming, of course that **not every react event would be supported in the first release but we should aim to cover as much events as possible in the next major release**.
<h6>API:</h6>
For every event implementation in the column context the following convention will be adopted 
`function onXxx(ev :SyntheticEvent, args: {rowIdx :number, idx: number, column :ColumnShape}) { ... }`. The correct usage of the args is a user responsibility.
<h6>Usage example:</h6>
```
columns = [{
   key: 'title',
   ...,
   events: {
      onDoubleClick: function() {
         console.log("The user double clicked on title column");
      },
      onClick: function(ev, args) {
         doStuff(ev, args);
      }
   }
}]
```
- <h3>Event execution on the Grid</h3>
To execute the event on the Grid side the best thing to do would be have something similar to a dispatcher or a afterEach in jasmine. The main responsibility for it would be to make sure that after a n event being fired in the grid context it would look at the column where the event was fired and fire the column event when necessary.


<h2>Progress</h2>
- [x] Pass an event to the grid should trigger that event (click and doubleClick for now)
- [x] Handle events on the grid
- [x] Efficient event execution on the grid 
- [x] Tests