### PR TITLE
Copy only allows you to paste once

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -247,6 +247,7 @@ const ReactDataGrid = React.createClass({
 
   onPressEscape(e: SyntheticKeyboardEvent) {
     this.setInactive(e.key);
+    this.handleCancelCopy();
   },
 
   onPressBackspace(e: SyntheticKeyboardEvent) {
@@ -409,7 +410,7 @@ const ReactDataGrid = React.createClass({
   },
 
   handlePaste() {
-    if (!this.copyPasteEnabled()) { return; }
+    if (!this.copyPasteEnabled() || !(this.state.copied)) { return; }
     let selected = this.state.selected;
     let cellKey = this.getColumn(this.state.selected.idx).key;
     let textToCopy = this.state.textToCopy;
@@ -423,7 +424,9 @@ const ReactDataGrid = React.createClass({
     if (this.props.onGridRowsUpdated) {
       this.onGridRowsUpdated(cellKey, toRow, toRow, {[cellKey]: textToCopy}, AppConstants.UpdateActions.COPY_PASTE);
     }
+  },
 
+  handleCancelCopy() {
     this.setState({copied: null});
   },
 
@@ -779,6 +782,7 @@ const ReactDataGrid = React.createClass({
       }
       if (showEditor !== false) {
         this.setState({selected: selected}, this.scrollToColumn(idx));
+        this.handleCancelCopy();
       }
     }
   },


### PR DESCRIPTION
## Description
Allow the grid to paste multiple times after a cell is copied.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
A user can only paste once after a cell is copied.


**What is the new behavior?**
A user can paste multiple times until they enter a cell editor or press escape (as in Excel)


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

- Allow for multiple pastes
- Cancel copy when entering a cell editor or when user presses Escape
- Added a check for copied state when calling handlePaste