### PR TITLE
Update viewport when given different number of columns, fixes issue where data in new cols is not displayed, introduced after 1.0.56

### DIFF
--- a/src/ViewportScrollMixin.js
+++ b/src/ViewportScrollMixin.js
@@ -43,7 +43,7 @@ module.exports = {
   },
 
   getGridState(props: { rowHeight: number; rowsCount: number; minHeight: number }): ViewportScrollState {
-    let totalNumberColumns = ColumnUtils.getSize(this.props.columnMetrics.columns);
+    let totalNumberColumns = ColumnUtils.getSize(props.columnMetrics.columns);
     let canvasHeight = props.minHeight - props.rowOffsetHeight;
     let renderedRowsCount = ceil((props.minHeight - props.rowHeight) / props.rowHeight);
     let totalRowCount = min(renderedRowsCount * 4, props.rowsCount);
@@ -167,7 +167,8 @@ module.exports = {
 
   componentWillReceiveProps(nextProps: { rowHeight: number; rowsCount: number, rowOffsetHeight: number }) {
     if (this.props.rowHeight !== nextProps.rowHeight ||
-      this.props.minHeight !== nextProps.minHeight) {
+      this.props.minHeight !== nextProps.minHeight ||
+      ColumnUtils.getSize(this.props.columnMetrics.columns) !== ColumnUtils.getSize(nextProps.columnMetrics.columns)) {
       this.setState(this.getGridState(nextProps));
     } else if (this.props.rowsCount !== nextProps.rowsCount) {
       this.updateScroll(

--- a/src/__tests__/HeaderCell.spec.js
+++ b/src/__tests__/HeaderCell.spec.js
@@ -45,21 +45,21 @@ describe('Header Cell Tests', () => {
   describe('shouldComponentUpdate method', () => {
     it('should return true if the column width property is updated (which can happen if column width is not set explicitly)', () => {
       headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
-      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {width: 100})})
-      let nextState = Object.assign({}, headerCell.state)
-      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true)
+      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {width: 100})});
+      let nextState = Object.assign({}, headerCell.state);
+      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true);
     });
     it('should return true if the column left property is updated (which can happen if column width is not set explicitly)', () => {
       headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
-      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {left: 100})})
-      let nextState = Object.assign({}, headerCell.state)
-      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true)
+      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {left: 100})});
+      let nextState = Object.assign({}, headerCell.state);
+      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true);
     });
     it('should return false if the column left and width properties are not updated', () => {
       headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
-      let nextProps = Object.assign({}, testProps)
-      let nextState = Object.assign({}, headerCell.state)
-      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(false)
+      let nextProps = Object.assign({}, testProps);
+      let nextState = Object.assign({}, headerCell.state);
+      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(false);
     });
   });
 

--- a/src/__tests__/Viewport.spec.js
+++ b/src/__tests__/Viewport.spec.js
@@ -65,4 +65,29 @@ describe('<Viewport />', () => {
       isScrolling: true
     });
   });
+
+  it('should update when given different number of columns', () => {
+    const wrapper = shallow(<Viewport {...viewportProps} />);
+    let extraColumn = {
+      key: 'description',
+      name: 'Description',
+      width: 100
+    };
+    let updatedColumns = helpers.columns.concat(extraColumn);
+    let newProps = Object.assign({}, viewportProps, {columnMetrics: Object.assign({}, viewportProps.columnMetrics, {columns: updatedColumns})});
+    wrapper.setProps(newProps);
+    expect(wrapper.state()).toEqual({
+      colDisplayEnd: updatedColumns.length,
+      colDisplayStart: 0,
+      colVisibleEnd: updatedColumns.length,
+      colVisibleStart: 0,
+      displayEnd: 50,
+      displayStart: 0,
+      height: viewportProps.minHeight,
+      scrollLeft: 0,
+      scrollTop: 0,
+      visibleEnd: 50,
+      visibleStart: 0
+    });
+  });
 });


### PR DESCRIPTION
## Description
Update viewport when nextProps has a different number of columns, to fix issue where data in the new columns is not displayed

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [n/a ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Introduced after 1.0.56, if you update the number of columns given to the viewport, it will not recalculate the number of visible columns. If the total number of new columns is higher than the previous, it causes data in the new columns not to be displayed.


**What is the new behavior?**
The viewport's componentWillReceiveProps method will trigger an update if the new total number of columns is different to the previous. This fixes the bug, so the data in the new columns is displayed


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```
