### PR TITLE
vv issue #440

### DIFF
--- a/src/addons/editors/EditorBase.js
+++ b/src/addons/editors/EditorBase.js
@@ -40,3 +40,4 @@ EditorBase.propTypes = {
 };
 
 module.exports = EditorBase;
+

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -31,7 +31,20 @@ const EditorContainer = React.createClass({
     return {isInvalid: false};
   },
 
+  componentDidUpdate: function() {
+    let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    let children =  Array.prototype.slice.call(nl);
+    children.forEach((el) => {
+      el.classList.add('no-blur');
+    });
+  },
+
   componentDidMount: function() {
+    let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    let children =  Array.prototype.slice.call(nl);
+    children.forEach((el) => {
+      el.classList.add('no-blur');
+    });
     let inputNode = this.getInputNode();
     if (inputNode !== undefined) {
       this.setTextInputFocus();
@@ -224,9 +237,9 @@ const EditorContainer = React.createClass({
 
   handleBlur(e) {
     e.stopPropagation();
-    let inputNode = this.getInputNode();
-    console.log(inputNode, document.activeElement);
-    this.commit();
+    if (e.relatedTarget === null || e.relatedTarget.className.indexOf('no-blur') === -1 ) {
+      this.commit(e);
+    }
   },
 
   setTextInputFocus() {

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -58,7 +58,7 @@ const EditorContainer = React.createClass({
       rowMetaData: this.getRowMetaData(),
       rowData: this.props.rowData,
       height: this.props.height,
-      onBlur: this.commit,
+      onfocusout: this.commit,
       onOverrideKeyDown: this.onKeyDown
     };
 

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -71,7 +71,7 @@ const EditorContainer = React.createClass({
       return <CustomEditor ref={editorRef} {...editorProps} />;
     }
 
-    return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;
+    return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onfocusout={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;
   },
 
   onPressEnter() {

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -227,7 +227,7 @@ const EditorContainer = React.createClass({
     e.stopPropagation();
     // commit if cliked anywhere outside editor
     // prevent commit if any element inside editor is clicked or if the active cell is clicked
-    if (!e.currentTarget.contains(e.relatedTarget) || !(e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell'))) {
+    if (!e.currentTarget.contains(e.relatedTarget) && !(e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell'))) {
       this.commit(e);
     }
   },

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -1,4 +1,5 @@
 const React                   = require('react');
+const ReactDOM                = require('react-dom');
 const joinClasses              = require('classnames');
 const keyboardHandlerMixin    = require('../../KeyboardHandlerMixin');
 const SimpleTextEditor        = require('./SimpleTextEditor');

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -33,7 +33,8 @@ const EditorContainer = React.createClass({
   },
 
   componentDidUpdate: function() {
-    let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
     let children =  Array.prototype.slice.call(nl);
     children.forEach((el) => {
       el.classList.add('no-blur');
@@ -41,7 +42,8 @@ const EditorContainer = React.createClass({
   },
 
   componentDidMount: function() {
-    let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
     let children =  Array.prototype.slice.call(nl);
     children.forEach((el) => {
       el.classList.add('no-blur');

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -264,8 +264,13 @@ const EditorContainer = React.createClass({
   },
 
   render(): ?ReactElement {
+    let divStyle = {
+      display: 'inline-block',
+      width: '200px',
+      height: '200px'
+    };
     return (
-        <div className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} commit={this.commit}>
+        <div style={divStyle} className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} commit={this.commit}>
           {this.createEditor()}
           {this.renderStatusIcon()}
         </div>

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -227,8 +227,14 @@ const EditorContainer = React.createClass({
     e.stopPropagation();
     // commit if cliked anywhere outside editor
     // prevent commit if any element inside editor is clicked or if the active cell is clicked
-    if (!e.currentTarget.contains(e.relatedTarget) && !(e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell'))) {
-      this.commit(e);
+    if (e.relatedTarget !== null) {
+      if (!e.currentTarget.contains(e.relatedTarget) && !(e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell')))  {
+        this.commit(e);
+      }
+    }else  {
+      if (!e.currentTarget.contains(e.relatedTarget)) {
+        this.commit(e);
+      }
     }
   },
 

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -227,7 +227,7 @@ const EditorContainer = React.createClass({
     e.stopPropagation();
     // commit if cliked anywhere outside editor
     // prevent commit if any element inside editor is clicked or if the active cell is clicked
-    if (!e.currentTarget.contains(e.relatedTarget) || (e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell'))) {
+    if (!e.currentTarget.contains(e.relatedTarget) || !(e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell'))) {
       this.commit(e);
     }
   },

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -187,12 +187,10 @@ const EditorContainer = React.createClass({
       this.props.cellMetaData.onCommit({cellKey: cellKey, rowIdx: this.props.rowIdx, updated: updated, key: opts.key});
     }
   },
-
   isNewValueValid(value: string): boolean {
     if (isFunction(this.getEditor().validate)) {
       let isValid = this.getEditor().validate(value);
       this.setState({isInvalid: !isValid});
-
       return isValid;
     }
 
@@ -222,6 +220,13 @@ const EditorContainer = React.createClass({
   isCaretAtEndOfInput(): boolean {
     let inputNode = this.getInputNode();
     return inputNode.selectionStart === inputNode.value.length;
+  },
+
+  handleBlur(e) {
+    e.stopPropagation();
+    let inputNode = this.getInputNode();
+    console.log(inputNode, document.activeElement);
+    this.commit();
   },
 
   setTextInputFocus() {
@@ -260,9 +265,9 @@ const EditorContainer = React.createClass({
 
   render(): ?ReactElement {
     return (
-        <div className={this.getContainerClass()} onBlur={this.commit} onKeyDown={this.onKeyDown} commit={this.commit}>
-        {this.createEditor()}
-        {this.renderStatusIcon()}
+        <div className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} commit={this.commit}>
+          {this.createEditor()}
+          {this.renderStatusIcon()}
         </div>
       );
   }

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -58,7 +58,7 @@ const EditorContainer = React.createClass({
       rowMetaData: this.getRowMetaData(),
       rowData: this.props.rowData,
       height: this.props.height,
-      onfocusout: this.commit,
+      onBlur: this.commit,
       onOverrideKeyDown: this.onKeyDown
     };
 
@@ -260,7 +260,7 @@ const EditorContainer = React.createClass({
 
   render(): ?ReactElement {
     return (
-        <div className={this.getContainerClass()} onKeyDown={this.onKeyDown} commit={this.commit}>
+        <div className={this.getContainerClass()} onBlur={this.commit} onKeyDown={this.onKeyDown} commit={this.commit}>
         {this.createEditor()}
         {this.renderStatusIcon()}
         </div>

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -225,7 +225,9 @@ const EditorContainer = React.createClass({
 
   handleBlur(e) {
     e.stopPropagation();
-    if (!e.currentTarget.contains(e.relatedTarget)) {
+    // commit if cliked anywhere outside editor
+    // prevent commit if any element inside editor is clicked or if the active cell is clicked
+    if (!e.currentTarget.contains(e.relatedTarget) || (e.relatedTarget.classList.contains('editing') && e.relatedTarget.classList.contains('react-grid-Cell'))) {
       this.commit(e);
     }
   },

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -34,18 +34,30 @@ const EditorContainer = React.createClass({
 
   componentDidUpdate: function() {
     // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
-    let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
-    let children =  Array.prototype.slice.call(nl);
-    children.forEach((el) => {
+    // let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
+    // let children =  Array.prototype.slice.call(nl);
+    let nodeIterator = document.createNodeIterator(ReactDOM.findDOMNode(this));
+    let elems = [];
+    let currentNode;
+    while (currentNode = nodeIterator.nextNode()) {
+      elems.push(currentNode);
+    }
+    elems.forEach((el) => {
       el.classList.add('no-blur');
     });
   },
 
   componentDidMount: function() {
-    // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
-    let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
-    let children =  Array.prototype.slice.call(nl);
-    children.forEach((el) => {
+     // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
+    // let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
+    // let children =  Array.prototype.slice.call(nl);
+    let nodeIterator = document.createNodeIterator(ReactDOM.findDOMNode(this));
+    let elems = [];
+    let currentNode;
+    while (currentNode = nodeIterator.nextNode()) {
+      elems.push(currentNode);
+    }
+    elems.forEach((el) => {
       el.classList.add('no-blur');
     });
     let inputNode = this.getInputNode();

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -32,34 +32,7 @@ const EditorContainer = React.createClass({
     return {isInvalid: false};
   },
 
-  componentDidUpdate: function() {
-    // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
-    // let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
-    // let children =  Array.prototype.slice.call(nl);
-    let nodeIterator = document.createNodeIterator(ReactDOM.findDOMNode(this));
-    let elems = [];
-    let currentNode;
-    while (currentNode = nodeIterator.nextNode()) {
-      elems.push(currentNode);
-    }
-    elems.forEach((el) => {
-      el.classList.add('no-blur');
-    });
-  },
-
   componentDidMount: function() {
-     // let nl = ReactDOM.findDOMNode(this).querySelectorAll(`*`);
-    // let nl = ReactDOM.findDOMNode(this).getElementsByTagName('*');
-    // let children =  Array.prototype.slice.call(nl);
-    let nodeIterator = document.createNodeIterator(ReactDOM.findDOMNode(this));
-    let elems = [];
-    let currentNode;
-    while (currentNode = nodeIterator.nextNode()) {
-      elems.push(currentNode);
-    }
-    elems.forEach((el) => {
-      el.classList.add('no-blur');
-    });
     let inputNode = this.getInputNode();
     if (inputNode !== undefined) {
       this.setTextInputFocus();
@@ -252,7 +225,7 @@ const EditorContainer = React.createClass({
 
   handleBlur(e) {
     e.stopPropagation();
-    if (e.relatedTarget === null || e.relatedTarget.className.indexOf('no-blur') === -1 ) {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
       this.commit(e);
     }
   },

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -71,7 +71,7 @@ const EditorContainer = React.createClass({
       return <CustomEditor ref={editorRef} {...editorProps} />;
     }
 
-    return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onfocusout={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;
+    return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;
   },
 
   onPressEnter() {

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -70,7 +70,7 @@ describe('Editor Container Tests', () => {
     });
   });
 
-  describe('Custom Editors', () => {
+  fdescribe('Custom Editors', () => {
     class TestEditor extends EditorBase {
       render() {
         return <div><input type="text" id="testpassed" /> <div> <input type="text" id="input2"/><button id="test-button" /></div> </div>;
@@ -124,7 +124,7 @@ describe('Editor Container Tests', () => {
         height={50}/>);
       let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
       spyOn(component, 'commit');
-      TestUtils.Simulate.blur(ReactDOM.findDOMNode(component));
+      TestUtils.Simulate.blur(ReactDOM.findDOMNode(component), {relatedTarget: document.body, currentTarget: ReactDOM.findDOMNode(component)});
       expect(component.commit).toHaveBeenCalled();
     });
 

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -69,50 +69,82 @@ describe('Editor Container Tests', () => {
     });
   });
 
-  describe('Custom Editors', () => {
-    class TestEditor extends EditorBase {
-      render() {
-        return <input type="text" id="testpassed" />;
-      }
-    }
+  // fdescribe('Custom Editors', () => {
+  //   class TestEditor extends EditorBase {
+  //     render() {
+  //       return <div><input type="text" id="testpassed" /> <div> <input type="text" id="input2"/><button id="test-button" /></div> </div>;
+  //     }
+  //   }
 
-    let column;
-    beforeEach(() => {
-      column = {
-        key: 'col1',
-        name: 'col1',
-        width: 100
-      };
-    });
+  //   let column;
+  //   beforeEach(() => {
+  //     column = {
+  //       key: 'col1',
+  //       name: 'col1',
+  //       width: 100
+  //     };
+  //   });
 
-    it('should render element custom editors', () => {
-      column.editor = <TestEditor />;
-      component = TestUtils.renderIntoDocument(<EditorContainer
-        rowData={rowData}
-        value={'SupernaviX'}
-        cellMetaData={cellMetaData}
-        column={column}
-        height={50}/>);
-      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
-      expect(editor).toBeDefined();
-      expect(editor.props.value).toBeDefined();
-      expect(editor.props.onCommit).toBeDefined();
-    });
+  //   it('should render element custom editors', () => {
+  //     column.editor = <TestEditor />;
+  //     component = TestUtils.renderIntoDocument(<EditorContainer
+  //       rowData={rowData}
+  //       value={'SupernaviX'}
+  //       cellMetaData={cellMetaData}
+  //       column={column}
+  //       height={50}/>);
+  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+  //     expect(editor).toBeDefined();
+  //     expect(editor.props.value).toBeDefined();
+  //     expect(editor.props.onCommit).toBeDefined();
+  //   });
 
-    it('should render component custom editors', () => {
-      column.editor = TestEditor;
-      component = TestUtils.renderIntoDocument(<EditorContainer
-        rowData={rowData}
-        value={'SupernaviX'}
-        cellMetaData={cellMetaData}
-        column={column}
-        height={50}/>);
-      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
-      expect(editor).toBeDefined();
-      expect(editor.props.value).toBeDefined();
-      expect(editor.props.onCommit).toBeDefined();
-    });
-  });
+  //   it('should render component custom editors', () => {
+  //     column.editor = TestEditor;
+  //     component = TestUtils.renderIntoDocument(<EditorContainer
+  //       rowData={rowData}
+  //       value={'SupernaviX'}
+  //       cellMetaData={cellMetaData}
+  //       column={column}
+  //       height={50}/>);
+  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+  //     expect(editor).toBeDefined();
+  //     expect(editor.props.value).toBeDefined();
+  //     expect(editor.props.onCommit).toBeDefined();
+  //   });
+
+  //   it('should commit if any element outside the editor is clicked', () => {
+  //     column.editor = <TestEditor />;
+  //     component = TestUtils.renderIntoDocument(<EditorContainer
+  //       rowData={rowData}
+  //       value={'SupernaviX'}
+  //       cellMetaData={cellMetaData}
+  //       column={column}
+  //       height={50}
+  //       />);
+
+  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+  //     TestUtils.Simulate.click(document.body);
+  //     expect(editor).toBeUndefined();
+  //   });
+
+  //   it('should not commit if any element inside the editor is clicked', () => {
+  //     cellMetaData.onCommit = function() {};
+  //     spyOn(cellMetaData, 'onCommit');
+
+  //     column.editor = <TestEditor />;
+  //     component = TestUtils.renderIntoDocument(<EditorContainer
+  //       rowData={rowData}
+  //       value={'SupernaviX'}
+  //       cellMetaData={cellMetaData}
+  //       column={column}
+  //       height={50}
+  //       />);
+  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+
+  //     TestUtils.Simulate.click(document.querySelector('#test-button'));
+  //     expect(cellMetaData.onCommit.calls.count()).toEqual(0);    });
+  // });
 
   describe('Events', () => {
     beforeEach(() => {

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -70,7 +70,7 @@ describe('Editor Container Tests', () => {
     });
   });
 
-  fdescribe('Custom Editors', () => {
+  describe('Custom Editors', () => {
     class TestEditor extends EditorBase {
       render() {
         return <div><input type="text" id="testpassed" /> <div> <input type="text" id="input2"/><button id="test-button" /></div> </div>;

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -1,5 +1,6 @@
 
 const React            = require('react');
+const ReactDOM         = require('react-dom');
 const rewire           = require('rewire');
 const EditorContainer  = rewire('../EditorContainer.js');
 const TestUtils        = require('react/lib/ReactTestUtils');
@@ -69,82 +70,78 @@ describe('Editor Container Tests', () => {
     });
   });
 
-  // fdescribe('Custom Editors', () => {
-  //   class TestEditor extends EditorBase {
-  //     render() {
-  //       return <div><input type="text" id="testpassed" /> <div> <input type="text" id="input2"/><button id="test-button" /></div> </div>;
-  //     }
-  //   }
+  describe('Custom Editors', () => {
+    class TestEditor extends EditorBase {
+      render() {
+        return <div><input type="text" id="testpassed" /> <div> <input type="text" id="input2"/><button id="test-button" /></div> </div>;
+      }
+    }
 
-  //   let column;
-  //   beforeEach(() => {
-  //     column = {
-  //       key: 'col1',
-  //       name: 'col1',
-  //       width: 100
-  //     };
-  //   });
+    let column;
+    beforeEach(() => {
+      column = {
+        key: 'col1',
+        name: 'col1',
+        width: 100
+      };
+    });
 
-  //   it('should render element custom editors', () => {
-  //     column.editor = <TestEditor />;
-  //     component = TestUtils.renderIntoDocument(<EditorContainer
-  //       rowData={rowData}
-  //       value={'SupernaviX'}
-  //       cellMetaData={cellMetaData}
-  //       column={column}
-  //       height={50}/>);
-  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
-  //     expect(editor).toBeDefined();
-  //     expect(editor.props.value).toBeDefined();
-  //     expect(editor.props.onCommit).toBeDefined();
-  //   });
+    it('should render element custom editors', () => {
+      column.editor = <TestEditor />;
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={cellMetaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      expect(editor).toBeDefined();
+      expect(editor.props.value).toBeDefined();
+      expect(editor.props.onCommit).toBeDefined();
+    });
 
-  //   it('should render component custom editors', () => {
-  //     column.editor = TestEditor;
-  //     component = TestUtils.renderIntoDocument(<EditorContainer
-  //       rowData={rowData}
-  //       value={'SupernaviX'}
-  //       cellMetaData={cellMetaData}
-  //       column={column}
-  //       height={50}/>);
-  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
-  //     expect(editor).toBeDefined();
-  //     expect(editor.props.value).toBeDefined();
-  //     expect(editor.props.onCommit).toBeDefined();
-  //   });
+    it('should render component custom editors', () => {
+      column.editor = TestEditor;
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={cellMetaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      expect(editor).toBeDefined();
+      expect(editor.props.value).toBeDefined();
+      expect(editor.props.onCommit).toBeDefined();
+    });
 
-  //   it('should commit if any element outside the editor is clicked', () => {
-  //     column.editor = <TestEditor />;
-  //     component = TestUtils.renderIntoDocument(<EditorContainer
-  //       rowData={rowData}
-  //       value={'SupernaviX'}
-  //       cellMetaData={cellMetaData}
-  //       column={column}
-  //       height={50}
-  //       />);
+    it('should commit if any element outside the editor is clicked', () => {
+      column.editor = <TestEditor />;
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={cellMetaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      spyOn(component, 'commit');
+      TestUtils.Simulate.blur(ReactDOM.findDOMNode(component));
+      expect(component.commit).toHaveBeenCalled();
+    });
 
-  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
-  //     TestUtils.Simulate.click(document.body);
-  //     expect(editor).toBeUndefined();
-  //   });
-
-  //   it('should not commit if any element inside the editor is clicked', () => {
-  //     cellMetaData.onCommit = function() {};
-  //     spyOn(cellMetaData, 'onCommit');
-
-  //     column.editor = <TestEditor />;
-  //     component = TestUtils.renderIntoDocument(<EditorContainer
-  //       rowData={rowData}
-  //       value={'SupernaviX'}
-  //       cellMetaData={cellMetaData}
-  //       column={column}
-  //       height={50}
-  //       />);
-  //     let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
-
-  //     TestUtils.Simulate.click(document.querySelector('#test-button'));
-  //     expect(cellMetaData.onCommit.calls.count()).toEqual(0);    });
-  // });
+    it('should not commit if any element inside the editor is clicked', () => {
+      column.editor = <TestEditor />;
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={cellMetaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      spyOn(component, 'commit');
+      TestUtils.Simulate.click(ReactDOM.findDOMNode(editor));
+      expect(component.commit.calls.count()).toEqual(0);
+    });
+  });
 
   describe('Events', () => {
     beforeEach(() => {

--- a/src/addons/editors/index.js
+++ b/src/addons/editors/index.js
@@ -5,13 +5,4 @@ const Editors = {
   CheckboxEditor: require('./CheckboxEditor')
 };
 
-window.addEventListener( 'click', (e) => {
-  e.stopPropagation;
-  if (document.querySelector('.DayPicker')) {
-    let el = document.querySelector('.DayPicker');
-    console.log(el);
-    el.remove();
-  }
-});
-
 module.exports = Editors;

--- a/src/addons/editors/index.js
+++ b/src/addons/editors/index.js
@@ -5,4 +5,13 @@ const Editors = {
   CheckboxEditor: require('./CheckboxEditor')
 };
 
+window.addEventListener( 'click', (e) => {
+  e.stopPropagation;
+  if (document.querySelector('.DayPicker')) {
+    let el = document.querySelector('.DayPicker');
+    console.log(el);
+    el.remove();
+  }
+});
+
 module.exports = Editors;


### PR DESCRIPTION
## Description
[CM-1217](https://adazzle.atlassian.net/browse/CM-1217?filter=-1) Editors should close when clicked outside of them.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently the editor will only close when you click on the cell outside of it. The expected behaviour is for it to close when clicked anywhere outside of it.

**What is the new behavior?**
Editors close when clicked outside of them.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
