### PR TITLE
fire cell selection events

### DIFF
--- a/examples/scripts/example21-cell-selection-events.js
+++ b/examples/scripts/example21-cell-selection-events.js
@@ -1,0 +1,101 @@
+
+var QuickStartDescription = require('../components/QuickStartDescription')
+var ReactPlayground       = require('../assets/js/ReactPlayground');
+
+
+var SimpleExample = `
+
+var SimpleCheckboxEditor = ReactDataGrid.Editors.SimpleCheckboxEditor;
+var SimpleCheckboxFormatter = ReactDataGrid.Editors.SimpleCheckboxFormatter;
+var _rows = [];
+for (var i = 1; i < 1000; i++) {
+  _rows.push({
+    id: i,
+    title: 'Title ' + i,
+    count: i * 1000,
+    active: i % 2
+  });
+}
+
+//A rowGetter function is required by the grid to retrieve a row for a given index
+var rowGetter = function(i){
+  return _rows[i];
+};
+
+
+var columns = [
+{
+  key: 'id',
+  name: 'ID'
+},
+{
+  key: 'title',
+  name: 'Title',
+  editable: true
+},
+{
+  key: 'count',
+  name: 'Count'
+},
+{
+  key: 'active',
+  name: 'Active',
+  editor: SimpleCheckboxEditor,
+  formatter: SimpleCheckboxFormatter
+}
+]
+
+var Example = React.createClass({
+
+  getInitialState: function() {
+    return {selectedRows: []}
+  },
+
+  onRowSelect: function(rows) {
+    this.setState({selectedRows: rows});
+  },
+  
+  onCellSelected(coordinates) {
+    this.refs.grid.openCellEditor(coordinates.rowIdx, coordinates.idx);
+  },
+  
+  onCellDeSelected(coordinates) {
+    if (coordinates.idx === 2) {
+      alert('the editor for cell (' + coordinates.rowIdx + ',' + coordinates.idx + ') should have just closed');
+    }
+  },
+  
+  render: function() {
+    var rowText = this.state.selectedRows.length === 1 ? 'row' : 'rows';
+    return  (<div>
+      <span>{this.state.selectedRows.length} {rowText} selected</span>
+      <ReactDataGrid ref="grid"
+    rowKey='id'
+    columns={columns}
+    rowGetter={rowGetter}
+    rowsCount={_rows.length}
+    enableRowSelect='multi'
+    minHeight={500}
+    onRowSelect={this.onRowSelect}
+    enableCellSelect={true}
+    onCellSelected={this.onCellSelected}
+    onCellDeSelected={this.onCellDeSelected} /></div>);
+  }
+});
+ReactDOM.render(<Example />, mountNode);
+`;
+
+module.exports = React.createClass({
+
+  render:function(){
+    return(
+      <div>
+        <h3>Cell selection/delesection events</h3>
+        <p>Define onCellSelected and onCellDeSelected callback handlers and pass them as props to enable events upon cell selection/deselection.</p>
+        <p>if passed, onCellSelected will be triggered each time a cell is selected with the cell coordinates. Similarly, onCellDeSelected will be triggered when a cell is deselected.</p>
+        <ReactPlayground codeText={SimpleExample} />
+      </div>
+    )
+  }
+
+});

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -344,6 +344,38 @@ describe('Grid', function() {
     });
   });
 
+  describe('Cell Selection/DeSelection handlers', function() {
+    describe('when cell selection/deselection handlers are passed', function() {
+      beforeEach(function() {
+        const extraProps = { onCellSelected: this.noop, onCellDeSelected: this.noop };
+        spyOn(extraProps, 'onCellSelected');
+        spyOn(extraProps, 'onCellDeSelected');
+        this.component = this.createComponent(extraProps);
+      });
+
+      describe('cell is selected', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 2, rowIdx: 1 } });
+        });
+        it('deselection handler should have been called', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.props.onCellDeSelected).toHaveBeenCalled();
+          expect(this.component.props.onCellDeSelected.mostRecentCall.args[0]).toEqual({
+            rowIdx: 1,
+            idx: 2
+          });
+        });
+        it('selection handler should have been called', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.props.onCellSelected).toHaveBeenCalled();
+          expect(this.component.props.onCellSelected.mostRecentCall.args[0]).toEqual({
+            rowIdx: 1,
+            idx: 3
+          });
+        });
+      });
+    });
+  });
   describe('User Interaction', function() {
     it('hitting TAB should decrement selected cell index by 1', function() {
       this.simulateGridKeyDown('Tab');

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -140,8 +140,10 @@ const ReactDataGrid = React.createClass({
         ) {
         const oldSelection = this.state.selected;
         this.setState({selected: selected}, () => {
-          if (this.props.onCellSelected) {
+          if (typeof this.props.onCellDeSelected === 'function') {
             this.props.onCellDeSelected(oldSelection);
+          }
+          if (typeof this.props.onCellSelected === 'function') {
             this.props.onCellSelected(selected);
           }
         });


### PR DESCRIPTION
add props to enable firing events for when a cell is selected/deselected. This would be a step towards full keyboard navigation functionality support. It could be used to activate the cell editor for example without the need to trigger via a click or a key down on the cell.