### PR TITLE
Delegate the logic of display value when the user double clicks cell.

### DIFF
--- a/src/addons/editors/AutoCompleteEditor.js
+++ b/src/addons/editors/AutoCompleteEditor.js
@@ -21,7 +21,8 @@ const AutoCompleteEditor = React.createClass({
     resultIdentifier: React.PropTypes.string,
     search: React.PropTypes.string,
     onKeyDown: React.PropTypes.func,
-    onFocus: React.PropTypes.func
+    onFocus: React.PropTypes.func,
+    editorDisplayValue: React.PropTypes.func
   },
 
   getDefaultProps(): {resultIdentifier: string} {
@@ -48,6 +49,17 @@ const AutoCompleteEditor = React.createClass({
 
     updated[this.props.column.key] = value;
     return updated;
+  },
+
+  getEditorDisplayValue() {
+    let displayValue = {title: ''};
+    let { column, value, editorDisplayValue } = this.props;
+    if (editorDisplayValue && typeof editorDisplayValue === 'function') {
+      displayValue.title = editorDisplayValue(column, value);
+    } else {
+      displayValue.title = value;
+    }
+    return displayValue;
   },
 
   getInputNode() {
@@ -87,7 +99,7 @@ const AutoCompleteEditor = React.createClass({
   render(): ?ReactElement {
     let label = this.props.label != null ? this.props.label : 'title';
     return (<div height={this.props.height} onKeyDown={this.props.onKeyDown}>
-      <ReactAutocomplete search={this.props.search} ref="autoComplete" label={label} onChange={this.handleChange} onFocus={this.props.onFocus} resultIdentifier={this.props.resultIdentifier} options={this.props.options} value={{title: this.props.value}} />
+      <ReactAutocomplete search={this.props.search} ref="autoComplete" label={label} onChange={this.handleChange} onFocus={this.props.onFocus} resultIdentifier={this.props.resultIdentifier} options={this.props.options} value={this.getEditorDisplayValue()} />
       </div>);
   }
 });

--- a/src/addons/editors/__tests__/AutoCompleteEditor.spec.js
+++ b/src/addons/editors/__tests__/AutoCompleteEditor.spec.js
@@ -131,4 +131,20 @@ describe('AutoCompleteEditor', () => {
       expect(component.getValue()).toEqual({autocomplete: 'a'});
     });
   });
+  describe('With editorDisplayValue prop', () => {
+    beforeEach(() => {
+      component = TestUtils.renderIntoDocument(<AutoCompleteEditor
+        options={fakeOptions}
+        value="value"
+        editorDisplayValue={(col, val) => col.key + val}
+        column={fakeColumn}/>);
+    });
+
+    it('should create a new AutoCompleteEditor instance', () => {
+      expect(component).toBeDefined();
+    });
+    it('should pass the value returned by editorDisplayValue prop to ReachAutocomplete as a prop', () => {
+      expect(component.refs.autoComplete.props.value.title).toEqual(fakeColumn.key + 'value');
+    });
+  });
 });


### PR DESCRIPTION
## Description
When the user double clicks the cell, there can be a need to apply some logic (ex, formatting, etc). So, provide the option to the users to supply such logic (via a function) as a prop to this component.