### PR TITLE
Stop the grid from autofocusing

### DIFF
--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -77,13 +77,22 @@ const ReactDataGrid = React.createClass({
 
   getInitialState: function(): {selected: SelectedType; copied: ?{idx: number; rowIdx: number}; selectedRows: Array<Row>; expandedRows: Array<Row>; canFilter: boolean; columnFilters: any; sortDirection: ?SortType; sortColumn: ?ExcelColumn; dragged: ?DraggedType;  } {
     let columnMetrics = this.createColumnMetrics();
-    let initialState = {columnMetrics, selectedRows: [], copied: null, expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, dragged: null, scrollOffset: 0 };
-    if (this.props.enableCellSelect) {
-      initialState.selected = {rowIdx: 0, idx: 0};
-    } else {
-      initialState.selected = {rowIdx: -1, idx: -1};
-    }
-    return initialState;
+    return {
+			columnMetrics,
+			selectedRows: [],
+			copied: null,
+			expandedRows: [],
+			canFilter: false,
+			columnFilters: {},
+			sortDirection: null,
+			sortColumn: null,
+			dragged: null,
+			scrollOffset: 0,
+			selected: {
+				rowIdx: -1,
+				idx: -1
+			}
+		};
   },
 
   onSelect: function(selected: SelectedType) {

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -492,7 +492,7 @@ const ReactDataGrid = React.createClass({
 
   canEdit(idx: number): boolean {
     const col = this.getColumn(idx);
-    return this.props.enableCellEdit === true && !!col.editor;
+    return this.props.enableCellEdit && (!!col.editor || col.editable)
   },
 
   isActive(): boolean {


### PR DESCRIPTION
If a grid live below the fold, the page will scroll down to the selected area.

A grid can _still_ be selectable without autofocusing it.

Thanks!