### PR TITLE
Select cell if a datagrid becomes selectable.

### DIFF
--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -73,6 +73,16 @@ const ReactDataGrid = React.createClass({
     onCellDeSelected: React.PropTypes.func
   },
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.enableCellSelect === true &&
+      this.state.selected.rowIdx === -1 &&
+      this.state.selected.idx === -1) {
+      this.setState({
+        selected: {rowIdx: 0, idx: 0}
+      });
+    }
+  },
+
   getDefaultProps(): {enableCellSelect: boolean} {
     return {
       enableCellSelect: false,


### PR DESCRIPTION
Selected index -1,-1 is established on original component initialization if enableCellSelect is false and 0,0 otherwise. If subsequently cell select is enabled the selected index remains -1, -1.  By instead capturing the newly received props and selecting cell 0,0 the user experience improves as it is more obvious that cell select is enabled.
