### PR TITLE
Guard filtering logic for undefined/null values

### DIFF
--- a/src/__tests__/Canvas.spec.js
+++ b/src/__tests__/Canvas.spec.js
@@ -71,7 +71,7 @@ describe('Canvas Tests', () => {
 
     describe('selectBy keys', () => {
       it('renders row selected', () => {
-        let rowGetter = () => { return {'id': 1}; };
+        let rowGetter = () => { return {id: 1}; };
 
         let props = { displayStart: 0, displayEnd: 1, COLUMNS, rowGetter, rowsCount: 1, rowSelection: { keys: { rowKey: 'id', values: [1] } } };
         testElement = renderComponent(props);
@@ -84,7 +84,7 @@ describe('Canvas Tests', () => {
 
     describe('selectBy `isSelectedKey`', () => {
       it('renders row selected', () => {
-        let rowGetter = (i) => { return i === 0 ? {'id': 1, 'isSelected': true} : null; };
+        let rowGetter = (i) => { return i === 0 ? {id: 1, isSelected: true} : null; };
 
         let props = { displayStart: 0, displayEnd: 1, COLUMNS, rowGetter, rowsCount: 1, rowSelection: { isSelectedKey: 'isSelected'} };
         testElement = renderComponent(props);

--- a/src/addons/data/RowFilterer.js
+++ b/src/addons/data/RowFilterer.js
@@ -9,8 +9,12 @@ const filterRows = (filters, rows = []) => {
           include = false;
         } else if (typeof colFilter.filterTerm === 'string') {
           // default filter action
-          let rowValue = r[columnKey].toString().toLowerCase();
-          if (rowValue.indexOf(colFilter.filterTerm.toLowerCase()) === -1) {
+          let rowValue = r[columnKey];
+          if (rowValue) {
+            if (rowValue.toString().toLowerCase().indexOf(colFilter.filterTerm.toLowerCase()) === -1) {
+              include = false;
+            }
+          } else {
             include = false;
           }
         }

--- a/themes/react-data-grid.less
+++ b/themes/react-data-grid.less
@@ -11,7 +11,7 @@
   border-color: #e7eaec;
   border-image: none;
   border-style: solid solid none;
-  border-width: 4px 1px 1px 1px;
+  border-width: 1px 1px 1px 1px;
   color: inherit;
   margin-bottom: 0;
   padding: 14px 15px 7px;


### PR DESCRIPTION
## Description
Fix a bug whereby if the value of the column is null or the column is not at all found in the row the filtering logic just doesnt include it rather than causing an exception when trying to convert null/undefined to a string.

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: CSS change to make toolbar border same thickness all sides.
```

**What is the current behavior?** (You can also link to an open issue here)
Currently if a column is filtered and is not found in the row/ its value is null an exception is fired.


**What is the new behavior?**
The row is not included.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
