### PR TITLE
implement cell selection/deselection events

### DIFF
--- a/examples/scripts/example21-cell-selection-events.js
+++ b/examples/scripts/example21-cell-selection-events.js
@@ -1,0 +1,94 @@
+var QuickStartDescription = require('../components/QuickStartDescription')
+var ReactPlayground       = require('../assets/js/ReactPlayground');
+
+
+var SimpleExample = `
+
+var SimpleCheckboxEditor = ReactDataGrid.Editors.SimpleCheckboxEditor;
+var SimpleCheckboxFormatter = ReactDataGrid.Editors.SimpleCheckboxFormatter;
+var _rows = [];
+for (var i = 1; i < 1000; i++) {
+  _rows.push({
+    id: i,
+    title: 'Title ' + i,
+    count: i * 1000,
+    active: i % 2
+  });
+}
+
+//A rowGetter function is required by the grid to retrieve a row for a given index
+var rowGetter = function(i){
+  return _rows[i];
+};
+
+
+var columns = [
+{
+  key: 'id',
+  name: 'ID'
+},
+{
+  key: 'title',
+  name: 'Title',
+  editable: true
+},
+{
+  key: 'count',
+  name: 'Count'
+}
+]
+
+var Example = React.createClass({
+
+  getInitialState: function() {
+    return {selectedRows: []}
+  },
+
+  onRowSelect: function(rows) {
+    this.setState({selectedRows: rows});
+  },
+  
+  onCellSelected(coordinates) {
+    this.refs.grid.openCellEditor(coordinates.rowIdx, coordinates.idx);
+  },
+  
+  onCellDeSelected(coordinates) {
+    if (coordinates.idx === 2) {
+      alert('the editor for cell (' + coordinates.rowIdx + ',' + coordinates.idx + ') should have just closed');
+    }
+  },
+  
+  render: function() {
+    var rowText = this.state.selectedRows.length === 1 ? 'row' : 'rows';
+    return  (<div>
+      <span>{this.state.selectedRows.length} {rowText} selected</span>
+      <ReactDataGrid ref="grid"
+    rowKey='id'
+    columns={columns}
+    rowGetter={rowGetter}
+    rowsCount={_rows.length}
+    enableRowSelect='multi'
+    minHeight={500}
+    onRowSelect={this.onRowSelect}
+    enableCellSelect={true}
+    onCellSelected={this.onCellSelected}
+    onCellDeSelected={this.onCellDeSelected} /></div>);
+  }
+});
+ReactDOM.render(<Example />, mountNode);
+`;
+
+module.exports = React.createClass({
+
+  render:function(){
+    return(
+      <div>
+        <h3>Cell selection/delesection events</h3>
+        <p>Define onCellSelected and onCellDeSelected callback handlers and pass them as props to enable events upon cell selection/deselection.</p>
+        <p>if passed, onCellSelected will be triggered each time a cell is selected with the cell coordinates. Similarly, onCellDeSelected will be triggered when a cell is deselected.</p>
+        <ReactPlayground codeText={SimpleExample} />
+      </div>
+    )
+  }
+
+});

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -343,7 +343,38 @@ describe('Grid', function() {
       });
     });
   });
+  describe('Cell Selection/DeSelection handlers', function() {
+    describe('when cell selection/deselection handlers are passed', function() {
+      beforeEach(function() {
+        const extraProps = { onCellSelected: this.noop, onCellDeSelected: this.noop };
+        spyOn(extraProps, 'onCellSelected');
+        spyOn(extraProps, 'onCellDeSelected');
+        this.component = this.createComponent(extraProps);
+      });
 
+      describe('cell is selected', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { rowIdx: 1, idx: 2 } });
+        });
+        it('deselection handler should have been called', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.props.onCellDeSelected).toHaveBeenCalled();
+          expect(this.component.props.onCellDeSelected.mostRecentCall.args[0]).toEqual({
+            rowIdx: 1,
+            idx: 2
+          });
+        });
+        it('selection handler should have been called', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.props.onCellSelected).toHaveBeenCalled();
+          expect(this.component.props.onCellSelected.mostRecentCall.args[0]).toEqual({
+            rowIdx: 1,
+            idx: 3
+          });
+        });
+      });
+    });
+  });
   describe('User Interaction', function() {
     it('hitting TAB should decrement selected cell index by 1', function() {
       this.simulateGridKeyDown('Tab');

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -68,7 +68,9 @@ const ReactDataGrid = React.createClass({
     rowScrollTimeout: React.PropTypes.number,
     onClearFilters: React.PropTypes.func,
     contextMenu: React.PropTypes.element,
-    cellNavigationMode: React.PropTypes.oneOf(['none', 'loopOverRow', 'changeRow'])
+    cellNavigationMode: React.PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
+    onCellSelected: React.PropTypes.func,
+    onCellDeSelected: React.PropTypes.func
   },
 
   getDefaultProps(): {enableCellSelect: boolean} {
@@ -136,7 +138,15 @@ const ReactDataGrid = React.createClass({
           && idx < ColumnUtils.getSize(this.state.columnMetrics.columns)
           && rowIdx < this.props.rowsCount
         ) {
-        this.setState({selected: selected});
+        const oldSelection = this.state.selected;
+        this.setState({selected: selected}, () => {
+          if (typeof this.props.onCellDeSelected === 'function') {
+            this.props.onCellDeSelected(oldSelection);
+          }
+          if (typeof this.props.onCellSelected === 'function') {
+            this.props.onCellSelected(selected);
+          }
+        });
       }
     }
   },
@@ -264,13 +274,13 @@ const ReactDataGrid = React.createClass({
   },
 
   onToggleFilter() {
-    // setState() does not immediately mutate this.state but creates a pending state transition. 
+    // setState() does not immediately mutate this.state but creates a pending state transition.
     // Therefore if you want to do something after the state change occurs, pass it in as a callback function.
-    this.setState({ canFilter: !this.state.canFilter }, () => {      
+    this.setState({ canFilter: !this.state.canFilter }, () => {
       if (this.state.canFilter === false && this.props.onClearFilters) {
         this.props.onClearFilters();
       }
-    });    
+    });
   },
 
   onDragHandleDoubleClick(e) {


### PR DESCRIPTION
add props to enable firing events for when a cell is selected/deselected. This would be a step towards full keyboard navigation functionality support. It could be used to activate the cell editor for example without the need to trigger via a click or a key down on the cell.