### PR TITLE
Check for existing drag and drop context before creating

### DIFF
--- a/src/addons/draggable/DragDropContainer.js
+++ b/src/addons/draggable/DragDropContainer.js
@@ -1,11 +1,16 @@
 import React, {Component} from 'react';
-import HTML5Backend from 'react-dnd-html5-backend';
-import { DragDropContext } from 'react-dnd';
 import DraggableHeaderCell from './DraggableHeaderCell';
 import RowDragLayer from './RowDragLayer';
 import isColumnsImmutable from '../../isColumnsImmutable';
+import getDndContext from './dnd-context';
 
 class DraggableContainer extends Component {
+
+  getChildContext() {
+    return {
+      dragDropManager: getDndContext(this.context)
+    };
+  }
 
   getRows(rowsCount, rowGetter) {
     let rows = [];
@@ -34,9 +39,17 @@ class DraggableContainer extends Component {
   }
 }
 
+DraggableContainer.childContextTypes = {
+  dragDropManager: React.PropTypes.object.isRequired
+};
+
+DraggableContainer.contextTypes = {
+  dragDropManager: React.PropTypes.object
+};
+
 DraggableContainer.propTypes = {
   children: React.PropTypes.element.isRequired,
   getDragPreviewRow: React.PropTypes.func
 };
 
-export default DragDropContext(HTML5Backend)(DraggableContainer);
+export default DraggableContainer;

--- a/src/addons/draggable/__tests__/DragDropContainer.spec.js
+++ b/src/addons/draggable/__tests__/DragDropContainer.spec.js
@@ -16,7 +16,7 @@ describe('<DragDropContainer />', () => {
   const GridStub = () => <div/>;
 
   function render(props = {}) {
-    let ComponentUnderTest = DragDropContainer.DecoratedComponent;
+    let ComponentUnderTest = DragDropContainer;
     wrapper = shallow(
       <ComponentUnderTest {...props} >
         <GridStub {...childProps} />

--- a/src/addons/draggable/dnd-context.js
+++ b/src/addons/draggable/dnd-context.js
@@ -1,0 +1,6 @@
+import { DragDropManager } from 'dnd-core';
+import HTML5Backend from 'react-dnd-html5-backend';
+
+export default function getDndContext(context) {
+  return context.dragDropManager || new DragDropManager(HTML5Backend);
+}


### PR DESCRIPTION
## Description

This allows consumers of `react-data-grid` to use the draggable rows on the same page as another component that uses `react-dnd`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently react-data-grid adds a react-dnd backend/context in the `DragDropContainer` for draggable rows. This works if the rest of the page does not use `react-dnd` however you get errors if you're including it elsewhere (see https://github.com/gaearon/react-dnd/issues/186).

For future reference, these are some of the errors because of this:
- `Cannot have two HTML5 backends at the same time`
- `Uncaught Invariant Violation: Cannot call beginDrag while dragging.` - (Because events hit both instances)

**What is the new behavior?**
The preferred way to use `react-dnd` is to [wrap the root component of your application](http://gaearon.github.io/react-dnd/docs-drag-drop-context.html) and it then uses `context` to pass the manager down to children. I've added a `dnd-context.js` helper that checks the given context for that and if one exists, uses it (to avoid the two backends error) and if none exists creates one (for backward compatibility).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Just a note, this is really just a workaround to this library including `react-dnd`. Normally this should probably be a peerDependency, but because `react-data-grid` publishes `dist` to npm rather than source, peer dependencies are not used. Any thoughts on changing the distribution process to either compile on install or just provide source files?

Side note, you could speed up consumer install time by moving everything from `dependencies` to `devDependencies` as only `dist` is used.
