### PR TITLE
Redux Container Editor Wrapper.

### DIFF
--- a/gulp/tasks/tests.js
+++ b/gulp/tasks/tests.js
@@ -13,9 +13,7 @@ function testTaskRunner(done) {
     configFile: '../../../config/karma.js',
     singleRun: singleRun,
     debug: debug
-  }, function() {
-      done();
-  });
+  }, done);
 
   karmaServer.start();
 }

--- a/gulp/tasks/tests.js
+++ b/gulp/tasks/tests.js
@@ -13,7 +13,9 @@ function testTaskRunner(done) {
     configFile: '../../../config/karma.js',
     singleRun: singleRun,
     debug: debug
-  }, done);
+  }, function() {
+      done();
+  });
 
   karmaServer.start();
 }

--- a/src/addons/editors/ContainerEditorWrapper.js
+++ b/src/addons/editors/ContainerEditorWrapper.js
@@ -1,40 +1,22 @@
 import React, { Component } from 'react';
 
-// Wrapper componenet used when having an editor which is a redux container.
+// Wrapper HOC used when having an editor which is a redux container.
 // Required since react-data-grid requires access to getInputNode, getValue,
 // howvever when doing this.getEditor() in react-data-grid we get a react
 // componenet wrapped by the redux connect function and thus wont have access
 // to the required methods.
-export class ContainerEditorWrapper extends Component {
-  constructor(props, context) {
-    super(props, context);
+export default (ContainerEditor) => {
+  return class ContainerEditorWrapper extends Component {
+    getInputNode() {
+      return this.editorRef.getInputNode();
+    }
 
-    this.setEditorRef = this.setEditorRef.bind(this);
-  }
+    getValue() {
+      return this.editorRef.getValue();
+    }
 
-  getInputNode() {
-    return this.editorRef.getInputNode();
-  }
-
-  getValue() {
-    return this.editorRef.getValue();
-  }
-
-  setEditorRef(ref) {
-    this.editorRef = ref;
-  }
-
-  render() {
-    let EditorComponent = this.props.editorComponent;
-    return (<EditorComponent refCallback={this.setEditorRef} {...this.props} />);
-  }
-}
-
-ContainerEditorWrapper.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  column: React.PropTypes.object.isRequired,
-  rowData: React.PropTypes.isRequired,
-  editorComponent: React.PropTypes.object.isRequired
+    render() {
+      return (<ContainerEditor refCallback={(ref) => { this.editorRef = ref; }} {...this.props} />);
+    }
+  };
 };
-
-export default ContainerEditorWrapper;

--- a/src/addons/editors/ContainerEditorWrapper.js
+++ b/src/addons/editors/ContainerEditorWrapper.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+
+// Wrapper componenet used when having an editor which is a redux container.
+// Required since react-data-grid requires access to getInputNode, getValue,
+// howvever when doing this.getEditor() in react-data-grid we get a react
+// componenet wrapped by the redux connect function and thus wont have access
+// to the required methods.
+export class ContainerEditorWrapper extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.setEditorRef = this.setEditorRef.bind(this);
+  }
+
+  getInputNode() {
+    return this.editorRef.getInputNode();
+  }
+
+  getValue() {
+    return this.editorRef.getValue();
+  }
+
+  setEditorRef(ref) {
+    this.editorRef = ref;
+  }
+
+  render() {
+    let EditorComponent = this.props.editorComponent;
+    return (<EditorComponent refCallback={this.setEditorRef} {...this.props} />);
+  }
+}
+
+ContainerEditorWrapper.propTypes = {
+  value: React.PropTypes.string.isRequired,
+  column: React.PropTypes.object.isRequired,
+  rowData: React.PropTypes.isRequired,
+  editorComponent: React.PropTypes.object.isRequired
+};
+
+export default ContainerEditorWrapper;

--- a/src/addons/editors/ContainerEditorWrapper.js
+++ b/src/addons/editors/ContainerEditorWrapper.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 // howvever when doing this.getEditor() in react-data-grid we get a react
 // componenet wrapped by the redux connect function and thus wont have access
 // to the required methods.
