### PR TITLE
Custom editors can be components (#403)

### DIFF
--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -62,10 +62,13 @@ const EditorContainer = React.createClass({
       onOverrideKeyDown: this.onKeyDown
     };
 
-    let customEditor = this.props.column.editor;
-    if (customEditor && React.isValidElement(customEditor)) {
-      // return custom column editor or SimpleEditor if none specified
-      return React.cloneElement(customEditor, editorProps);
+    let CustomEditor = this.props.column.editor;
+    // return custom column editor or SimpleEditor if none specified
+    if (React.isValidElement(CustomEditor)) {
+      return React.cloneElement(CustomEditor, editorProps);
+    }
+    if (isFunction(CustomEditor)) {
+      return <CustomEditor ref={editorRef} {...editorProps} />
     }
 
     return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -68,7 +68,7 @@ const EditorContainer = React.createClass({
       return React.cloneElement(CustomEditor, editorProps);
     }
     if (isFunction(CustomEditor)) {
-      return <CustomEditor ref={editorRef} {...editorProps} />
+      return <CustomEditor ref={editorRef} {...editorProps} />;
     }
 
     return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -1,9 +1,11 @@
 
 const React            = require('react');
+const ReactDOM         = require('react-dom');
 const rewire           = require('rewire');
 const EditorContainer  = rewire('../EditorContainer.js');
 const TestUtils        = require('react/lib/ReactTestUtils');
 const SimpleTextEditor = require('../SimpleTextEditor');
+const EditorBase       = require('../EditorBase');
 
 describe('Editor Container Tests', () => {
   let cellMetaData = {
@@ -65,6 +67,58 @@ describe('Editor Container Tests', () => {
       let editor = TestUtils.findRenderedComponentWithType(component, SimpleTextEditor);
       expect(editor.props.value).toEqual('Adwolf');
       expect(editor.props.column).toEqual(fakeColumn);
+    });
+  });
+
+  describe('Custom Editors', () => {
+
+    class TestEditor extends EditorBase {
+      getInputNode() {
+        return ReactDOM.findDOMNode(this);
+      }
+      render() {
+        return <input ref="node" type="text" id="testpassed" />;
+      }
+      hasResults() {
+        return true;
+      }
+    }
+
+    let column;
+    beforeEach(() => {
+      column = {
+        key: 'col1',
+        name: 'col1',
+        width: 100
+      };
+    });
+
+    it('should render element custom editors', () => {
+      column.editor = <TestEditor />;
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={cellMetaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      expect(editor).toBeDefined();
+      expect(editor.props.value).toBeDefined();
+      expect(editor.props.onCommit).toBeDefined();
+    });
+
+    it('should render component custom editors', () => {
+      column.editor = TestEditor;
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={cellMetaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      expect(editor).toBeDefined();
+      expect(editor.props.value).toBeDefined();
+      expect(editor.props.onCommit).toBeDefined();
     });
   });
 

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -1,6 +1,5 @@
 
 const React            = require('react');
-const ReactDOM         = require('react-dom');
 const rewire           = require('rewire');
 const EditorContainer  = rewire('../EditorContainer.js');
 const TestUtils        = require('react/lib/ReactTestUtils');
@@ -71,16 +70,9 @@ describe('Editor Container Tests', () => {
   });
 
   describe('Custom Editors', () => {
-
     class TestEditor extends EditorBase {
-      getInputNode() {
-        return ReactDOM.findDOMNode(this);
-      }
       render() {
-        return <input ref="node" type="text" id="testpassed" />;
-      }
-      hasResults() {
-        return true;
+        return <input type="text" id="testpassed" />;
       }
     }
 


### PR DESCRIPTION
## Description
Custom editors can now be react components as well as pre-rendered react elements.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
[If your editor is a component, it will be silently ignored.](https://github.com/adazzle/react-data-grid/issues/403)


**What is the new behavior?**
Components and editors both work.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

