### PR TITLE
Only load in groupBy lodash function, not the whole library

### DIFF
--- a/src/addons/data/RowGrouper.js
+++ b/src/addons/data/RowGrouper.js
@@ -1,4 +1,4 @@
-import {groupBy} from 'lodash';
+import groupBy from 'lodash/groupby';
 import { createSelector } from 'reselect';
 const getInputRows = (state) => state.rows;
 const getGroupedColumns = (state) => state.groupedColumns;


### PR DESCRIPTION
## Description
Previously the whole lodash library was imported into the distribution code

have changed

`import {groupBy} from 'lodash`

to 
`import groupBy from 'lodash/groupby';`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md



**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The whole lodash library is imported into the ReactDataGrid.ui.plugins library is imported


**What is the new behavior?**
Only the groupBy function is imported into the distribution file


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

