### PR TITLE
Fix #515, column header misalignment

### DIFF
--- a/config/karma.js
+++ b/config/karma.js
@@ -124,6 +124,8 @@ module.exports = function (config) {
     },
 
     browserNoActivityTimeout: 1000000,
+    browserDisconnectTimeout: 5000,
+    browserDisconnectTolerance: 3,
 
     // coverage reporter generates the coverage
     reporters: ['junit', 'progress', 'coverage'],

--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -32,7 +32,7 @@ const HeaderCell = React.createClass({
   },
 
   shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState) && this.props.column.width !== nextProps.column.width;
+    return shallowCompare(this, nextProps, nextState) && (this.props.column.width !== nextProps.column.width || this.props.column.left !== nextProps.column.left);
   },
 
   onDragStart(e: SyntheticMouseEvent) {

--- a/src/__tests__/HeaderCell.spec.js
+++ b/src/__tests__/HeaderCell.spec.js
@@ -42,6 +42,27 @@ describe('Header Cell Tests', () => {
     );
   });
 
+  describe('shouldComponentUpdate method', () => {
+    it('should return true if the column width property is updated (which can happen if column width is not set explicitly)', () => {
+      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
+      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {width: 100})})
+      let nextState = Object.assign({}, headerCell.state)
+      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true)
+    });
+    it('should return true if the column left property is updated (which can happen if column width is not set explicitly)', () => {
+      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
+      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {left: 100})})
+      let nextState = Object.assign({}, headerCell.state)
+      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true)
+    });
+    it('should return false if the column left and width properties are not updated', () => {
+      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
+      let nextProps = Object.assign({}, testProps)
+      let nextState = Object.assign({}, headerCell.state)
+      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(false)
+    });
+  });
+
   describe('When custom render is supplied', () => {
     it('will render', () => {
       let CustomRenderer = new StubComponent('CustomRenderer');


### PR DESCRIPTION
## Description
Bug fix for #515 

If the column width isn't specified, the ColumnMetrics will recalculate the width and the left position of each of the columns. Originally, the column header was only triggering an update if the column width was changed, but not if the left position was changed.

This PR has changed the HeaderCell's shouldComponentUpdate method to return true if the column's left property has changed, and I've set up tests to confirm the behaviour of the shouldComponentUpdate method.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```
