### PR TITLE
Link Label to Checkbox for select-all

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -630,7 +630,7 @@ const ReactDataGrid = React.createClass({
     if (props.enableRowSelect) {
       let headerRenderer = props.enableRowSelect === 'single' ? null :
       <div className="react-grid-checkbox-container">
-        <input className="react-grid-checkbox" type="checkbox" name="select-all-checkbox" onChange={this.handleCheckboxChange} />
+        <input className="react-grid-checkbox" type="checkbox" name="select-all-checkbox" id="select-all-checkbox" onChange={this.handleCheckboxChange} />
         <label htmlFor="select-all-checkbox" className="react-grid-checkbox-label"></label>
       </div>;
       let selectColumn = {

--- a/themes/react-data-grid.css
+++ b/themes/react-data-grid.css
@@ -176,10 +176,6 @@ textareaselect.editor-main {
   height: auto;
 }
 
-.react-grid-checkbox-container {
-    cursor: pointer;
-}
-
 .react-grid-checkbox, .radio-custom {
     opacity: 0;
     position: absolute;


### PR DESCRIPTION
## Description
A user was unable to select-all by clicking the outer area of the checkbox, only by clicking the centre.  Adding an id to the checkbox links the Label allowing the full checkbox to be clickable.

Remove unused pointer that gave a false impression as to what was clickable.

This patch makes no attempt to resolve the interface for single line checkboxes which seems to suffer from the reverse problem (whereby a larger are is clickable than perhaps should be).

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

A user cannot select-all when clicking the outer areas of the checkbox, only the middle.

**What is the new behavior?**

The user can now click anywhere on the checkbox in order to select-all.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

