### PR TITLE
Update react-contextmenu to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es5-shim": "^4.0.3",
     "fbjs": "^0.6.1",
     "object-assign": "^2.0.0",
-    "react-contextmenu": "1.5.0",
+    "react-contextmenu": "^1.5.0",
     "ron-react-autocomplete": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Revert back to latest (minor) version after [failing tests](https://github.com/vkbansal/react-contextmenu/issues/20) were fixed in v1.6.2