### PR TITLE
Add Ids of updated rows to data passed to OnGridRowsUpdated call back

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -332,7 +332,8 @@ const ReactDataGrid = React.createClass({
     }
 
     if (this.props.onGridRowsUpdated) {
-      this.onGridRowsUpdated(this.getColumn(e.idx).key, e.rowIdx, this.props.rowsCount - 1, {[cellKey]: e.rowData[cellKey]}, 'columnFill');
+      let cellKey = this.getColumn(e.idx).key;
+      this.onGridRowsUpdated(cellKey, e.rowIdx, this.props.rowsCount - 1, {[cellKey]: e.rowData[cellKey]}, 'columnFill');
     }
   },
 

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -270,6 +270,16 @@ const ReactDataGrid = React.createClass({
     }
   },
 
+  onGridRowsUpdated(cellKey, fromRow, toRow, updated, action) {
+    let rowIds = [];
+
+    for (let i = fromRow; i <= toRow; i++) {
+      rowIds.push(this.props.rowGetter(i)[this.props.rowKey]);
+    }
+
+    this.props.onGridRowsUpdated({cellKey, fromRow, toRow, rowIds, updated, action});
+  },
+
   onCellCommit(commit: RowUpdateEvent) {
     let selected = Object.assign({}, this.state.selected);
     selected.active = false;
@@ -289,12 +299,7 @@ const ReactDataGrid = React.createClass({
     let targetRow = commit.rowIdx;
 
     if (this.props.onGridRowsUpdated) {
-      this.props.onGridRowsUpdated({
-        cellKey: commit.cellKey,
-        fromRow: targetRow,
-        toRow: targetRow,
-        updated: commit.updated,
-        action: 'cellUpdate'});
+      this.onGridRowsUpdated(commit.cellKey, targetRow, targetRow, commit.updated, 'cellUpdate');
     }
   },
 
@@ -327,18 +332,7 @@ const ReactDataGrid = React.createClass({
     }
 
     if (this.props.onGridRowsUpdated) {
-      let cellKey = this.getColumn(e.idx).key;
-
-      let updated = {
-        [cellKey]: e.rowData[cellKey]
-      };
-
-      this.props.onGridRowsUpdated({
-        cellKey: cellKey,
-        fromRow: e.rowIdx,
-        toRow: this.props.rowsCount - 1,
-        updated: updated,
-        action: 'columnFill'});
+      this.onGridRowsUpdated(this.getColumn(e.idx).key, e.rowIdx, this.props.rowsCount - 1, {[cellKey]: e.rowData[cellKey]}, 'columnFill');
     }
   },
 
@@ -380,18 +374,11 @@ const ReactDataGrid = React.createClass({
     if (this.props.onCellsDragged) {
       this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
     }
-    if (this.props.onGridRowsUpdated) {
-      let updated = {
-        [cellKey]: dragged.value
-      };
 
-      this.props.onGridRowsUpdated({
-        cellKey: cellKey,
-        fromRow: fromRow,
-        toRow: toRow,
-        updated: updated,
-        action: 'cellDrag'});
+    if (this.props.onGridRowsUpdated) {
+      this.onGridRowsUpdated(cellKey, fromRow, toRow, {[cellKey]: dragged.value}, 'cellDrag');
     }
+
     this.setState({dragged: {complete: true}});
   },
 
@@ -419,16 +406,7 @@ const ReactDataGrid = React.createClass({
     }
 
     if (this.props.onGridRowsUpdated) {
-      let updated = {
-        [cellKey]: textToCopy
-      };
-
-      this.props.onGridRowsUpdated({
-        cellKey: cellKey,
-        fromRow: toRow,
-        toRow: toRow,
-        updated: updated,
-        action: 'copyPaste'});
+      this.onGridRowsUpdated(cellKey, toRow, toRow, {[cellKey]: textToCopy}, 'copyPaste');
     }
 
     this.setState({copied: null});


### PR DESCRIPTION
## Description
Required to have a context of which rows were changed by their primary keys rather than just there position in the data. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When performing an update on the react data grid the onGridRowsUpdate call back function is called with the cellKey, fromRow index, toRow index, updated object and the action. 


**What is the new behavior?**
Same behaviour, however an additional property rowIds has been added to provide a list of ids for the updated rows.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

