### PR TITLE
move to previous/next row when selection moves beyond first/last cell in row

### DIFF
--- a/examples/scripts/example20-cell-navigation.js
+++ b/examples/scripts/example20-cell-navigation.js
@@ -78,7 +78,8 @@ ReactDOM.render(<ReactDataGrid
   rowGetter={rowGetter}
   rowsCount={_rows.length}
   minHeight={500}
-  enableCellSelect={true}/>, mountNode);
+  enableCellSelect={true}
+  cellNavigationMode="changeRow" />, mountNode);
 `;
 
 module.exports = React.createClass({

--- a/examples/scripts/example20-cell-navigation.js
+++ b/examples/scripts/example20-cell-navigation.js
@@ -78,8 +78,7 @@ ReactDOM.render(<ReactDataGrid
   rowGetter={rowGetter}
   rowsCount={_rows.length}
   minHeight={500}
-  enableCellSelect={true}
-  enableCellSelectionLoop={false} />, mountNode);
+  enableCellSelect={true}/>, mountNode);
 `;
 
 module.exports = React.createClass({
@@ -87,9 +86,10 @@ module.exports = React.createClass({
   render:function(){
     return(
       <div>
-        <h3>Column Navigation Example</h3>
-        <p>By setting enableCellSelectionLoop={true}, you enable looping round the same row when navigation goes beyond the first/last cells.</p>
-        <p>The default behavior is to jump to the next/previous row.</p>
+        <h3>Column Navigation Modes Example</h3>
+        <p>By setting <code>cellNavigationMode = 'loopOverRow'</code>, you enable looping round the same row when navigation goes beyond the first/last cells.</p>
+        <p>Setting <code>cellNavigationMode = 'changeRow'</code>, would make the selection jump to the next/previous row.</p>
+        <p>The default behavior is to do nothing.</p>
         <ReactPlayground codeText={NavigationExample} />
       </div>
     )

--- a/examples/scripts/example20-cell-navigation.js
+++ b/examples/scripts/example20-cell-navigation.js
@@ -1,0 +1,98 @@
+var ReactGrid             = require('../build/react-data-grid');
+var QuickStartDescription = require('../components/QuickStartDescription')
+var ReactPlayground       = require('../assets/js/ReactPlayground');
+
+var NavigationExample = `
+
+//helper to generate a random date
+function randomDate(start, end) {
+  return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime())).toLocaleDateString();
+};
+
+var _rows = [];
+for (var i = 1; i < 1000; i++) {
+  _rows.push({
+    id: i,
+    task: 'Task ' + i,
+    complete: Math.min(100, Math.round(Math.random() * 110)),
+    priority : ['Critical', 'High', 'Medium', 'Low'][Math.floor((Math.random() * 3) + 1)],
+    issueType : ['Bug', 'Improvement', 'Epic', 'Story'][Math.floor((Math.random() * 3) + 1)],
+    startDate: randomDate(new Date(2015, 3, 1), new Date()),
+    completeDate: randomDate(new Date(), new Date(2016, 0, 1))
+  });
+};
+
+//function to retrieve a row for a given index
+var rowGetter = function(i){
+  return _rows[i];
+};
+
+
+//Columns definition
+var columns = [
+{
+  key: 'id',
+  name: 'ID',
+  locked : true
+},
+{
+  key: 'task',
+  name: 'Title',
+  width: 200
+},
+{
+  key: 'priority',
+  name: 'Priority',
+  width: 200
+},
+{
+  key: 'issueType',
+  name: 'Issue Type',
+  width: 200
+},
+{
+  key: 'complete',
+  name: '% Complete',
+  width: 200
+},
+{
+  key: 'startDate',
+  name: 'Start Date',
+  width: 200
+},
+{
+  key: 'completeDate',
+  name: 'Expected Complete',
+  width: 200
+},
+{
+  key: 'completeDate',
+  name: 'Expected Complete',
+  width: 200
+}
+]
+
+
+ReactDOM.render(<ReactDataGrid
+  columns={columns}
+  rowGetter={rowGetter}
+  rowsCount={_rows.length}
+  minHeight={500}
+  enableCellSelect={true}
+  enableCellSelectionLoop={false} />, mountNode);
+`;
+
+module.exports = React.createClass({
+
+  render:function(){
+    return(
+      <div>
+        <h3>Column Navigation Example</h3>
+        <p>By setting enableCellSelectionLoop={true}, you enable looping round the same row when navigation goes beyond the first/last cells.</p>
+        <p>The default behavior is to jump to the next/previous row.</p>
+        <ReactPlayground codeText={NavigationExample} />
+      </div>
+    )
+  }
+
+});

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -232,12 +232,37 @@ describe('Grid', function() {
   });
 
   describe('Cell Navigation', function() {
-    describe('when cell selection looping is disabled', function() {
+    describe('when cell navigation is configured to default, none', function() {
       beforeEach(function() {
-        this.component = this.createComponent({enableCellSelectionLoop: false, enableCellSelect: true});
+        this.component = this.createComponent({enableCellSelect: true});
       });
 
-      describe('when on last cell', function() {
+      describe('when on last cell in a row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
+        });
+        it('selection should stay on cell', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
+        });
+      });
+      describe('when on first cell in row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 0, rowIdx: 1 } });
+        });
+        it('nothing should happen', function() {
+          this.simulateGridKeyDown('ArrowLeft');
+          expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
+        });
+      });
+    });
+
+    describe('when cell navigation is configured to change rows', function() {
+      beforeEach(function() {
+        this.component = this.createComponent({cellNavigationMode: 'changeRow', enableCellSelect: true});
+      });
+
+      describe('when on last cell in a row that\'s not the last', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
         });
@@ -246,7 +271,16 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 2 });
         });
       });
