### PR TITLE
fix: cell navigation broken when row selection is enabled

### DIFF
--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -255,6 +255,15 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
         });
       });
+      describe('when row selection is enabled and positionned on cell before last in row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 2, rowIdx: 1 }, enableRowSelect: true });
+        });
+        it('selection should move to last cell', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
+        });
+      });
     });
 
     describe('when cell navigation is configured to change rows', function() {
@@ -298,6 +307,15 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 0 });
         });
       });
+      describe('when row selection is enabled and positionned on cell before last in row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 2, rowIdx: 1 }, enableRowSelect: true });
+        });
+        it('selection should move to last cell', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
+        });
+      });
     });
 
     describe('when cell navigation is configured to loop over cells in row', function() {
@@ -339,6 +357,15 @@ describe('Grid', function() {
         it('selection should move to last cell in same row', function() {
           this.simulateGridKeyDown('ArrowLeft');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 0 });
+        });
+      });
+      describe('when row selection enabled and positionned on cell before last in row', function() {
+        beforeEach(function() {
+          this.component.setState({ selected: { idx: 2, rowIdx: 1 }, enableRowSelect: true });
+        });
+        it('selection should move to last cell', function() {
+          this.simulateGridKeyDown('Tab');
+          expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
         });
       });
     });

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -512,11 +512,17 @@ const ReactDataGrid = React.createClass({
     this.onSelect({ idx: idx, rowIdx: rowIdx });
   },
 
+  getNbrColumns() {
+    const {columns, enableRowSelect} = this.props;
+    return enableRowSelect ? columns.length + 1 : columns.length;
+  },
+
   calculateNextSelectionPosition(cellNavigationMode: string, cellDelta: number, rowDelta: number) {
     let _rowDelta = rowDelta;
     let idx = this.state.selected.idx + cellDelta;
+    const nbrColumns = this.getNbrColumns();
     if (cellDelta > 0) {
-      if (this.isAtLastCellInRow()) {
+      if (this.isAtLastCellInRow(nbrColumns)) {
         if (cellNavigationMode === 'changeRow') {
           _rowDelta = this.isAtLastRow() ? rowDelta : rowDelta + 1;
           idx = this.isAtLastRow() ? idx : 0;
@@ -528,9 +534,9 @@ const ReactDataGrid = React.createClass({
       if (this.isAtFirstCellInRow()) {
         if (cellNavigationMode === 'changeRow') {
           _rowDelta = this.isAtFirstRow() ? rowDelta : rowDelta - 1;
-          idx = this.isAtFirstRow() ? 0 : this.props.columns.length - 1;
+          idx = this.isAtFirstRow() ? 0 : nbrColumns - 1;
         } else {
-          idx = this.props.columns.length - 1;
+          idx = nbrColumns - 1;
         }
       }
     }
@@ -538,8 +544,8 @@ const ReactDataGrid = React.createClass({
     return {idx, rowIdx};
   },
 
-  isAtLastCellInRow() {
-    return this.state.selected.idx === this.props.columns.length - 1;
+  isAtLastCellInRow(nbrColumns) {
+    return this.state.selected.idx === nbrColumns - 1;
   },
 
   isAtLastRow() {


### PR DESCRIPTION
This is to fix a bug with the cell navigation. When row selection is enabled, a new column -the row selection checkbox- is added to the columns list and we end up with `props.columns.length` not returning the correct number of columns.