### PR TITLE
Fix width of the Cell to solve custom formatter issue

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -444,7 +444,7 @@ const Cell = React.createClass({
       cellExpander = (<span style={{float: 'left', marginLeft: marginLeft}} onClick={this.onCellExpand} >{this.props.expandableOptions.expanded ? String.fromCharCode('9660') : String.fromCharCode('9658')}</span>);
     }
     return (<div  ref="cell"
-      className="react-grid-Cell__value">{cellExpander}<span style={{float: 'left', marginLeft: marginLeftCell}}>{CellContent}</span> {this.props.cellControls} </div>);
+      className="react-grid-Cell__value">{cellExpander}<span style={{float: 'left', marginLeft: marginLeftCell, width: '100%'}}>{CellContent}</span> {this.props.cellControls} </div>);
   },
 
   render() {


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
In custom formatter example we can see the cell width as auto, making the "value" with wrong visual.

**What is the new behavior?**
Now the width is 100% of the space, so the formatter is correct.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```