-      describe('when on first cell', function() {
+      describe('when on last cell in last row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 3, rowIdx: 999 } });
+        });
+        it('nothing should happen', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 999 });
+        });
+      });
+      describe('when on first cell in a row that\'s not the first', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 0, rowIdx: 2 } });
         });
@@ -255,14 +289,23 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
         });
       });
+      describe('when on first cell in the first row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 0, rowIdx: 0 } });
+        });
+        it('nothing should happen', function() {
+          this.simulateGridKeyDown('ArrowLeft');
+          expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 0 });
+        });
+      });
     });
 
-    describe('when cell selection looping is enabled', function() {
+    describe('when cell navigation is configured to loop over cells in row', function() {
       beforeEach(function() {
-        this.component = this.createComponent({enableCellSelectionLoop: true, enableCellSelect: true});
+        this.component = this.createComponent({cellNavigationMode: 'loopOverRow', enableCellSelect: true});
       });
 
-      describe('when on last cell with selection looping', function() {
+      describe('when on last cell, looping enabled', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
         });
@@ -271,13 +314,31 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
         });
       });
-      describe('when on first cell with selection looping', function() {
+      describe('when on last cell in last row with looping enabled', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 3, rowIdx: 999 } });
+        });
+        it('selection should move to first cell in same row', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 999 });
+        });
+      });
+      describe('when on first cell with looping enabled', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 0, rowIdx: 2 } });
         });
         it('selection should move to last cell in same row', function() {
           this.simulateGridKeyDown('ArrowLeft');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 2 });
+        });
+      });
+      describe('when on first cell in first row with looping enabled', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 0, rowIdx: 0 } });
+        });
+        it('selection should move to last cell in same row', function() {
+          this.simulateGridKeyDown('ArrowLeft');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 0 });
         });
       });
     });

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -230,7 +230,58 @@ describe('Grid', function() {
       });
     });
   });
-
+  
+  describe('Cell Navigation', function() {
+    describe('when cell selection looping is disabled', function() {
+      beforeEach(function() {
+        this.component = this.createComponent({enableCellSelectionLoop: false, enableCellSelect: true});
+      });
+      
+      describe('when on last cell', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
+        });
+        it('selection should move to first cell in next row', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 2 });
+        });
+      });
+      describe('when on first cell', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 0, rowIdx: 2 } });
+        });
+        it('selection should move to last cell in previous row', function() {
+          this.simulateGridKeyDown('ArrowLeft');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
+        });
+      });
+    });
+    describe('when cell selection looping is enabled', function() {
+      beforeEach(function() {
+        this.component = this.createComponent({enableCellSelectionLoop: true, enableCellSelect: true});
+      });
+      
+      describe('when on last cell with selection looping', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
+        });
+        it('selection should move to first cell in same row', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
+        });
+      });
+      describe('when on first cell with selection looping', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 0, rowIdx: 2 } });
+        });
+        it('selection should move to last cell in same row', function() {
+          this.simulateGridKeyDown('ArrowLeft');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 2 });
+        });
+      });
+    });
+  });
+  
   describe('User Interaction', function() {
     it('hitting TAB should decrement selected cell index by 1', function() {
       this.simulateGridKeyDown('Tab');

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -230,13 +230,13 @@ describe('Grid', function() {
       });
     });
   });
-  
+
   describe('Cell Navigation', function() {
     describe('when cell selection looping is disabled', function() {
       beforeEach(function() {
         this.component = this.createComponent({enableCellSelectionLoop: false, enableCellSelect: true});
       });
-      
+
       describe('when on last cell', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
@@ -256,11 +256,12 @@ describe('Grid', function() {
         });
       });
     });
+
     describe('when cell selection looping is enabled', function() {
       beforeEach(function() {
         this.component = this.createComponent({enableCellSelectionLoop: true, enableCellSelect: true});
       });
-      
+
       describe('when on last cell with selection looping', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
@@ -281,7 +282,7 @@ describe('Grid', function() {
       });
     });
   });
