### PR TITLE
Issue424 - AutoCompleteFilter throws a TypeError

### DIFF
--- a/src/addons/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/src/addons/cells/headerCells/filters/AutoCompleteFilter.js
@@ -8,6 +8,7 @@ class AutoCompleteFilter extends React.Component {
     super(props);
     this.getOptions = this.getOptions.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.filterValues = this.filterValues.bind(this);
     this.state = {options: this.getOptions(), rawValue: '', placeholder: 'Search...'};
   }
 

--- a/src/addons/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/src/addons/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -48,7 +48,7 @@ describe('AutoCompleteFilter', () => {
       expect(component).toBeDefined();
     });
 
-    it('should handle', () => {
+    it('should handle change', () => {
       let value = [{ value: '1' }];
       component.handleChange(value);
       expect(component.state.filters).toEqual(value);

--- a/src/addons/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/src/addons/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -25,8 +25,14 @@ describe('AutoCompleteFilter', () => {
   let rows;
 
   describe('Basic tests', () => {
+    const columnKey = 'title';
+
     let fakeColumn = { name: 'Titles', key: 'title', width: 100 };
-    function fakeOnChange() { return true; }
+
+    function fakeOnChange(obj) {
+      obj.filterValues(rows[0], obj, columnKey);
+      return true;
+    }
 
     beforeEach(() => {
       component = TestUtils.renderIntoDocument(
@@ -42,6 +48,12 @@ describe('AutoCompleteFilter', () => {
       expect(component).toBeDefined();
     });
 
+    it('should handle', () => {
+      let value = [{ value: '1' }];
+      component.handleChange(value);
+      expect(component.state.filters).toEqual(value);
+    });
+
     it('When options are valid', () => {
       let request = component.getOptions();
       let result = [
@@ -52,8 +64,6 @@ describe('AutoCompleteFilter', () => {
     });
 
     describe('When filtering a row', () => {
-      const columnKey = 'title';
-
       const filterValues = (columnFilter) => {
         return component.filterValues(rows[0], columnFilter, columnKey);
       };


### PR DESCRIPTION
## Description
PR to fix #424 
Binds `filterValues` method to correct context so that error is not thrown when said method is called in the supplied onChange prop.

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
[AutoCompleteFilter throws a TypeError
](https://github.com/adazzle/react-data-grid/issues/424)
**What is the new behavior?**
Now works as intended

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
