### PR TITLE
uses column formatters on dragging/row reordering

### DIFF
--- a/src/addons/draggable/DragDropContainer.js
+++ b/src/addons/draggable/DragDropContainer.js
@@ -24,10 +24,11 @@ class DraggableContainer extends Component {
     let grid = this.renderGrid();
     let rowGetter = this.props.getDragPreviewRow || grid.props.rowGetter;
     let rowsCount = grid.props.rowsCount;
+    let columns = grid.props.columns;
     let rows = this.getRows(rowsCount, rowGetter);
     return (<div>
       {grid}
-      <RowDragLayer rowSelection={grid.props.rowSelection} rows={rows}/>
+      <RowDragLayer rowSelection={grid.props.rowSelection} rows={rows} columns={columns} />
     </div>);
   }
 }

--- a/src/addons/draggable/RowDragLayer.js
+++ b/src/addons/draggable/RowDragLayer.js
@@ -55,19 +55,25 @@ class CustomDragLayer extends Component {
   }
 
   renderDraggedRows() {
+    const columns = this.props.columns;
     return this.getDraggedRows().map((r, i) => {
-      return <tr key={`dragged-row-${i}`}>{this.renderDraggedCells(r, i) }</tr>;
+      return <tr key={`dragged-row-${i}`}>{this.renderDraggedCells(r, i, columns) }</tr>;
     });
   }
 
-  renderDraggedCells(item, rowIdx) {
+  renderDraggedCells(item, rowIdx, columns) {
     let cells = [];
     if (item != null) {
-      for (let c in item) {
-        if (item.hasOwnProperty(c)) {
-          cells.push(<td key={`dragged-cell-${rowIdx}-${c}`} className="react-grid-Cell" style={{padding: '5px'}}>{item[c]}</td>);
+      columns.forEach( c => {
+        if (item.hasOwnProperty(c.key)) {
+          if (c.formatter) {
+            const Formatter = c.formatter;
+            cells.push(<td key={`dragged-cell-${rowIdx}-${c.key}`} className="react-grid-Cell" style={{padding: '5px'}}><Formatter value={item[c.key]} /></td>);
+          } else {
+            cells.push(<td key={`dragged-cell-${rowIdx}-${c.key}`} className="react-grid-Cell" style={{padding: '5px'}}>{item[c.key]}</td>);
+          }
         }
-      }
+      });
     }
     return cells;
   }
@@ -97,7 +103,8 @@ CustomDragLayer.propTypes = {
   }),
   isDragging: PropTypes.bool.isRequired,
   rowSelection: PropTypes.object,
-  rows: PropTypes.array.isRequired
+  rows: PropTypes.array.isRequired,
+  columns: PropTypes.array.isRequired
 };
 
 function collect(monitor) {


### PR DESCRIPTION
## Description
This is a solution to the issue #454. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#454


**What is the new behavior?**
New behavior uses a column formatter when available.  Also iterates over columns, rather than row attributes to determine what values should be shown while dragging.  


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

…not columns