-  
+
   describe('User Interaction', function() {
     it('hitting TAB should decrement selected cell index by 1', function() {
       this.simulateGridKeyDown('Tab');

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -484,24 +484,24 @@ const ReactDataGrid = React.createClass({
     e.preventDefault();
     let rowIdx = this.state.selected.rowIdx;
     let idx = this.state.selected.idx + cellDelta;
-    const {enableCellSelectionLoop} = this.props;
-    if (cellDelta > 0){
-        if (this.state.selected.idx === this.props.columns.length - 1 && this.state.selected.rowIdx < this.props.rowsCount -1) {
-          if (!enableCellSelectionLoop) {
-            rowDelta = rowDelta + 1;
-          }
-          idx = 0;
+    let _rowDelta = rowDelta;
+    const { enableCellSelectionLoop } = this.props;
+    if (cellDelta > 0) {
+      if (this.state.selected.idx === this.props.columns.length - 1 && this.state.selected.rowIdx < this.props.rowsCount - 1) {
+        if (!enableCellSelectionLoop) {
+          _rowDelta = rowDelta + 1;
         }
-    } else if (cellDelta < 0){
-        if (this.state.selected.idx === 0 && this.state.selected.rowIdx > 0) {
-          if (!enableCellSelectionLoop) {
-            rowDelta = rowDelta - 1;
-          }
-          idx = 0;
-            idx = this.props.columns.length - 1;
+        idx = 0;
+      }
+    } else if (cellDelta < 0) {
+      if (this.state.selected.idx === 0 && this.state.selected.rowIdx > 0) {
+        if (!enableCellSelectionLoop) {
+          _rowDelta = rowDelta - 1;
         }
+        idx = this.props.columns.length - 1;
+      }
     }
-    rowIdx = rowIdx + rowDelta;
+    rowIdx = rowIdx + _rowDelta;
     this.onSelect({ idx: idx, rowIdx: rowIdx });
   },
 

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -494,7 +494,7 @@ const ReactDataGrid = React.createClass({
     this.onSelect({ idx: idx, rowIdx: rowIdx });
   },
 
-  calculateNextSelectionPosition(cellNavigationMode: any, cellDelta: number, rowDelta: number) {
+  calculateNextSelectionPosition(cellNavigationMode: string, cellDelta: number, rowDelta: number) {
     let _rowDelta = rowDelta;
     let idx = this.state.selected.idx + cellDelta;
     if (cellDelta > 0) {

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -67,7 +67,8 @@ const ReactDataGrid = React.createClass({
     rowKey: React.PropTypes.string,
     rowScrollTimeout: React.PropTypes.number,
     onClearFilters: React.PropTypes.func,
-    contextMenu: React.PropTypes.element
+    contextMenu: React.PropTypes.element,
+    enableCellSelectionLoop: React.PropTypes.bool
   },
 
   getDefaultProps(): {enableCellSelect: boolean} {
@@ -78,7 +79,8 @@ const ReactDataGrid = React.createClass({
       enableRowSelect: false,
       minHeight: 350,
       rowKey: 'id',
-      rowScrollTimeout: 0
+      rowScrollTimeout: 0,
+      enableCellSelectionLoop: false
     };
   },
 
@@ -480,9 +482,27 @@ const ReactDataGrid = React.createClass({
     // we need to prevent default as we control grid scroll
     // otherwise it moves every time you left/right which is janky
     e.preventDefault();
-    let rowIdx = this.state.selected.rowIdx + rowDelta;
+    let rowIdx = this.state.selected.rowIdx;
     let idx = this.state.selected.idx + cellDelta;
-    this.onSelect({idx: idx, rowIdx: rowIdx});
+    const {enableCellSelectionLoop} = this.props;
+    if (cellDelta > 0){
+        if (this.state.selected.idx === this.props.columns.length - 1 && this.state.selected.rowIdx < this.props.rowsCount -1) {
+          if (!enableCellSelectionLoop) {
+            rowDelta = rowDelta + 1;
+          }
+          idx = 0;
+        }
+    } else if (cellDelta < 0){
+        if (this.state.selected.idx === 0 && this.state.selected.rowIdx > 0) {
+          if (!enableCellSelectionLoop) {
+            rowDelta = rowDelta - 1;
+          }
+          idx = 0;
+            idx = this.props.columns.length - 1;
+        }
+    }
+    rowIdx = rowIdx + rowDelta;
+    this.onSelect({ idx: idx, rowIdx: rowIdx });
   },
 
   openCellEditor(rowIdx, idx) {


### PR DESCRIPTION
pull request for [https://github.com/adazzle/react-data-grid/issues/307](https://github.com/adazzle/react-data-grid/issues/307). 

- move selection to next/previous row when user navigates beyond last/first cell in a row.

- added a property "enableCellSelectionLoop" to enable/disable looping around the same row's cells when navigating with keyboard. when set to true, moving the selection beyond the last cell will select the first cell in the same row.