### PR TITLE
Make editor completely visible when cell is near the boundary of the grid

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -741,30 +741,30 @@ const ReactDataGrid = React.createClass({
     let canvas = ReactDOM.findDOMNode(this).querySelector('.react-grid-Canvas');
     if (canvas) {
       let left = 0;
+      let locked = 0;
+
       for (let i = 0; i < colIdx; i++) {
-        let column = this.props.columns[i];
-        if (column && column.width) {
-          left += column.width;
+        let column = this.getColumn(i);
+        if (column) {
+          if (column.width) {
+            left += column.width;
+          }
+          if (column.locked) {
+            locked += column.width;
+          }
         }
       }
 
-      let selectedColumn = this.props.columns[colIdx];
+      let selectedColumn = this.getColumn(colIdx);
       if (selectedColumn) {
-        let padding = selectedColumn.width / 2;
-        let currentScroll = canvas.scrollLeft;
-        let canvasWidth = canvas.clientWidth;
-        let center =  canvasWidth / 2.0;
-        let scrollLeft = left - center;
-        let actualScrollToCenter = scrollLeft - currentScroll;
+        let scrollLeft = left - locked - canvas.scrollLeft;
+        let scrollRight =  left + selectedColumn.width - canvas.scrollLeft;
 
-        if (actualScrollToCenter > 0) {
-          actualScrollToCenter = actualScrollToCenter + padding;
-        } else if (actualScrollToCenter < 0) {
-          actualScrollToCenter = actualScrollToCenter - padding;
-        }
-
-        if (Math.abs(actualScrollToCenter) > center) {
-          canvas.scrollLeft = scrollLeft;
+        if (scrollLeft < 0) {
+          canvas.scrollLeft += scrollLeft;
+        } else if (scrollRight > canvas.clientWidth) {
+          let scrollAmount =  scrollRight - canvas.clientWidth;
+          canvas.scrollLeft += scrollAmount;
         }
       }
     }

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -737,6 +737,39 @@ const ReactDataGrid = React.createClass({
     }
   },
 
+  scrollToColumn(colIdx) {
+    let canvas = ReactDOM.findDOMNode(this).querySelector('.react-grid-Canvas');
+    if (canvas) {
+      let left = 0;
+      for (let i = 0; i < colIdx; i++) {
+        let column = this.props.columns[i];
+        if (column && column.width) {
+          left += column.width;
+        }
+      }
+
+      let selectedColumn = this.props.columns[colIdx];
+      if (selectedColumn) {
+        let padding = selectedColumn.width / 2;
+        let currentScroll = canvas.scrollLeft;
+        let canvasWidth = canvas.clientWidth;
+        let center =  canvasWidth / 2.0;
+        let scrollLeft = left - center;
+        let actualScrollToCenter = scrollLeft - currentScroll;
+
+        if (actualScrollToCenter > 0) {
+          actualScrollToCenter = actualScrollToCenter + padding;
+        } else if (actualScrollToCenter < 0) {
+          actualScrollToCenter = actualScrollToCenter - padding;
+        }
+
+        if (Math.abs(actualScrollToCenter) > center) {
+          canvas.scrollLeft = scrollLeft;
+        }
+      }
+    }
+  },
+
   setActive(keyPressed: string) {
     let rowIdx = this.state.selected.rowIdx;
     let row = this.props.rowGetter(rowIdx);
@@ -746,7 +779,7 @@ const ReactDataGrid = React.createClass({
 
     if (ColumnUtils.canEdit(col, row, this.props.enableCellSelect) && !this.isActive()) {
       let selected = Object.assign(this.state.selected, {idx: idx, rowIdx: rowIdx, active: true, initialKeyCode: keyPressed});
-      this.setState({selected: selected});
+      this.setState({selected: selected}, this.scrollToColumn(idx));
     }
   },
 


### PR DESCRIPTION
## Description
This will center the cell/editor to the grid when the cell is set to active.

https://www.opentest.co/share/b60c5e5057e511e6b8b30155fac93b1a

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When a user attempts to open an editor for a cell near the edge/boundary of the grid... when the editor appears it will often appear to be cut off.

**What is the new behavior?**

The cell will centre on the grid and open the editor so it will be fully visible.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

