### PR TITLE
Fixed rows container plugins related bug

### DIFF
--- a/src/RowsContainer.js
+++ b/src/RowsContainer.js
@@ -14,20 +14,22 @@ SimpleRowsContainer.propTypes = {
 };
 
 class RowsContainer extends React.Component {
-
-  constructor() {
-    super();
-    this.state = {ContextMenuContainer: this.getContextMenuContainer()};
+  constructor(props) {
+    super(props);
+    this.plugins = props.window ? props.window.ReactDataGridPlugins : window.ReactDataGridPlugins;
     this.hasContextMenu = this.hasContextMenu.bind(this);
     this.renderRowsWithContextMenu = this.renderRowsWithContextMenu.bind(this);
     this.getContextMenuContainer = this.getContextMenuContainer.bind(this);
+    this.state = {ContextMenuContainer: this.getContextMenuContainer(props)};
   }
 
   getContextMenuContainer() {
-    if (!window.ReactDataGridPlugins) {
-      throw new Error('You need to include ReactDataGrid UiPlugins in order to initialise context menu');
+    if (this.hasContextMenu()) {
+      if (!this.plugins) {
+        throw new Error('You need to include ReactDataGrid UiPlugins in order to initialise context menu');
+      }
+      return this.plugins.Menu.ContextMenuLayer('reactDataGridContextMenu')(SimpleRowsContainer);
     }
-    return window.ReactDataGridPlugins.Menu.ContextMenuLayer('reactDataGridContextMenu')(SimpleRowsContainer);
   }
 
   hasContextMenu() {
@@ -50,7 +52,8 @@ class RowsContainer extends React.Component {
 RowsContainer.propTypes = {
   contextMenu: PropTypes.element,
   rowIdx: PropTypes.number,
-  idx: PropTypes.number
+  idx: PropTypes.number,
+  window: PropTypes.object
 };
 
 export default RowsContainer;

--- a/src/__tests__/RowsContainer.spec.js
+++ b/src/__tests__/RowsContainer.spec.js
@@ -11,7 +11,7 @@ describe('Rows Container', () => {
     let componentWithoutContextMenu = {};
 
     beforeEach(() => {
-      componentWithoutContextMenu = ReactTestUtils.renderIntoDocument(<RowsContainer />);
+      componentWithoutContextMenu = ReactTestUtils.renderIntoDocument(<RowsContainer window={{ ReactDataGridPlugins: undefined }} />);
     });
 
     it('should create a new RowsContainer instance', () => {


### PR DESCRIPTION
<h3>Bug description</h3>
`getContextMenuContainer` was running either if the container was using `react data grid plugins` or not, obviously a error was thrown in [RowsContainer Component constructor](https://github.com/adazzle/react-data-grid/blob/master/src/RowsContainer.js#L20) when the plugins were not in use and not accessible in the window. that is wrong.