### PR TITLE
Dropdown text

### DIFF
--- a/examples/scripts/example06-built-in-editors.js
+++ b/examples/scripts/example06-built-in-editors.js
@@ -17,7 +17,10 @@ var issueTypes = [
   { id: 'story', value: 'story', text: 'Story', title: 'Story' }
 ];
 var DropDownEditor = ReactDataGridPlugins.Editors.DropDownEditor;
-var IssueTypesEditor = <DropDownEditor options={issueTypes}/>
+var IssueTypesEditor = <DropDownEditor options={issueTypes}/>;
+
+var DropDownFormatter = ReactDataGridPlugins.Formatters.DropDownFormatter;
+var IssueTypesFormatter = <DropDownFormatter options={issueTypes}/>;
 
 //helper to generate a random date
 function randomDate(start, end) {
@@ -66,7 +69,8 @@ var columns = [
 {
   key : 'issueType',
   name : 'Issue Type',
-  editor : IssueTypesEditor
+  editor : IssueTypesEditor,
+  formatter: IssueTypesFormatter
 }
 ]
 

--- a/examples/scripts/example06-built-in-editors.js
+++ b/examples/scripts/example06-built-in-editors.js
@@ -9,7 +9,13 @@ var AutoCompleteEditor = ReactDataGridPlugins.Editors.AutoComplete;
 var PrioritiesEditor = <AutoCompleteEditor options={priorities}/>
 
 //options for IssueType dropdown editor
-var issueTypes = ['Bug', 'Improvement', 'Epic', 'Story'];
+//these can either be an array of strings, or an object that matches the schema below.
+var issueTypes = [
+  { id: 'bug', value: 'bug', text: 'Bug', title: 'Bug' },
+  { id: 'improvement', value: 'improvement', text: 'Improvement', title: 'Improvement' },
+  { id: 'epic', value: 'epic', text: 'Epic', title: 'Epic' },
+  { id: 'story', value: 'story', text: 'Story', title: 'Story' }
+];
 var DropDownEditor = ReactDataGridPlugins.Editors.DropDownEditor;
 var IssueTypesEditor = <DropDownEditor options={issueTypes}/>
 
@@ -27,7 +33,7 @@ function createRows(numberOfRows){
       task: 'Task ' + i,
       complete: Math.min(100, Math.round(Math.random() * 110)),
       priority : ['Critical', 'High', 'Medium', 'Low'][Math.floor((Math.random() * 3) + 1)],
-      issueType : issueTypes[Math.floor((Math.random() * 3) + 1)],
+      issueType : issueTypes[Math.floor((Math.random() * 3) + 1)].value,
       startDate: randomDate(new Date(2015, 3, 1), new Date()),
       completeDate: randomDate(new Date(), new Date(2016, 0, 1))
     });

--- a/src/addons/editors/DropDownEditor.js
+++ b/src/addons/editors/DropDownEditor.js
@@ -29,7 +29,7 @@ class DropDownEditor extends EditorBase {
       if (typeof(name) === 'string') {
         options.push(<option key={name} value={name}>{name}</option>);
       } else {
-        options.push(<option key={name.id} value={name.value} title={name.title}  >{name.value}</option>);
+        options.push(<option key={name.id} value={name.value} title={name.title}  >{name.text || name.value}</option>);
       }
     }, this);
     return options;
@@ -39,7 +39,12 @@ class DropDownEditor extends EditorBase {
 DropDownEditor.propTypes = {
   options: React.PropTypes.arrayOf(React.PropTypes.oneOfType([
     React.PropTypes.string,
-    React.PropTypes.objectOf({ id: React.PropTypes.string, title: React.PropTypes.string, meta: React.PropTypes.string })
+    React.PropTypes.objectOf({
+      id: React.PropTypes.string,
+      title: React.PropTypes.string,
+      value: React.PropTypes.string,
+      text: React.PropTypes.string
+    })
   ])).isRequired
 };
 

--- a/src/addons/editors/__tests__/DropDownEditor.spec.js
+++ b/src/addons/editors/__tests__/DropDownEditor.spec.js
@@ -60,7 +60,7 @@ describe('DropDownEditor', () => {
     let fakeOptions = [
       { id: '1', value: 'option1', title: 'Option 1' },
       { id: '2', value: 'option2', text: 'Option Two' },
-      { id: '3', value: 'option3', title: 'Option 3', text: 'Option Three' },
+      { id: '3', value: 'option3', title: 'Option 3', text: 'Option Three' }
     ];
     let fakeColumn = { key: 'selected' };
     function fakeCommitCb() { return true; }
@@ -97,6 +97,5 @@ describe('DropDownEditor', () => {
       expect(option.props.title).toBe('Option 3');
       expect(option.props.children).toBe('Option Three');
     });
-    
   });
 });

