### PR TITLE
Updated links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ Features
 --------
 
 - Lightning fast virtual rendering
-- [Can render hundreds of thousands of rows with no lag](http://adazzle.github.io/react-data-grid/examples.html#/million-rows)
+- [Can render hundreds of thousands of rows with no lag](http://adazzle.github.io/react-data-grid/examples.html#/one-million-rows)
 - Keyboard navigation
 - [Fully editable grid](http://adazzle.github.io/react-data-grid/examples.html#/editable)
-- [Rich cell editors like autocomplete, checkbox and dropdown editors, complete with keyboard navigation](http://adazzle.github.io/react-data-grid/examples.html#/editors)
+- [Rich cell editors like autocomplete, checkbox and dropdown editors, complete with keyboard navigation](http://adazzle.github.io/react-data-grid/examples.html#/built-in-editors)
 - Custom cell Editors - Easily create your own
-- [Custom cell Formatters](http://adazzle.github.io/react-data-grid/examples.html#/formatters)
-- [Frozen columns](http://adazzle.github.io/react-data-grid/examples.html#/fixed)
-- [Resizable columns](http://adazzle.github.io/react-data-grid/examples.html#/resizable)
-- [Sorting](http://adazzle.github.io/react-data-grid/examples.html#/sortable) 
-- [Filtering] (http://adazzle.github.io/react-data-grid/examples.html#/filterable) 
+- [Custom cell Formatters](http://adazzle.github.io/react-data-grid/examples.html#/custom-formatters)
+- [Frozen columns](http://adazzle.github.io/react-data-grid/examples.html#/fixed-cols)
+- [Resizable columns](http://adazzle.github.io/react-data-grid/examples.html#/resizable-cols)
+- [Sorting](http://adazzle.github.io/react-data-grid/examples.html#/sortable-cols) 
+- [Filtering] (http://adazzle.github.io/react-data-grid/examples.html#/filterable-sortable-grid) 
 - [Context Menu] (http://adazzle.github.io/react-data-grid/examples.html#/context-menu)
 - Copy and Paste values into other cells
 - [Multiple cell updates using cell dragdown] (http://adazzle.github.io/react-data-grid/examples.html#/cell-drag-down)


### PR DESCRIPTION
## Description
I noticed that some of the links in the examples section of the readme were broken. I've updated them to point to their correct locations. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
Fixed broken links in README.md, no code added.

**What is the current behavior?** (You can also link to an open issue here)
Fixed broken links in README.md, no code added.


**What is the new behavior?**
Fixed broken links in README.md, no code added.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
