### PR TITLE
NODE_ENV now changes on release config

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -5,6 +5,19 @@ var path = require("path");
 var argv = require('minimist')(process.argv.slice(2));
 var RELEASE = argv.release;
 
+function getPlugins() {
+  var nodeEnv = RELEASE ? '"production"' : '"development"';
+  var pluginsBase =  [
+    new webpack.DefinePlugin({'process.env.NODE_ENV': nodeEnv, 'global': 'window'})
+  ];
+
+  if (RELEASE) {
+    pluginsBase.push(new webpack.optimize.DedupePlugin());
+    pluginsBase.push(new webpack.optimize.OccurenceOrderPlugin());
+    pluginsBase.push(new webpack.optimize.AggressiveMergingPlugin());
+  }
+  return pluginsBase;
+};
 
 var config = {
   externals: {
@@ -25,15 +38,9 @@ var config = {
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"}
-      
     ]
   },
-  plugins: [
-      new webpack.optimize.DedupePlugin(),
-      new webpack.optimize.OccurenceOrderPlugin(),
-      new webpack.optimize.AggressiveMergingPlugin(),
-      new webpack.DefinePlugin({'global': 'window'})
-    ],
+  plugins: getPlugins(),
   postLoaders: [
   {
     test: /\.js$/,


### PR DESCRIPTION
## Description
This PR fixes https://github.com/adazzle/react-data-grid/issues/341, (NODE_ENV not replaced in minified version).

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
NODE_ENV is not being set, that means that it ends up always being dev.

**What is the new behaviour?**
NODE_ENV no is set depending on the environment .

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```