### PR TITLE
Fix Console Warnings Caused by Row Grouping

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -260,7 +260,16 @@ const Canvas = React.createClass({
   renderRow(props: any) {
     let row = props.row;
     if (row.__metaData && row.__metaData.isGroup) {
-      return <RowGroup name={row.name} {...row.__metaData} row={props.row} idx={props.idx} cellMetaData={this.props.cellMetaData} renderer={this.props.rowGroupRenderer}/>;
+      return (<RowGroup
+        key={props.key}
+        name={row.name}
+        {...row.__metaData}
+        row={props.row}
+        idx={props.idx}
+        height={props.height}
+        cellMetaData={this.props.cellMetaData}
+        renderer={this.props.rowGroupRenderer}
+      />);
     }
     if (this.state.scrollingTimeout !== null) {
       // in the midst of a rapid scroll, so we render placeholders

--- a/src/addons/toolbars/GroupedColumnButton.js
+++ b/src/addons/toolbars/GroupedColumnButton.js
@@ -14,6 +14,6 @@ export default class GroupedColumnButton extends Component {
 }
 
 GroupedColumnButton.propTypes = {
-  name: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
   onColumnGroupDeleted: PropTypes.func
 };

--- a/src/addons/toolbars/GroupedColumnButton.js
+++ b/src/addons/toolbars/GroupedColumnButton.js
@@ -8,8 +8,15 @@ export default class GroupedColumnButton extends Component {
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap'
     };
-    return (<button  className="btn grouped-col-btn btn-sm"><span style={style}>{this.props.name}</span>
-    <span className="glyphicon glyphicon-trash" style={{float: 'right', paddingLeft: '5px'}} onClick={this.props.onColumnGroupDeleted.bind(this, this.props.name)}></span></button>);
+    return (
+      <button  className="btn grouped-col-btn btn-sm"><span style={style}>{this.props.name}</span>
+        <span
+          className="glyphicon glyphicon-trash"
+          style={{float: 'right', paddingLeft: '5px'}}
+          onClick={this.props.onColumnGroupDeleted.bind(null, this.props.name)}>
+        </span>
+      </button>
+    );
   }
 }
 

--- a/src/addons/toolbars/GroupedColumnsPanel.js
+++ b/src/addons/toolbars/GroupedColumnsPanel.js
@@ -30,7 +30,7 @@ class GroupedColumnsPanel extends Component {
 
   renderGroupedColumns() {
     return this.props.groupBy.map(c => {
-      return (<GroupedColumnButton name={c} onColumnGroupDeleted={this.props.onColumnGroupDeleted}/>);
+      return (<GroupedColumnButton key={c} name={c} onColumnGroupDeleted={this.props.onColumnGroupDeleted}/>);
     });
   }
 


### PR DESCRIPTION
## Description
When using the Row Grouping feature, a number of console warnings appear when a column is selected for grouping. This pull request removes the errors by fixing their source.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

![before](https://cloud.githubusercontent.com/assets/1955800/18675916/ca648ea8-7f4b-11e6-86b1-d6fc0a8cc21a.PNG)

**What is the new behavior?**

![after](https://cloud.githubusercontent.com/assets/1955800/18675929/d15d83e0-7f4b-11e6-9827-78944391a907.PNG)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
