### PR TITLE
Remove jQuery tooltip from NumericFilter

### DIFF
--- a/src/addons/cells/headerCells/filters/NumericFilter.js
+++ b/src/addons/cells/headerCells/filters/NumericFilter.js
@@ -15,22 +15,6 @@ class NumericFilter extends React.Component {
     this.getRules = this.getRules.bind(this);
   }
 
-  componentDidMount() {
-    this.attachTooltip();
-  }
-
-  componentDidUpdate() {
-    this.attachTooltip();
-  }
-
-  attachTooltip() {
-    if ($) {
-      $('[data-toggle="tooltip"]').tooltip();
-    } else if (jQuery) {
-      jQuery('[data-toggle="tooltip"]').tooltip();
-    }
-  }
-
   filterValues(row, columnFilter, columnKey) {
     if (columnFilter.filterTerm == null) {
       return true;
@@ -133,7 +117,7 @@ class NumericFilter extends React.Component {
       cursor: 'help'
     };
 
-    let tooltipText = '<table><tbody><tr><td colspan="2"><strong>Input Methods:</strong></td></tr><tr><td><strong>- &nbsp;</strong></td><td style="text-align:left">Range</td></tr><tr><td><strong>> &nbsp;</strong></td><td style="text-align:left"> Greater Then</td></tr><tr><td><strong>< &nbsp;</strong></td><td style="text-align:left"> Less Then</td></tr></tbody>';
+    let tooltipText = 'Input Methods: Range (x-y), Greater Then (>x), Less Then (<y)';
 
     return (
       <div>
@@ -141,7 +125,7 @@ class NumericFilter extends React.Component {
           <input key={inputKey} type="text" placeholder="e.g. 3,10-15,>20" className="form-control input-sm" onChange={this.handleChange} onKeyPress={this.handleKeyPress}/>
         </div>
         <div className="input-sm">
-          <span className="badge" style={badgeStyle} data-toggle="tooltip" data-container="body" data-html="true" title={tooltipText}>?</span>
+          <span className="badge" style={badgeStyle} title={tooltipText}>?</span>
         </div>
       </div>
     );

--- a/src/addons/cells/headerCells/filters/__tests__/NumericFilter.spec.js
+++ b/src/addons/cells/headerCells/filters/__tests__/NumericFilter.spec.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import TestUtils from 'react/lib/ReactTestUtils';
 import NumericFilter from '../NumericFilter';
-import {jQuery, $} from 'jquery';
-
-window.jQuery = jQuery;
-window.$ = $;
 
 describe('NumericFilter', () => {
   let component;


### PR DESCRIPTION
## Description
Removes the jQuery tooltip from NumericFilter and use a simple tooltip instead.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The tooltip in NumericFilter relies on jQuery (#477).


**What is the new behavior?**
The tooltip text contains no more HTML so can simply be rendered via the `title` attribute. Hence no need for jQuery.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```