### PR TITLE
on select row, add handler to capture row index

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -64,6 +64,7 @@ const ReactDataGrid = React.createClass({
     onDragHandleDoubleClick: React.PropTypes.func,
     onGridRowsUpdated: React.PropTypes.func,
     onRowSelect: React.PropTypes.func,
+    onRowSelectIdx: React.PropTypes.func,
     rowKey: React.PropTypes.string,
     rowScrollTimeout: React.PropTypes.number,
     onClearFilters: React.PropTypes.func,
@@ -446,6 +447,9 @@ const ReactDataGrid = React.createClass({
     this.setState({selectedRows: selectedRows, selected: {rowIdx: rowIdx, idx: 0}});
     if (this.props.onRowSelect) {
       this.props.onRowSelect(selectedRows.filter(r => r.isSelected === true));
+    }
+    if (this.props.onRowSelectIdx) {
+      this.props.onRowSelectIdx(rowIdx);
     }
   },
 


### PR DESCRIPTION
## Description
On Select a Row, the entire Row is returned.  Sometimes you just want the index of the selected Row.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
You can capture a selected Row, but not the Index of the selected Row.


**What is the new behavior?**
You can capture the index of a selected Row with:

onRowSelectIdx={this.handleRowSelectIdx}


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

