### PR TITLE
Fix fromRow on cell paste

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -403,14 +403,15 @@ const ReactDataGrid = React.createClass({
     let selected = this.state.selected;
     let cellKey = this.getColumn(this.state.selected.idx).key;
     let textToCopy = this.state.textToCopy;
+    let fromRow = this.state.copied.rowIdx;
     let toRow = selected.rowIdx;
 
     if (this.props.onCellCopyPaste) {
-      this.props.onCellCopyPaste({cellKey: cellKey, rowIdx: toRow, value: textToCopy, fromRow: this.state.copied.rowIdx, toRow: toRow});
+      this.props.onCellCopyPaste({cellKey: cellKey, rowIdx: toRow, value: textToCopy, fromRow: fromRow, toRow: toRow});
     }
 
     if (this.props.onGridRowsUpdated) {
-      this.onGridRowsUpdated(cellKey, toRow, toRow, {[cellKey]: textToCopy}, AppConstants.UpdateActions.COPY_PASTE);
+      this.onGridRowsUpdated(cellKey, fromRow, toRow, {[cellKey]: textToCopy}, AppConstants.UpdateActions.COPY_PASTE);
     }
 
     this.setState({copied: null});


### PR DESCRIPTION
## Description
Fixing the fromRow property when calling onGridRowUpdated on cell paste

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```