--- a/src/addons/editors/__tests__/DropDownEditor.spec.js
+++ b/src/addons/editors/__tests__/DropDownEditor.spec.js
@@ -55,4 +55,48 @@ describe('DropDownEditor', () => {
       expect(component.getValue().selected).toBe('option1');
     });
   });
+
+  describe('Object parameters', () => {
+    let fakeOptions = [
+      { id: '1', value: 'option1', title: 'Option 1' },
+      { id: '2', value: 'option2', text: 'Option Two' },
+      { id: '3', value: 'option3', title: 'Option 3', text: 'Option Three' },
+    ];
+    let fakeColumn = { key: 'selected' };
+    function fakeCommitCb() { return true; }
+
+    beforeEach(() => {
+      component = TestUtils.renderIntoDocument(<DropDownEditor
+        name={'DropDownEditor'}
+        options={fakeOptions}
+        value={'Choose a thing'}
+        onCommit={fakeCommitCb}
+        column={fakeColumn}/>);
+    });
+
+    it('should display value unless text is specified', () => {
+      let option = component.renderOptions()[0];
+      expect(option.key).toBe('1');
+      expect(option.props.value).toBe('option1');
+      expect(option.props.title).toBe('Option 1');
+      expect(option.props.children).toBe('option1');
+    });
+
+    it('should display text', () => {
+      let option = component.renderOptions()[1];
+      expect(option.key).toBe('2');
+      expect(option.props.value).toBe('option2');
+      expect(option.props.title).not.toBeDefined();
+      expect(option.props.children).toBe('Option Two');
+    });
+
+    it('should display title', () => {
+      let option = component.renderOptions()[2];
+      expect(option.key).toBe('3');
+      expect(option.props.value).toBe('option3');
+      expect(option.props.title).toBe('Option 3');
+      expect(option.props.children).toBe('Option Three');
+    });
+    
+  });
 });

--- a/src/addons/formatters/DropDownFormatter.js
+++ b/src/addons/formatters/DropDownFormatter.js
@@ -1,0 +1,37 @@
+// Used for displaying the value of a dropdown (using DropDownEditor) when not editing it.
+// Accepts the same parameters as the DropDownEditor.
+const React = require('react');
+
+const DropDownFormatter = React.createClass({
+  propTypes: {
+    options: React.PropTypes.arrayOf(React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.objectOf({
+        id: React.PropTypes.string,
+        title: React.PropTypes.string,
+        value: React.PropTypes.string,
+        text: React.PropTypes.string
+      })
+    ])).isRequired,
+    value: React.PropTypes.string.isRequired
+  },
+
+  shouldComponentUpdate(nextProps: any): boolean {
+    return nextProps.value !== this.props.value;
+  },
+
+  render(): ?ReactElement {
+    let value = this.props.value;
+    let option = this.props.options.filter(function(v) {
+      return v === value || v.value === value;
+    })[0];
+    if (!option) {
+      option = value;
+    }
+    let title = option.title || option.value || option;
+    let text = option.text || option.value || option;
+    return <div title={title}>{text}</div>;
+  }
+});
+
+module.exports = DropDownFormatter;

--- a/src/addons/formatters/index.js
+++ b/src/addons/formatters/index.js
@@ -2,9 +2,11 @@
 // not including this
 // it currently requires the whole of moment, which we dont want to take as a dependency
 const ImageFormatter = require('./ImageFormatter');
+const DropDownFormatter = require('./DropDownFormatter');
 
 const Formatters = {
-  ImageFormatter: ImageFormatter
+  ImageFormatter: ImageFormatter,
+  DropDownFormatter: DropDownFormatter
 };
 
 module.exports = Formatters;


### PR DESCRIPTION
## Description
Enhances the built-in DropdownEditor so we can customize the text

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The dropdown editor lets you set the title text for each option, but doesn't let you display a different value than what gets selected.


**What is the new behavior?**
The options now include a "text" property to control what text is actually displayed. The editor still uses "value" if this isn't set, so this isn't a breaking change. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
