### PR TITLE
Fix for Drag double click feature

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -99,7 +99,7 @@ const Cell = React.createClass({
   onDragHandleDoubleClick(e) {
     e.stopPropagation();
     let meta = this.props.cellMetaData;
-    if (meta != null && typeof(meta.onDragHandleDoubleClick != null) === 'function') {
+    if (meta != null && typeof(meta.onDragHandleDoubleClick) === 'function') {
       meta.onDragHandleDoubleClick({rowIdx: this.props.rowIdx, idx: this.props.idx, rowData: this.getRowData(), e});
     }
   },

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -84,7 +84,7 @@ const Cell = React.createClass({
 
   onCellContextMenu() {
     let meta = this.props.cellMetaData;
-    if (meta != null && typeof(meta.onCellContextMenu) === 'function') {
+    if (meta != null && meta.onCellContextMenu && typeof(meta.onCellContextMenu) === 'function') {
       meta.onCellContextMenu({rowIdx: this.props.rowIdx, idx: this.props.idx});
     }
   },
@@ -99,7 +99,7 @@ const Cell = React.createClass({
   onDragHandleDoubleClick(e) {
     e.stopPropagation();
     let meta = this.props.cellMetaData;
-    if (meta != null && typeof(meta.onDragHandleDoubleClick) === 'function') {
+    if (meta != null && meta.onDragHandleDoubleClick && typeof(meta.onDragHandleDoubleClick) === 'function') {
       meta.onDragHandleDoubleClick({rowIdx: this.props.rowIdx, idx: this.props.idx, rowData: this.getRowData(), e});
     }
   },

--- a/src/__tests__/Cell.spec.js
+++ b/src/__tests__/Cell.spec.js
@@ -131,6 +131,31 @@ describe('Cell Tests', () => {
       it('should have a onDragOver event associated', () => {
         expect(cellEvents.hasOwnProperty('onDragOver')).toBe(true);
       });
+
+      describe('Cell Metadata', () => {
+        describe('When Action is defined on CellMetaData', () => {
+          it('should call metaData onCellClick when it is defined', () => {
+            // Arrange
+            testCellMetaData.onCellClick = jasmine.createSpy();
+            let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
+
+            // Act
+            cellInstance.onCellClick();
+
+            // Assert
+            expect(testCellMetaData.onCellClick).toHaveBeenCalled();
+          });
+
+          it('should call metaData onDragHandleDoubleClick when it is defined', () => {
+            testCellMetaData.onDragHandleDoubleClick = jasmine.createSpy();
+            let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
+
+            cellInstance.onDragHandleDoubleClick(new Event('click'));
+
+            expect(testCellMetaData.onDragHandleDoubleClick).toHaveBeenCalled();
+          });
+        });
+      });
     });
 
     describe('Column events', () => {

--- a/src/__tests__/Cell.spec.js
+++ b/src/__tests__/Cell.spec.js
@@ -22,6 +22,7 @@ describe('Cell Tests', () => {
     selected: {idx: 2, rowIdx: 3},
     dragged: null,
     onCellClick: function() {},
+    onCellContextMenu: function() {},
     onCellDoubleClick: function() {},
     onCommit: function() {},
     onCommitCancel: function() {},
@@ -150,9 +151,27 @@ describe('Cell Tests', () => {
             testCellMetaData.onDragHandleDoubleClick = jasmine.createSpy();
             let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
 
-            cellInstance.onDragHandleDoubleClick(new Event('click'));
+            cellInstance.onDragHandleDoubleClick(document.createEvent('Event'));
 
             expect(testCellMetaData.onDragHandleDoubleClick).toHaveBeenCalled();
+          });
+
+          it('should call metaData onCellContextMenu if defined', () => {
+            testCellMetaData.onCellContextMenu = jasmine.createSpy();
+            let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
+
+            cellInstance.onCellContextMenu();
+
+            expect(testCellMetaData.onCellContextMenu).toHaveBeenCalled();
+          });
+
+          it('should call metaData onCellDoubleClick if defined', () => {
+            testCellMetaData.onCellDoubleClick = jasmine.createSpy();
+            let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps} />);
+
+            cellInstance.onCellDoubleClick();
+
+            expect(testCellMetaData.onCellDoubleClick).toHaveBeenCalled();
           });
         });
       });


### PR DESCRIPTION
Feature was broken [in here](https://github.com/adazzle/react-data-grid/commit/d8b3e36de47bd0e1285175a62dfd707d9ed26f00). 

To fix it it will be a matter of fixing the if clause [in here](https://github.com/adazzle/react-data-grid/blob/master/src/Cell.js#L102) to be` meta != null && meta.onDragHandleDoubleClick && typeof(meta.onDragHandleDoubleClick) === 'function'`

Need to write some tests for this meta functions to make sure no one breaks this any more.

- [x] Failing test for onDragHandleDoubleClick
- [x] Fix if clause
- [x] Write tests to avoid further similar breaking changes

@willgates Will take this one