### PR TITLE
fix AutoCompleteEditor

### DIFF
--- a/src/KeyboardHandlerMixin.js
+++ b/src/KeyboardHandlerMixin.js
@@ -1,7 +1,4 @@
 let KeyboardHandlerMixin = {
-  getInitialState() {
-    return {keysDown: {}};
-  },
   onKeyDown(e: SyntheticKeyboardEvent) {
     if (this.isCtrlKeyHeldDown(e)) {
       this.checkAndCall('onPressKeyWithCtrl', e);
@@ -15,9 +12,8 @@ let KeyboardHandlerMixin = {
     }
 
     // Track which keys are currently down for shift clicking etc
-    let keysDown = this.state.keysDown || {};
-    keysDown[e.keyCode] = true;
-    this.setState({keysDown});
+    this._keysDown = this._keysDown || {};
+    this._keysDown[e.keyCode] = true;
 
     if (this.props.onGridKeyDown && typeof this.props.onGridKeyDown === 'function') {
       this.props.onGridKeyDown(e);
@@ -26,22 +22,21 @@ let KeyboardHandlerMixin = {
 
   onKeyUp(e) {
     // Track which keys are currently down for shift clicking etc
-    let keysDown = this.state.keysDown || {};
-    delete keysDown[e.keyCode];
-    this.setState({keysDown});
+    this._keysDown = this._keysDown || {};
+    delete this._keysDown[e.keyCode];
 
     if (this.props.onGridKeyUp && typeof this.props.onGridKeyUp === 'function') {
       this.props.onGridKeyUp(e);
     }
   },
   isKeyDown(keyCode) {
-    if (!this.state.keysDown) return false;
-    return keyCode in this.state.keysDown;
+    if (!this._keysDown) return false;
+    return keyCode in this._keysDown;
   },
 
   isSingleKeyDown(keyCode) {
-    if (!this.state.keysDown) return false;
-    return keyCode in this.state.keysDown && Object.keys(this.state.keysDown).length === 1;
+    if (!this._keysDown) return false;
+    return keyCode in this._keysDown && Object.keys(this._keysDown).length === 1;
   },
 
   // taken from http://stackoverflow.com/questions/12467240/determine-if-javascript-e-keycode-is-a-printable-non-control-character

--- a/src/__tests__/KeyboardHandlerMixin.spec.js
+++ b/src/__tests__/KeyboardHandlerMixin.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import KeyboardHandlerMixin from '../KeyboardHandlerMixin';
+
+
+let TestComponent = React.createClass({
+  mixins: [KeyboardHandlerMixin],
+  render: function() {
+    return (
+      <div tabIndex="0" onKeyDown={this.onKeyDown} onKeyUp={this.onKeyUp} />
+    );
+  }
+});
+
+describe('KeyboardHandlerMixin', () => {
+  it('renders', () => {
+    let component = TestUtils.renderIntoDocument(<TestComponent/>);
+    expect(component).toBeDefined();
+  });
+
+  it('registers keyDown events', () => {
+    let component = TestUtils.renderIntoDocument(<TestComponent/>);
+    const node = ReactDOM.findDOMNode(component);
+    TestUtils.Simulate.keyDown(node, {key: 'Enter', keyCode: 13, which: 13});
+
+    expect(component.isKeyDown(13)).toBeTruthy();
+  });
+
+  it('registers keyUp events', () => {
+    let component = TestUtils.renderIntoDocument(<TestComponent/>);
+    const node = ReactDOM.findDOMNode(component);
+    TestUtils.Simulate.keyDown(node, {key: 'Enter', keyCode: 13, which: 13});
+    TestUtils.Simulate.keyUp(node, {key: 'Enter', keyCode: 13, which: 13});
+
+    expect(component.isKeyDown(13)).toBeFalsy();
+  });
+});

--- a/src/addons/__tests__/data/MockStateObject.js
+++ b/src/addons/__tests__/data/MockStateObject.js
@@ -41,7 +41,6 @@ module.exports = function(stateValues, events) {
     sortColumn: null,
     dragged: null,
     scrollOffset: 0,
-    keysDown: {},
     lastRowIdxUiSelected: -1
   }, stateValues);
 };

--- a/src/addons/editors/__tests__/AutoCompleteEditor.spec.js
+++ b/src/addons/editors/__tests__/AutoCompleteEditor.spec.js
@@ -105,4 +105,30 @@ describe('AutoCompleteEditor', () => {
       });
     });
   });
+
+  describe('interactions', () => {
+    it('should render', () => {
+      component = TestUtils.renderIntoDocument(<AutoCompleteEditor
+      onCommit={fakeCb}
+      options={fakeOptions}
+      label="title"
+      value="value"
+      valueParams={fakeParams}
+      column={fakeColumn}
+      resultIdentifier="id"
+      search={() => true}
+      height={30}
+      onKeyDown={fakeCb}/>);
+
+      expect(component).toBeDefined();
+
+      // type a key!
+      let node = component.getInputNode();
+      node.value = 'a';
+      TestUtils.Simulate.change(node);
+      TestUtils.Simulate.keyDown(node, {key: 'Enter', keyCode: 13, which: 13});
+
+      expect(component.getValue()).toEqual({autocomplete: 'a'});
+    });
+  });
 });


### PR DESCRIPTION
## Description
Changes made to KeyboardHandlerMixin for rowSelection enhancement broke the AutoCompleteEditor.  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
AutoCompleteEditor can't be typed in.


**What is the new behavior?**
AutoCompleteEditor works correctly.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

