### PR TITLE
Fix resizing prop warning for HeaderRow

### DIFF
--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -34,7 +34,7 @@ const HeaderRow = React.createClass({
     headerCellRenderer: PropTypes.func,
     filterable: PropTypes.bool,
     onFilterChange: PropTypes.func,
-    resizing: PropTypes.func,
+    resizing: PropTypes.object,
     onScroll: PropTypes.func,
     rowType: PropTypes.string
   },


### PR DESCRIPTION
I get this warning when manually resizing a column:

Warning: Failed propType: Invalid prop `resizing` of type `object` supplied to `HeaderRow`, expected `function`. Check the render method of `Header`.

It looks like HeaderRow expects a column definition instead of a function, this change made the warning go away.