### PR TITLE
Fix slow row sorting

### DIFF
--- a/src/addons/data/RowSorter.js
+++ b/src/addons/data/RowSorter.js
@@ -1,10 +1,13 @@
 const sortRows = (rows, sortColumn, sortDirection) => {
+  let sortDirectionSign = sortDirection === 'ASC' ? 1 : -1;
   let comparer = (a, b) => {
-    if (sortDirection === 'ASC') {
-      return (a[sortColumn] > b[sortColumn]) ? 1 : -1;
-    } else if (sortDirection === 'DESC') {
-      return (a[sortColumn] < b[sortColumn]) ? 1 : -1;
+    if (a[sortColumn] === b[sortColumn]) {
+      return 0;
     }
+    if (a[sortColumn] > b[sortColumn]) {
+      return sortDirectionSign;
+    }
+    return -sortDirectionSign;
   };
   if (sortDirection === 'NONE') {
     return rows;

--- a/src/addons/data/RowSorter.js
+++ b/src/addons/data/RowSorter.js
@@ -1,13 +1,12 @@
 const sortRows = (rows, sortColumn, sortDirection) => {
   let sortDirectionSign = sortDirection === 'ASC' ? 1 : -1;
   let comparer = (a, b) => {
-    if (a[sortColumn] === b[sortColumn]) {
-      return 0;
-    }
     if (a[sortColumn] > b[sortColumn]) {
       return sortDirectionSign;
+    } else if (a[sortColumn] < b[sortColumn]) {
+      return -sortDirectionSign;
     }
-    return -sortDirectionSign;
+    return 0;
   };
   if (sortDirection === 'NONE') {
     return rows;

--- a/src/addons/data/RowSorter.js
+++ b/src/addons/data/RowSorter.js
@@ -1,17 +1,22 @@
+const comparer = (a, b) => {
+  if (a > b) {
+    return 1;
+  } else if (a < b) {
+    return -1;
+  }
+  return 0;
+};
+
 const sortRows = (rows, sortColumn, sortDirection) => {
   let sortDirectionSign = sortDirection === 'ASC' ? 1 : -1;
-  let comparer = (a, b) => {
-    if (a[sortColumn] > b[sortColumn]) {
-      return sortDirectionSign;
-    } else if (a[sortColumn] < b[sortColumn]) {
-      return -sortDirectionSign;
-    }
-    return 0;
+  let rowComparer = (a, b) => {
+    return sortDirectionSign * comparer(a[sortColumn], b[sortColumn]);
   };
   if (sortDirection === 'NONE') {
     return rows;
   }
-  return rows.sort(comparer);
+  return rows.sort(rowComparer);
 };
 
 module.exports = sortRows;
+module.exports.comparer = comparer;

--- a/src/addons/data/__tests__/RowSorter.spec.js
+++ b/src/addons/data/__tests__/RowSorter.spec.js
@@ -1,6 +1,6 @@
 import sortRows from '../RowSorter';
 
-fdescribe('RowSorter', () => {
+describe('RowSorter', () => {
   let rows = [
     { number: 0,  text: 'Z' },
     { number: -1, text: 'A' },

--- a/src/addons/data/__tests__/RowSorter.spec.js
+++ b/src/addons/data/__tests__/RowSorter.spec.js
@@ -1,0 +1,57 @@
+import sortRows from '../RowSorter';
+
+fdescribe('RowSorter', () => {
+  let rows = [
+    { number: 0,  text: 'Z' },
+    { number: -1, text: 'A' },
+    { number: 2,  text: 'a' },
+    { number: -2, text: 'beta' },
+    { number: 0,  text: 'alpha' },
+    { number: 9999,  text: 'a' }
+  ];
+
+  it('should import RowSorter', () => {
+    expect(sortRows).toBeDefined();
+  });
+
+  describe('with sort direction NONE', () => {
+    it('should not sort', () => {
+      let rowsSorted = sortRows(rows, 'number', 'NONE');
+      for (let i = 0; i < rowsSorted.length; i++) {
+        expect(rowsSorted[i]).toEqual(rows[i]);
+      }
+    });
+  });
+
+  describe('with sort direction ASC', () => {
+    it('should sort numbers', () => {
+      let rowsSorted = sortRows(rows, 'number', 'ASC');
+      for (let i = 0; i < rowsSorted.length - 1; i++) {
+        expect(rowsSorted[i].number <= rowsSorted[i + 1].number).toBe(true);
+      }
+    });
+
+    it('should sort text', () => {
+      let rowsSorted = sortRows(rows, 'text', 'ASC');
+      for (let i = 0; i < rowsSorted.length - 1; i++) {
+        expect(rowsSorted[i].text <= rowsSorted[i + 1].text).toBe(true);
+      }
+    });
+  });
+
+  describe('with sort direction DESC', () => {
+    it('should sort numbers', () => {
+      let rowsSorted = sortRows(rows, 'number', 'DESC');
+      for (let i = 0; i < rowsSorted.length - 1; i++) {
+        expect(rowsSorted[i].number >= rowsSorted[i + 1].number).toBe(true);
+      }
+    });
+
+    it('should sort text', () => {
+      let rowsSorted = sortRows(rows, 'text', 'DESC');
+      for (let i = 0; i < rowsSorted.length - 1; i++) {
+        expect(rowsSorted[i].text >= rowsSorted[i + 1].text).toBe(true);
+      }
+    });
+  });
+});

--- a/src/addons/data/__tests__/RowSorter.spec.js
+++ b/src/addons/data/__tests__/RowSorter.spec.js
@@ -1,4 +1,4 @@
-import sortRows from '../RowSorter';
+import sortRows, {comparer} from '../RowSorter';
 
 describe('RowSorter', () => {
   let rows = [
@@ -52,6 +52,24 @@ describe('RowSorter', () => {
       for (let i = 0; i < rowsSorted.length - 1; i++) {
         expect(rowsSorted[i].text >= rowsSorted[i + 1].text).toBe(true);
       }
+    });
+  });
+
+  describe('comparer', () => {
+    it('should import comparer', () => {
+      expect(comparer).toBeDefined();
+    });
+
+    it('should return 1 if greater than', () => {
+      expect(comparer(1, 0)).toBe(1);
+    });
+
+    it('should return -1 if lower than', () => {
+      expect(comparer(0, 1)).toBe(-1);
+    });
+
+    it('should return 0 if equal', () => {
+      expect(comparer(0, 0)).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Description
Fix the slow row sorting by returning 0 if two cells are the same.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently row sorting can get very slow when there are many rows (and when there are only a few different values for a column) - see #448. E.g. change the number of rows in the [sortable example](http://adazzle.github.io/react-data-grid/examples.html#/filterable-sortable-grid) to 100000 and sort on column Priority (which only contains values `Low`, `Medium` or `High`).


**What is the new behavior?**
Row sorting is faster.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```