### PR TITLE
Change react-contextmenu to v1.5.0 to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es5-shim": "^4.0.3",
     "fbjs": "^0.6.1",
     "object-assign": "^2.0.0",
-    "react-contextmenu": "^1.4.0",
+    "react-contextmenu": "1.5.0",
     "ron-react-autocomplete": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use react-contextmenu v1.5.0 until [this issue](https://github.com/vkbansal/react-contextmenu/issues/20) is fixed