### PR TITLE
HeaderCell/Cell should update when the name/cellClass is changed

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -73,6 +73,7 @@ const Cell = React.createClass({
   shouldComponentUpdate(nextProps: any): boolean {
     let shouldUpdate = this.props.column.width !== nextProps.column.width
     || this.props.column.left !== nextProps.column.left
+    || this.props.column.cellClass !== nextProps.column.cellClass
     || this.props.height !== nextProps.height
     || this.props.rowIdx !== nextProps.rowIdx
     || this.isCellSelectionChanging(nextProps)

--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -32,7 +32,7 @@ const HeaderCell = React.createClass({
   },
 
   shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState) && (this.props.column.width !== nextProps.column.width || this.props.column.left !== nextProps.column.left);
+    return shallowCompare(this, nextProps, nextState) && (this.props.column.width !== nextProps.column.width || this.props.column.left !== nextProps.column.left || this.props.column.name !== nextProps.column.name || this.props.column.cellClass !== nextProps.column.cellClass);
   },
 
   onDragStart(e: SyntheticMouseEvent) {


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Changing the column cellClass to highlight the entire column will on occasionly not happen because the HeaderCell/Cell does not think it should update.


**What is the new behavior?**
The HeaderCell/Cell will update and respect the column cellClass change.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

