### PR TITLE
Update cell class

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -41,7 +41,9 @@ const Cell = React.createClass({
 
   getInitialState() {
     return {
-      isCellValueChanging: false
+      isCellValueChanging: false,
+      oldRowData: {},
+      newRowData: {}
     };
   },
 
@@ -51,7 +53,9 @@ const Cell = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      isCellValueChanging: this.props.value !== nextProps.value
+      isCellValueChanging: this.props.value !== nextProps.value,
+      oldRowData: this.props.rowData,
+      newRowData: nextProps.rowData
     });
   },
 
@@ -164,7 +168,7 @@ const Cell = React.createClass({
 
   getUpdateCellClass() {
     return this.props.column.getUpdateCellClass
-      ? this.props.column.getUpdateCellClass(this.props.selectedColumn, this.props.column, this.state.isCellValueChanging)
+      ? this.props.column.getUpdateCellClass(this.props.selectedColumn, this.props.column, this.state.isCellValueChanging, this.state.oldRowData, this.state.newRowData)
       : '';
   },
 

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -40,7 +40,9 @@ const Cell = React.createClass({
   },
 
   getInitialState() {
-    return {isRowChanging: false, isCellValueChanging: false};
+    return {
+      isCellValueChanging: false
+    };
   },
 
   componentDidMount: function() {
@@ -48,7 +50,9 @@ const Cell = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    this.setState({isRowChanging: this.props.rowData !== nextProps.rowData, isCellValueChanging: this.props.value !== nextProps.value});
+    this.setState({
+      isCellValueChanging: this.props.value !== nextProps.value
+    });
   },
 
   componentDidUpdate: function() {
@@ -57,7 +61,7 @@ const Cell = React.createClass({
     if (dragged && dragged.complete === true) {
       this.props.cellMetaData.handleTerminateDrag();
     }
-    if (this.state.isRowChanging && this.props.selectedColumn != null) {
+    if (this.state.isCellValueChanging && this.props.selectedColumn != null) {
       this.applyUpdateClass();
     }
   },
@@ -65,7 +69,6 @@ const Cell = React.createClass({
   shouldComponentUpdate(nextProps: any): boolean {
     return this.props.column.width !== nextProps.column.width
     || this.props.column.left !== nextProps.column.left
-    || this.props.rowData !== nextProps.rowData
     || this.props.height !== nextProps.height
     || this.props.rowIdx !== nextProps.rowIdx
     || this.isCellSelectionChanging(nextProps)
@@ -160,7 +163,9 @@ const Cell = React.createClass({
   },
 
   getUpdateCellClass() {
-    return this.props.column.getUpdateCellClass ? this.props.column.getUpdateCellClass(this.props.selectedColumn, this.props.column, this.state.isCellValueChanging) : '';
+    return this.props.column.getUpdateCellClass
+      ? this.props.column.getUpdateCellClass(this.props.selectedColumn, this.props.column, this.state.isCellValueChanging)
+      : '';
   },
 
   isColumnSelected() {

--- a/src/__tests__/Cell.spec.js
+++ b/src/__tests__/Cell.spec.js
@@ -108,7 +108,8 @@ describe('Cell Tests', () => {
       testProps.column.getUpdateCellClass = () => updateClass;
       let cellInstance = TestUtils.renderIntoDocument(<Cell {...testProps}/>);
       // force update
-      cellInstance.setProps({rowData: {}, selectedColumn: testProps.column});
+      let newValue = 'London';
+      cellInstance.setProps({value: newValue, selectedColumn: testProps.column});
       let cellHasUpdateClass = ReactDOM.findDOMNode(cellInstance).getAttribute('class').indexOf(updateClass) > -1;
       expect(cellHasUpdateClass).toBe(true);
     });


### PR DESCRIPTION
- [x] `isRowChanging` is obsolete since we can use `isCellValueChanging`
- [x] Old and new row data can be used to compare changes in own implementations of `getUpdateCellClass`