-export default (ContainerEditor) => {
+module.exports = (ContainerEditor) => {
   return class ContainerEditorWrapper extends Component {
     getInputNode() {
       return this.editorRef.getInputNode();

--- a/src/addons/editors/__tests__/ContainerEditorWrapper.spec.js
+++ b/src/addons/editors/__tests__/ContainerEditorWrapper.spec.js
@@ -1,0 +1,62 @@
+const Enzyme = require('enzyme');
+const React = require('react');
+
+const ContainerEditorWrapper = require('../ContainerEditorWrapper');
+
+class FakeComponent extends React.Component {
+    getValue = jasmine.createSpy()
+    getInputNode = jasmine.createSpy()
+    render() {return (<div></div>);}
+}
+
+class FakeContainer extends React.Component {
+    render() { return (<FakeComponent ref={this.props.refCallback} />); }
+}
+
+describe('ContainerEditorWrapper', () => {
+  describe('Basic tests', () => {
+    it('should create a new ContainerEditorWrapper instance wrapping the passed in component', () => {
+      // ACT
+      let ConnectedContainerEditorWrapper = ContainerEditorWrapper(FakeContainer);
+      const renderedComp = Enzyme.mount(<ConnectedContainerEditorWrapper />);
+
+      // ASSERT
+      expect(renderedComp).toBeDefined();
+      expect(renderedComp.find('ContainerEditorWrapper').length).toBe(1);
+      expect(renderedComp.find('FakeContainer').length).toBe(1);
+      expect(renderedComp.find('FakeComponent').length).toBe(1);
+    });
+
+    describe('when calling the getValue on ContainerEditorWrapper', () => {
+      it('should call the components getValue', () => {
+        // ACT
+        let ConnectedContainerEditorWrapper = ContainerEditorWrapper(FakeContainer);
+        const renderedComp = Enzyme.mount(<ConnectedContainerEditorWrapper />);
+
+        // ASSERT
+        let redneredContainerEditorWrapper = renderedComp.find('ContainerEditorWrapper').node;
+        let renderedFakeComponent = renderedComp.find('FakeComponent').node;
+        redneredContainerEditorWrapper.getValue();
+
+        expect(renderedComp).toBeDefined();
+        expect(renderedFakeComponent.getValue).toHaveBeenCalled();
+      });
+    });
+
+    describe('when calling the getInputNode on ContainerEditorWrapper', () => {
+      it('should call the components getInputNode', () => {
+        // ACT
+        let ConnectedContainerEditorWrapper = ContainerEditorWrapper(FakeContainer);
+        const renderedComp = Enzyme.mount(<ConnectedContainerEditorWrapper />);
+
+        // ASSERT
+        let redneredContainerEditorWrapper = renderedComp.find('ContainerEditorWrapper').node;
+        let renderedFakeComponent = renderedComp.find('FakeComponent').node;
+        redneredContainerEditorWrapper.getInputNode();
+
+        expect(renderedComp).toBeDefined();
+        expect(renderedFakeComponent.getInputNode).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/addons/editors/index.js
+++ b/src/addons/editors/index.js
@@ -2,7 +2,8 @@ const Editors = {
   AutoComplete: require('./AutoCompleteEditor'),
   DropDownEditor: require('./DropDownEditor'),
   SimpleTextEditor: require('./SimpleTextEditor'),
-  CheckboxEditor: require('./CheckboxEditor')
+  CheckboxEditor: require('./CheckboxEditor'),
+  ContainerEditorWrapper: require('./ContainerEditorWrapper')
 };
 
 module.exports = Editors;


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Other... Please describe:
Wrapper componenet used when having an editor which is a redux container.
Required since react-data-grid requires access to getInputNode, getValue,
howvever when doing this.getEditor() in react-data-grid we get a react
componenet wrapped by the redux connect function and thus wont have access
to the required methods.

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

