### PR TITLE
Fix #463

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -52,7 +52,9 @@ const Canvas = React.createClass({
         }).isRequired
       })
     ]),
-    rowGroupRenderer: React.PropTypes.func
+    rowGroupRenderer: React.PropTypes.func,
+    handleDragStart: React.PropTypes.func.isRequired,
+    handleDragEnd: React.PropTypes.func.isRequired
   },
 
   getDefaultProps() {
@@ -263,6 +265,8 @@ const Canvas = React.createClass({
       return (<RowGroup
         key={props.key}
         name={row.name}
+        handleDragEnd={props.handleDragEnd}
+        handleDragStart={props.handleDragStart}
         {...row.__metaData}
         row={props.row}
         idx={props.idx}
@@ -331,6 +335,8 @@ const Canvas = React.createClass({
           key: displayStart + idx,
           ref: idx,
           idx: displayStart + idx,
+          handleDragStart: this.props.handleDragStart,
+          handleDragEnd: this.props.handleDragEnd,
           row: r.row,
           height: rowHeight,
           onMouseOver: this.onMouseOver,

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -27,6 +27,7 @@ const Cell = React.createClass({
     isRowSelected: React.PropTypes.bool,
     cellMetaData: React.PropTypes.shape(CellMetaDataShape).isRequired,
     handleDragStart: React.PropTypes.func,
+    handleDragEnd: React.PropTypes.func,
     className: React.PropTypes.string,
     cellControls: React.PropTypes.any,
     rowData: React.PropTypes.object.isRequired,
@@ -460,7 +461,7 @@ const Cell = React.createClass({
       isExpanded: this.props.isExpanded
     });
 
-    let dragHandle = (!this.isActive() && ColumnUtils.canEdit(this.props.column, this.props.rowData, this.props.cellMetaData.enableCellSelect)) ? <div className="drag-handle" draggable="true" onDoubleClick={this.onDragHandleDoubleClick}><span style={{ display: 'none' }}></span></div> : null;
+    let dragHandle = (!this.isActive() && ColumnUtils.canEdit(this.props.column, this.props.rowData, this.props.cellMetaData.enableCellSelect)) ? <div className="drag-handle" draggable="true" onDragStart={this.props.handleDragStart} onDragEnd={this.props.handleDragEnd} onDoubleClick={this.onDragHandleDoubleClick}><span style={{ display: 'none' }}></span></div> : null;
     let events = this.getEvents();
 
     return (

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -97,7 +97,7 @@ const Grid = React.createClass({
           getValidFilterValues={this.props.getValidFilterValues}
           />
           {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
-            <div ref="viewPortContainer" tabIndex="0" onKeyDown={this.props.onViewportKeydown} onKeyUp={this.props.onViewportKeyup} onDoubleClick={this.props.onViewportDoubleClick}   onDragStart={this.props.onViewportDragStart} onDragEnd={this.props.onViewportDragEnd}>
+            <div ref="viewPortContainer" tabIndex="0" onKeyDown={this.props.onViewportKeydown} onKeyUp={this.props.onViewportKeyup} onDoubleClick={this.props.onViewportDoubleClick}>
                 <Viewport
                   ref="viewport"
                   rowKey={this.props.rowKey}
@@ -111,6 +111,8 @@ const Grid = React.createClass({
                   columnMetrics={this.props.columnMetrics}
                   totalWidth={this.props.totalWidth}
                   onScroll={this.onScroll}
+                  handleDragEnd={this.props.onViewportDragEnd}
+                  handleDragStart={this.props.onViewportDragStart}
                   onRows={this.props.onRows}
                   cellMetaData={this.props.cellMetaData}
                   rowOffsetHeight={this.props.rowOffsetHeight || this.props.rowHeight * headerRows.length}

--- a/src/Row.js
+++ b/src/Row.js
@@ -26,7 +26,9 @@ const Row = React.createClass({
     extraClasses: PropTypes.string,
     forceUpdate: PropTypes.bool,
     subRowDetails: PropTypes.object,
-    isRowHovered: PropTypes.bool
+    isRowHovered: PropTypes.bool,
+    handleDragEnd: PropTypes.func.isRequired,
+    handleDragStart: PropTypes.func.isRequired
   },
 
   mixins: [ColumnUtilsMixin],
@@ -87,6 +89,8 @@ const Row = React.createClass({
                       ref={i}
                       key={`${column.key}-${i}`}
                       idx={i}
+                      handleDragEnd={this.props.handleDragEnd}
+                      handleDragStart={this.props.handleDragStart}
                       rowIdx={this.props.idx}
                       value={this.getCellValue(column.key || i)}
                       column={column}

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -39,7 +39,9 @@ const Viewport = React.createClass({
     rowScrollTimeout: PropTypes.number,
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
-    rowGroupRenderer: PropTypes.func
+    rowGroupRenderer: PropTypes.func,
+    handleDragEnd: PropTypes.func.isRequired,
+    handleDragStart: PropTypes.func.isRequired
   },
 
   onScroll(scroll: {scrollTop: number; scrollLeft: number}) {
@@ -100,6 +102,8 @@ const Viewport = React.createClass({
           rowSelection={this.props.rowSelection}
           getSubRowDetails={this.props.getSubRowDetails}
           rowGroupRenderer={this.props.rowGroupRenderer}
+          handleDragStart={this.props.handleDragStart}
+          handleDragEnd={this.props.handleDragEnd}
         />
       </div>
     );


### PR DESCRIPTION
## Description

A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#463

**What is the new behavior?**
Dragging a row no longer engages the "drag to copy" functionality.
![](http://g.recordit.co/xvmWDqd1oC.gif)

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
- If anything else in cells is marked as draggable, previously that would trigger to the drag to copy functionality. This will break that.

**Other information**:

After getting into the code, this seemed like the appropriate solution to me (it actually looks like this is how drag originally was then it was moved to `Viewport`). The problem with the listener on viewport is any drag events will trigger a "drag to copy" which means any cell formaters etc in the grid wouldn't be able to use dnd.

This is still failing tests. If this looks like the solution to go with I can update the PR to fix those before merging.
