### PR TITLE
Check if columns is immutable

### DIFF
--- a/src/ColumnMetrics.js
+++ b/src/ColumnMetrics.js
@@ -2,6 +2,7 @@ const shallowCloneObject = require('./shallowCloneObject');
 const sameColumn = require('./ColumnComparer');
 const ColumnUtils = require('./ColumnUtils');
 const getScrollbarSize  = require('./getScrollbarSize');
+const isColumnsImmutable  = require('./isColumnsImmutable');
 
 type Column = {
   key: string;
@@ -104,7 +105,7 @@ function resizeColumn(metrics: ColumnMetricsType, index: number, width: number):
 }
 
 function areColumnsImmutable(prevColumns: Array<Column>, nextColumns: Array<Column>) {
-  return (typeof Immutable !== 'undefined' && (prevColumns instanceof Immutable.List) && (nextColumns instanceof Immutable.List));
+  return isColumnsImmutable(prevColumns) && isColumnsImmutable(nextColumns);
 }
 
 function compareEachColumn(prevColumns: Array<Column>, nextColumns: Array<Column>, isSameColumn: (a: Column, b: Column) => boolean) {

--- a/src/addons/draggable/DragDropContainer.js
+++ b/src/addons/draggable/DragDropContainer.js
@@ -3,6 +3,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContext } from 'react-dnd';
 import DraggableHeaderCell from './DraggableHeaderCell';
 import RowDragLayer from './RowDragLayer';
+import isColumnsImmutable from '../../isColumnsImmutable';
 
 class DraggableContainer extends Component {
 
@@ -28,7 +29,7 @@ class DraggableContainer extends Component {
     let rows = this.getRows(rowsCount, rowGetter);
     return (<div>
       {grid}
-      <RowDragLayer rowSelection={grid.props.rowSelection} rows={rows} columns={columns} />
+      <RowDragLayer rowSelection={grid.props.rowSelection} rows={rows} columns={isColumnsImmutable(columns) ? columns.toArray() : columns} />
     </div>);
   }
 }

--- a/src/isColumnsImmutable.js
+++ b/src/isColumnsImmutable.js
@@ -1,0 +1,3 @@
+module.exports = function isColumnsImmutable(columns: Array<Column>) {
+  return (typeof Immutable !== 'undefined' && (columns instanceof Immutable.List));
+};


### PR DESCRIPTION
## Description
#455 adds the use of cell formatters in the drag preview by iterating over columns and grabbing the formatter, but assumes `columns` is an array. This handles the use case of `columns` being an `Immutable.List`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
If an `Immutable.List` is passed, the drag row will **not** use the `column.formatter` (see https://github.com/adazzle/react-data-grid/blob/master/src/addons/draggable/RowDragLayer.js#L71).



**What is the new behavior?**
This checks if `props.columns` is an `Immutable.List` and if so, converts it to an array `RowDragLayer` can understand.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

