### PR TITLE
Fixed #321 Warning: Row: `key` is not a prop 

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -16,7 +16,6 @@ const Row = React.createClass({
     cellMetaData: PropTypes.shape(cellMetaDataShape),
     isSelected: PropTypes.bool,
     idx: PropTypes.number.isRequired,
-    key: PropTypes.string,
     expandedRows: PropTypes.arrayOf(PropTypes.object),
     extraClasses: PropTypes.string,
     forceUpdate: PropTypes.bool
@@ -94,8 +93,8 @@ const Row = React.createClass({
 
   getRowHeight(): number {
     let rows = this.props.expandedRows || null;
-    if (rows && this.props.key) {
-      let row = rows[this.props.key] || null;
+    if (rows && this.props.idx) {
+      let row = rows[this.props.idx] || null;
       if (row) {
         return row.height;
       }


### PR DESCRIPTION
#321 

I used “this.props.idx” instead of “this.prop.key“ because both have the same value.
https://github.com/adazzle/react-data-grid/blob/90f5477921f667fe7177facfa55822a53dcab3ba/src/Canvas.js#L249-L251