### PR TITLE
Update components to only pass known properties when rendering divs (fix for #418)

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -8,6 +8,10 @@ const isFunction = require('./addons/utils/isFunction');
 const CellMetaDataShape = require('./PropTypeShapes/CellMetaDataShape');
 const SimpleCellFormatter = require('./addons/formatters/SimpleCellFormatter');
 const ColumnUtils = require('./ColumnUtils');
+const createObjectWithProperties = require('./createObjectWithProperties');
+
+// The list of the propTypes that we want to include in the Cell div
+const knownDivPropertyKeys = ['height', 'tabIndex', 'value'];
 
 const Cell = React.createClass({
 
@@ -409,6 +413,10 @@ const Cell = React.createClass({
     return this.createEventDTO(gridEvents, columnEvents, onColumnEvent);
   },
 
+  getKnownDivProps() {
+    return createObjectWithProperties(this.props, knownDivPropertyKeys);
+  },
+
   renderCellContent(props) {
     let CellContent;
     let Formatter = this.getFormatter();
@@ -448,7 +456,7 @@ const Cell = React.createClass({
     let events = this.getEvents();
 
     return (
-      <div {...this.props} className={className} style={style}   {...events}>
+      <div {...this.getKnownDivProps()} className={className} style={style}   {...events}>
         {cellContent}
         {dragHandle}
       </div>

--- a/src/Draggable.js
+++ b/src/Draggable.js
@@ -1,12 +1,17 @@
 const React         = require('react');
 const PropTypes     = React.PropTypes;
+const createObjectWithProperties = require('./createObjectWithProperties');
+
+// The list of the propTypes that we want to include in the Draggable div
+const knownDivPropertyKeys = ['onDragStart', 'onDragEnd', 'onDrag', 'style'];
 
 const Draggable = React.createClass({
   propTypes: {
     onDragStart: PropTypes.func,
     onDragEnd: PropTypes.func,
     onDrag: PropTypes.func,
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.constructor])
+    component: PropTypes.oneOfType([PropTypes.func, PropTypes.constructor]),
+    style: PropTypes.object
   },
 
   getDefaultProps() {
@@ -67,9 +72,13 @@ const Draggable = React.createClass({
     window.removeEventListener('touchmove', this.onMouseMove);
   },
 
+  getKnownDivProps() {
+    return createObjectWithProperties(this.props, knownDivPropertyKeys);
+  },
+
   render(): ?ReactElement {
     return (
-      <div {...this.props}
+      <div {...this.getKnownDivProps()}
         onMouseDown={this.onMouseDown}
         onTouchStart={this.onMouseDown}
         className="react-grid-HeaderCell__draggable" />

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -82,7 +82,7 @@ const Grid = React.createClass({
     let EmptyRowsView = this.props.emptyRowsView;
 
     return (
-      <div {...this.props} style={this.getStyle()} className="react-grid-Grid">
+      <div style={this.getStyle()} className="react-grid-Grid">
         <Header
           ref="header"
           columnMetrics={this.props.columnMetrics}

--- a/src/Header.js
+++ b/src/Header.js
@@ -6,10 +6,14 @@ const ColumnMetrics       = require('./ColumnMetrics');
 const ColumnUtils         = require('./ColumnUtils');
 const HeaderRow           = require('./HeaderRow');
 const PropTypes           = React.PropTypes;
+const createObjectWithProperties = require('./createObjectWithProperties');
 
 type Column = {
   width: number
 }
+
+// The list of the propTypes that we want to include in the Header div
+const knownDivPropertyKeys = ['height', 'onScroll'];
 
 const Header = React.createClass({
   propTypes: {
@@ -171,6 +175,10 @@ const Header = React.createClass({
     }
   },
 
+  getKnownDivProps() {
+    return createObjectWithProperties(this.props, knownDivPropertyKeys);
+  },
+
   render(): ?ReactElement {
     let className = joinClasses({
       'react-grid-Header': true,
@@ -179,8 +187,7 @@ const Header = React.createClass({
     let headerRows = this.getHeaderRows();
 
     return (
-
-      <div {...this.props} style={this.getStyle()} className={className}>
+      <div {...this.getKnownDivProps()} style={this.getStyle()} className={className}>
         {headerRows}
       </div>
     );

--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -65,9 +65,12 @@ const HeaderCell = React.createClass({
 
   getCell(): ReactComponent {
     if (React.isValidElement(this.props.renderer)) {
+      // if it is a string, it's an HTML element, and column is not a valid property, so only pass height
+      if (typeof this.props.renderer.type === 'string') {
+        return React.cloneElement(this.props.renderer, {height: this.props.height});
+      }
       return React.cloneElement(this.props.renderer, {column: this.props.column, height: this.props.height});
     }
-
     return this.props.renderer({column: this.props.column});
   },
 

--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -7,6 +7,7 @@ const ColumnUtilsMixin  = require('./ColumnUtils');
 const SortableHeaderCell    = require('./addons/cells/headerCells/SortableHeaderCell');
 const FilterableHeaderCell  = require('./addons/cells/headerCells/FilterableHeaderCell');
 const HeaderCellType = require('./HeaderCellType');
+const createObjectWithProperties = require('./createObjectWithProperties');
 
 const PropTypes         = React.PropTypes;
 
@@ -19,11 +20,14 @@ const HeaderRowStyle  = {
 
 const DEFINE_SORT = ['ASC', 'DESC', 'NONE'];
 
+// The list of the propTypes that we want to include in the HeaderRow div
+const knownDivPropertyKeys = ['width', 'height', 'style', 'onScroll'];
+
 const HeaderRow = React.createClass({
   propTypes: {
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     height: PropTypes.number.isRequired,
-    columns: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    columns: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
     onColumnResize: PropTypes.func,
     onSort: PropTypes.func.isRequired,
     onColumnResizeEnd: PropTypes.func,
@@ -145,6 +149,10 @@ const HeaderRow = React.createClass({
     });
   },
 
+  getKnownDivProps() {
+    return createObjectWithProperties(this.props, knownDivPropertyKeys);
+  },
+
   render(): ?ReactElement {
     let cellsStyle = {
       width: this.props.width ? (this.props.width + getScrollbarSize()) : '100%',
@@ -156,7 +164,7 @@ const HeaderRow = React.createClass({
 
     let cells = this.getCells();
     return (
-      <div {...this.props} className="react-grid-HeaderRow" onScroll={this.props.onScroll}>
+      <div {...this.getKnownDivProps()} className="react-grid-HeaderRow">
         <div style={cellsStyle}>
           {cells}
         </div>

--- a/src/Row.js
+++ b/src/Row.js
@@ -6,12 +6,16 @@ const Cell = require('./Cell');
 const ColumnUtilsMixin = require('./ColumnUtils');
 const cellMetaDataShape = require('./PropTypeShapes/CellMetaDataShape');
 const PropTypes = React.PropTypes;
+const createObjectWithProperties = require('./createObjectWithProperties');
 
 const CellExpander = React.createClass({
   render() {
     return (<Cell {...this.props}/>);
   }
 });
+
+// The list of the propTypes that we want to include in the Row div
+const knownDivPropertyKeys = ['height'];
 
 const Row = React.createClass({
 
@@ -162,6 +166,10 @@ const Row = React.createClass({
     });
   },
 
+  getKnownDivProps() {
+    return createObjectWithProperties(this.props, knownDivPropertyKeys);
+  },
+
   renderCell(props) {
     if (typeof this.props.cellRenderer === 'function') {
       this.props.cellRenderer.call(this, props);
@@ -192,7 +200,7 @@ const Row = React.createClass({
 
     let cells = this.getCells();
     return (
-      <div {...this.props} className = { className } style= { style } onDragEnter= { this.handleDragEnter } >
+      <div {...this.getKnownDivProps()} className = { className } style= { style } onDragEnter= { this.handleDragEnter } >
         {
           React.isValidElement(this.props.row) ?
             this.props.row : cells

--- a/src/__tests__/Cell.spec.js
+++ b/src/__tests__/Cell.spec.js
@@ -3,9 +3,10 @@ let rewire       = require('rewire');
 let Cell         = rewire('../Cell');
 let rewireModule = require('../../test/rewireModule');
 let StubComponent = require('../../test/StubComponent');
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import isEqual from 'lodash/isEqual';
 Object.assign = require('object-assign');
+import * as helpers from './GridPropHelpers';
 
 let testCellMetaData = {
   selected: {idx: 2, rowIdx: 3},
@@ -490,6 +491,127 @@ describe('Cell Tests', () => {
           idx: testProps.idx
         });
       });
+    });
+  });
+
+  describe('Rendering Cell component', () => {
+    const shallowRenderComponent = (props) => {
+      const wrapper = shallow(<Cell {...props} />);
+      return wrapper;
+    };
+
+    const requiredProperties = {
+      rowIdx: 18,
+      idx: 19,
+      column: helpers.columns[0],
+      row: {key: 'value'},
+      value: 'requiredValue',
+      cellMetaData: {
+        selected: {idx: 2, rowIdx: 3},
+        dragged: null,
+        onCellClick: jasmine.createSpy(),
+        onCellContextMenu: jasmine.createSpy(),
+        onCellDoubleClick: jasmine.createSpy(),
+        onCommit: jasmine.createSpy(),
+        onCommitCancel: jasmine.createSpy(),
+        copied: null,
+        handleDragEnterRow: jasmine.createSpy(),
+        handleTerminateDrag: jasmine.createSpy(),
+        onColumnEvent: jasmine.createSpy()
+      },
+      rowData: helpers.rowGetter(11),
+      expandableOptions: {key: 'reqValue'},
+      isScrolling: false
+    };
+
+    const allProperties = {
+      rowIdx: 20,
+      idx: 21,
+      selected: {idx: 18},
+      height: 35,
+      tabIndex: 12,
+      ref: 'cellRef',
+      column: helpers.columns[1],
+      value: 'allValue',
+      isExpanded: true,
+      isRowSelected: false,
+      cellMetaData: {
+        selected: {idx: 2, rowIdx: 3},
+        dragged: null,
+        onCellClick: jasmine.createSpy(),
+        onCellContextMenu: jasmine.createSpy(),
+        onCellDoubleClick: jasmine.createSpy(),
+        onCommit: jasmine.createSpy(),
+        onCommitCancel: jasmine.createSpy(),
+        copied: null,
+        handleDragEnterRow: jasmine.createSpy(),
+        handleTerminateDrag: jasmine.createSpy(),
+        onColumnEvent: jasmine.createSpy()
+      },
+      handleDragStart: jasmine.createSpy(),
+      className: 'a-class-name',
+      cellControls: 'something',
+      rowData: helpers.rowGetter(10),
+      extraClasses: 'extra-classes',
+      forceUpdate: false,
+      expandableOptions: {key: 'value'},
+      isScrolling: true
+    };
+
+
+    it('passes classname property', () => {
+      const wrapper = shallowRenderComponent(requiredProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.hasClass('react-grid-Cell'));
+    });
+    it('passes style property', () => {
+      const wrapper = shallowRenderComponent(requiredProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().style).toBeDefined();
+    });
+    it('passes height property if available from props', () => {
+      const wrapper = shallowRenderComponent(allProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().height).toBe(35);
+    });
+    it('does not pass height property if not available from props', () => {
+      const wrapper = shallowRenderComponent(requiredProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().height).toBeUndefined();
+    });
+    it('passes tabIndex property if available from props', () => {
+      const wrapper = shallowRenderComponent(allProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().tabIndex).toBe(12);
+    });
+    it('passes tabIndex if not available from props, because it is set as a default', () => {
+      const wrapper = shallowRenderComponent(requiredProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().tabIndex).toBe(-1);
+    });
+    it('passes value property', () => {
+      const wrapper = shallowRenderComponent(requiredProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().value).toBe('requiredValue');
+    });
+    it('does not pass unknown properties to the div', () => {
+      const wrapper = shallowRenderComponent(allProperties);
+      const cellDiv = wrapper.find('div').at(0);
+      expect(cellDiv.props().rowIdx).toBeUndefined();
+      expect(cellDiv.props().idx).toBeUndefined();
+      expect(cellDiv.props().selected).toBeUndefined();
+      expect(cellDiv.props().selectedColumn).toBeUndefined();
+      expect(cellDiv.props().ref).toBeUndefined();
+      expect(cellDiv.props().column).toBeUndefined();
+      expect(cellDiv.props().isExpanded).toBeUndefined();
+      expect(cellDiv.props().isRowSelected).toBeUndefined();
+      expect(cellDiv.props().cellMetaData).toBeUndefined();
+      expect(cellDiv.props().handleDragStart).toBeUndefined();
+      expect(cellDiv.props().cellControls).toBeUndefined();
+      expect(cellDiv.props().rowData).toBeUndefined();
+      expect(cellDiv.props().forceUpdate).toBeUndefined();
+      expect(cellDiv.props().expandableOptions).toBeUndefined();
+      expect(cellDiv.props().isScrolling).toBeUndefined();
     });
   });
 });

--- a/src/__tests__/Draggable.spec.js
+++ b/src/__tests__/Draggable.spec.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+let rewire    = require('rewire');
+let Draggable = rewire('../Draggable');
+
+const renderComponent = (props) => {
+  const wrapper = shallow(<Draggable {...props} />);
+  return wrapper;
+};
+
+const onDragStart = jasmine.createSpy();
+const onDragEnd = jasmine.createSpy();
+const onDrag = jasmine.createSpy();
+const component = jasmine.createSpy();
+
+const allProperties = {
+  onDragStart,
+  onDragEnd,
+  onDrag,
+  component,
+  style: {
+    position: 'absolute',
+    top: '0px',
+    right: '0px',
+    width: '6px',
+    height: '100%'
+  }
+};
+
+describe('Draggable Tests', () => {
+  describe('Rendering draggable component', () => {
+    it('passes classname property', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.hasClass('react-grid-HeaderCell__draggable'));
+    });
+    it('passes onMouseDown property', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onMouseDown).toBeDefined();
+    });
+    it('passes onTouchStart property', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onTouchStart).toBeDefined();
+    });
+    it('passes onDragStart if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDragStart).toBe(onDragStart);
+    });
+    it('passes onDragStart if not available from props, because it is set as a default', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDragStart).toBeDefined();
+    });
+    it('passes onDragEnd if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDragEnd).toBe(onDragEnd);
+    });
+    it('passes onDragEnd if not available from props, because it is set as a default', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDragEnd).toBeDefined();
+    });
+    it('passes onDrag if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDrag).toBe(onDrag);
+    });
+    it('passes onDrag if not available from props, because it is set as a default', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDrag).toBeDefined();
+    });
+    it('passes style if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().style).toBe(allProperties.style);
+    });
+    it('does not pass style if not available from props', () => {
+      const wrapper = renderComponent({});
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().style).toBeUndefined();
+    });
+    it('does not pass unknown properties to the div', () => {
+      const wrapper = renderComponent(allProperties);
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().component).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/Grid.spec.js
+++ b/src/__tests__/Grid.spec.js
@@ -5,6 +5,8 @@ const Grid          = rewire('../Grid');
 const TestUtils     = require('react-addons-test-utils');
 const helpers       = require('./GridPropHelpers');
 const rewireModule = require('../../test/rewireModule');
+import { shallow } from 'enzyme';
+import { ContextMenu } from 'react-contextmenu';
 
 let testElement;
 let HeaderStub = React.createClass({
@@ -136,5 +138,112 @@ describe('Empty Grid Tests', () => {
   it('should not have any viewport', () => {
     expect(testElement.refs.viewPortContainer).not.toBeDefined();
     expect(testElement.refs.emptyView).toBeDefined();
+  });
+});
+
+describe('Rendering Grid component', () => {
+  const renderComponent = (props) => {
+    const wrapper = shallow(<Grid {...props} />);
+    return wrapper;
+  };
+
+  const allProperties = () => {
+    return {
+      rowGetter: jasmine.createSpy(),
+      columns: helpers.columns,
+      columnMetrics: {
+        columns: helpers.columns,
+        width: 1200
+      },
+      minHeight: 500,
+      totalWidth: 700,
+      headerRows: [],
+      rowHeight: 50,
+      rowRenderer: jasmine.createSpy(),
+      emptyRowsView: jasmine.createSpy(),
+      expandedRows: jasmine.createSpy(),
+      selectedRows: jasmine.createSpy(),
+      rowSelection: {isSelectedKey: 'selectedKey'},
+      rowsCount: 14,
+      onRows: jasmine.createSpy(),
+      sortColumn: 'sortColumn',
+      sortDirection: 'ASC',
+      rowOffsetHeight: 100,
+      onViewportKeydown: jasmine.createSpy(),
+      onViewportKeyup: jasmine.createSpy(),
+      onViewportDragStart: jasmine.createSpy(),
+      onViewportDragEnd: jasmine.createSpy(),
+      onViewportDoubleClick: jasmine.createSpy(),
+      onColumnResize: jasmine.createSpy(),
+      onSort: jasmine.createSpy(),
+      cellMetaData: {
+        selected: {idx: 2, rowIdx: 3},
+        dragged: null,
+        onCellClick: jasmine.createSpy(),
+        onCellContextMenu: jasmine.createSpy(),
+        onCellDoubleClick: jasmine.createSpy(),
+        onCommit: jasmine.createSpy(),
+        onCommitCancel: jasmine.createSpy(),
+        copied: null,
+        handleDragEnterRow: jasmine.createSpy(),
+        handleTerminateDrag: jasmine.createSpy(),
+        onColumnEvent: jasmine.createSpy()
+      },
+      rowKey: 'rowKeyValue',
+      rowScrollTimeout: 300,
+      contextMenu: <ContextMenu />,
+      getSubRowDetails: jasmine.createSpy(),
+      draggableHeaderCell: jasmine.createSpy(),
+      getValidFilterValues: jasmine.createSpy(),
+      rowGroupRenderer: jasmine.createSpy(),
+      overScan: {key: 'value'}
+    };
+  };
+  it('passes classname property', () => {
+    const wrapper = renderComponent(allProperties());
+    const draggableDiv = wrapper.find('div').at(0);
+    expect(draggableDiv.hasClass('react-grid-Grid'));
+  });
+  it('passes style property', () => {
+    const wrapper = renderComponent(allProperties());
+    const draggableDiv = wrapper.find('div').at(0);
+    expect(draggableDiv.props().style).toBeDefined();
+  });
+  it('does not pass unknown properties to the div', () => {
+    const wrapper = renderComponent(allProperties());
+    const draggableDiv = wrapper.find('div').at(0);
+    expect(draggableDiv.props().rowGetter).toBeUndefined();
+    expect(draggableDiv.props().columns).toBeUndefined();
+    expect(draggableDiv.props().columnMetrics).toBeUndefined();
+    expect(draggableDiv.props().minHeight).toBeUndefined();
+    expect(draggableDiv.props().totalWidth).toBeUndefined();
+    expect(draggableDiv.props().headerRows).toBeUndefined();
+    expect(draggableDiv.props().rowHeight).toBeUndefined();
+    expect(draggableDiv.props().rowRenderer).toBeUndefined();
+    expect(draggableDiv.props().emptyRowsView).toBeUndefined();
+    expect(draggableDiv.props().expandedRows).toBeUndefined();
+    expect(draggableDiv.props().selectedRows).toBeUndefined();
+    expect(draggableDiv.props().rowSelection).toBeUndefined();
+    expect(draggableDiv.props().rowsCount).toBeUndefined();
+    expect(draggableDiv.props().onRows).toBeUndefined();
+    expect(draggableDiv.props().sortColumn).toBeUndefined();
+    expect(draggableDiv.props().sortDirection).toBeUndefined();
+    expect(draggableDiv.props().rowOffsetHeight).toBeUndefined();
+    expect(draggableDiv.props().onViewportKeydown).toBeUndefined();
+    expect(draggableDiv.props().onViewportKeyup).toBeUndefined();
+    expect(draggableDiv.props().onViewportDragStart).toBeUndefined();
+    expect(draggableDiv.props().onViewportDragEnd).toBeUndefined();
+    expect(draggableDiv.props().onViewportDoubleClick).toBeUndefined();
+    expect(draggableDiv.props().onColumnResize).toBeUndefined();
+    expect(draggableDiv.props().onSort).toBeUndefined();
+    expect(draggableDiv.props().cellMetaData).toBeUndefined();
+    expect(draggableDiv.props().rowKey).toBeUndefined();
+    expect(draggableDiv.props().rowScrollTimeout).toBeUndefined();
+    expect(draggableDiv.props().contextMenu).toBeUndefined();
+    expect(draggableDiv.props().getSubRowDetails).toBeUndefined();
+    expect(draggableDiv.props().draggableHeaderCell).toBeUndefined();
+    expect(draggableDiv.props().getValidFilterValues).toBeUndefined();
+    expect(draggableDiv.props().rowGroupRenderer).toBeUndefined();
+    expect(draggableDiv.props().overScan).toBeUndefined();
   });
 });

--- a/src/__tests__/Header.spec.js
+++ b/src/__tests__/Header.spec.js
@@ -5,6 +5,7 @@ const TestUtils     = require('react/lib/ReactTestUtils');
 const rewireModule  = require('../../test/rewireModule');
 const StubComponent = require('../../test/StubComponent');
 const helpers       = require('./GridPropHelpers');
+import { shallow } from 'enzyme';
 
 describe('Header Unit Tests', () => {
   let header;
@@ -94,6 +95,79 @@ describe('Header Unit Tests', () => {
 
     it('header row drag end should trigger onColumnResize callback', () => {
       shouldTriggerOnColumnResize();
+    });
+  });
+
+  describe('Rendering Header component', () => {
+    const renderComponent = (props) => {
+      const wrapper = shallow(<Header {...props} />);
+      return wrapper;
+    };
+    let testRequiredProps = {
+      columnMetrics: {
+        columns: helpers.columns,
+        minColumnWidth: 81,
+        totalWidth: true,
+        width: 2601
+      },
+      height: 51,
+      headerRows: [{height: 51, ref: 'row'}]
+    };
+    let testAllProps = {
+      columnMetrics: {
+        columns: helpers.columns,
+        minColumnWidth: 80,
+        totalWidth: true,
+        width: 2600
+      },
+      totalWidth: 1000,
+      height: 50,
+      headerRows: [{height: 50, ref: 'row'}],
+      sortColumn: 'sortColumnValue',
+      sortDirection: 'DESC',
+      onSort: jasmine.createSpy(),
+      onColumnResize: jasmine.createSpy(),
+      onScroll: jasmine.createSpy(),
+      draggableHeaderCell: jasmine.createSpy(),
+      getValidFilterValues: jasmine.createSpy()
+    };
+    it('passes classname property', () => {
+      const wrapper = renderComponent(testAllProps);
+      const headerDiv = wrapper.find('div');
+      expect(headerDiv.hasClass('react-grid-Header'));
+    });
+    it('passes style property', () => {
+      const wrapper = renderComponent(testAllProps);
+      const headerDiv = wrapper.find('div');
+      expect(headerDiv.props().style).toBeDefined();
+    });
+    it('passes height property', () => {
+      const wrapper = renderComponent(testAllProps);
+      const headerDiv = wrapper.find('div');
+      expect(headerDiv.props().height).toBe(50);
+    });
+    it('passes onScroll property, if available from props', () => {
+      const wrapper = renderComponent(testAllProps);
+      const headerDiv = wrapper.find('div');
+      expect(headerDiv.props().onScroll).toBe(testAllProps.onScroll);
+    });
+    it('does not pass onScroll properties if it is not available from props', () => {
+      const wrapper = renderComponent(testRequiredProps);
+      const headerDiv = wrapper.find('div');
+      expect(headerDiv.props().onScroll).toBeUndefined();
+    });
+    it('does not pass unknown properties to the div', () => {
+      const wrapper = renderComponent(testAllProps);
+      const headerDiv = wrapper.find('div');
+      expect(headerDiv.props().columnMetrics).toBeUndefined();
+      expect(headerDiv.props().totalWidth).toBeUndefined();
+      expect(headerDiv.props().headerRows).toBeUndefined();
+      expect(headerDiv.props().sortColumn).toBeUndefined();
+      expect(headerDiv.props().sortDirection).toBeUndefined();
+      expect(headerDiv.props().onSort).toBeUndefined();
+      expect(headerDiv.props().onColumnResize).toBeUndefined();
+      expect(headerDiv.props().draggableHeaderCell).toBeUndefined();
+      expect(headerDiv.props().getValidFilterValues).toBeUndefined();
     });
   });
 });

--- a/src/__tests__/HeaderCell.spec.js
+++ b/src/__tests__/HeaderCell.spec.js
@@ -4,6 +4,7 @@ const HeaderCell    = rewire('../HeaderCell');
 const TestUtils     = require('react/lib/ReactTestUtils');
 const rewireModule  = require('../../test/rewireModule');
 const StubComponent = require('../../test/StubComponent');
+import SortableHeaderCell from '../addons/cells/headerCells/SortableHeaderCell';
 
 describe('Header Cell Tests', () => {
   // Configure local constiable replacements for the module.
@@ -134,6 +135,30 @@ describe('Header Cell Tests', () => {
       expect(testProps.onResizeEnd).toHaveBeenCalled();
       expect(testProps.onResizeEnd.calls.mostRecent().args[0]).toEqual(testProps.column);
       expect(testProps.onResizeEnd.calls.mostRecent().args[1]).toEqual(250);
+    });
+  });
+
+  describe('getCell method', () => {
+    it('pass the column as property to cell renderer if it is a function', () => {
+      let rendererFunction = jasmine.createSpy();
+      let props = Object.assign({}, testProps, {renderer: rendererFunction});
+      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...props}/>);
+      headerCell.getCell();
+      expect(rendererFunction.calls.argsFor(0)[0]).toEqual({column: props.column});
+    });
+    it('should not pass the column as property to cell renderer if it is an HTML element', () => {
+      let renderer = <div>Value</div>;
+      let props = Object.assign({}, testProps, {renderer: renderer});
+      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...props}/>);
+      let cell = headerCell.getCell();
+      expect(cell.props.column).toBeUndefined();
+    });
+    it('should pass the column as property to cell renderer if it is a React class', () => {
+      let renderer = <SortableHeaderCell columnKey="colKey" onSort={jasmine.createSpy()} />;
+      let props = Object.assign({}, testProps, {renderer: renderer});
+      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...props}/>);
+      let cell = headerCell.getCell();
+      expect(cell.props.column).toBe(props.column);
     });
   });
 });

--- a/src/__tests__/HeaderRow.spec.js
+++ b/src/__tests__/HeaderRow.spec.js
@@ -5,6 +5,7 @@ const rewireModule  = require('../../test/rewireModule');
 const StubComponent = require('../../test/StubComponent');
 const helpers       = require('./GridPropHelpers');
 const HeaderRow     = rewire('../HeaderRow');
+import { shallow } from 'enzyme';
 
 describe('Header Row Unit Tests', () => {
   let headerRow;
@@ -125,6 +126,103 @@ describe('Header Row Unit Tests', () => {
 
     afterEach(() => {
       testProps.columns[customColumnIdx].headerRenderer = null;
+    });
+  });
+
+  describe('Rendering HeaderRow component', () => {
+    const renderComponent = (props) => {
+      const wrapper = shallow(<HeaderRow {...props} />);
+      return wrapper;
+    };
+
+    const onScroll = jasmine.createSpy();
+
+    const requiredProps = {
+      height: 35,
+      columns: helpers.columns,
+      onSort: jasmine.createSpy()
+    };
+
+    const allProperties = {
+      width: 200,
+      height: 35,
+      columns: helpers.columns,
+      onColumnResize: jasmine.createSpy(),
+      onSort: jasmine.createSpy(),
+      onColumnResizeEnd: jasmine.createSpy(),
+      style: {overflow: 'scroll',
+        width: 201,
+        height: 36,
+        position: 'relative'
+      },
+      sortColumn: 'sortColumnValue',
+      sortDirection: 'NONE',
+      cellRenderer: jasmine.createSpy(),
+      headerCellRenderer: jasmine.createSpy(),
+      filterable: true,
+      onFilterChange: jasmine.createSpy(),
+      resizing: {key: 'value'},
+      onScroll,
+      rowType: 'rowTypeValue',
+      draggableHeaderCell: jasmine.createSpy()
+    };
+
+    it('passes classname property', () => {
+      const wrapper = renderComponent(requiredProps);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.hasClass('react-grid-HeaderRow'));
+    });
+    it('passes width if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().width).toBe(200);
+    });
+    it('does not pass width if not available from props', () => {
+      const wrapper = renderComponent(requiredProps);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().width).toBeUndefined();
+    });
+    it('passes height property', () => {
+      const wrapper = renderComponent(allProperties);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().height).toBe(35);
+    });
+    it('passes style property, if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().style).toBe(allProperties.style);
+    });
+    it('does not pass style if not available from props', () => {
+      const wrapper = renderComponent(requiredProps);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().style).toBeUndefined();
+    });
+    it('passes onScroll property, if available from props', () => {
+      const wrapper = renderComponent(allProperties);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().onScroll).toBe(onScroll);
+    });
+    it('does not pass onScroll if not available from props', () => {
+      const wrapper = renderComponent(requiredProps);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().onScoll).toBeUndefined();
+    });
+    it('does not pass unknown properties to the div', () => {
+      const wrapper = renderComponent(allProperties);
+      const headerRowDiv = wrapper.find('div').at(0);
+      expect(headerRowDiv.props().columns).toBeUndefined();
+      expect(headerRowDiv.props().onColumnResize).toBeUndefined();
+      expect(headerRowDiv.props().onSort).toBeUndefined();
+      expect(headerRowDiv.props().onColumnResizeEnd).toBeUndefined();
+      expect(headerRowDiv.props().sortColumn).toBeUndefined();
+      expect(headerRowDiv.props().sortDirection).toBeUndefined();
+      expect(headerRowDiv.props().cellRenderer).toBeUndefined();
+      expect(headerRowDiv.props().headerCellRenderer).toBeUndefined();
+      expect(headerRowDiv.props().filterable).toBeUndefined();
+      expect(headerRowDiv.props().onFilterChange).toBeUndefined();
+      expect(headerRowDiv.props().resizing).toBeUndefined();
+      expect(headerRowDiv.props().rowType).toBeUndefined();
+      expect(headerRowDiv.props().draggableHeaderCell).toBeUndefined();
     });
   });
 });

--- a/src/__tests__/Row.spec.js
+++ b/src/__tests__/Row.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import Row from '../Row';
+import { shallow } from 'enzyme';
+import * as helpers from './GridPropHelpers';
 
 describe('Row', () => {
   let fakeProps = {
@@ -31,6 +33,98 @@ describe('Row', () => {
         let containsExtraClass = row.className.indexOf(c) > -1;
         expect(containsExtraClass).toBe(true);
       });
+    });
+  });
+
+  describe('Rendering Row component', () => {
+    const renderComponent = (props) => {
+      const wrapper = shallow(<Row {...props} />);
+      return wrapper;
+    };
+
+    const requiredProperties = {
+      height: 30,
+      columns: helpers.columns,
+      row: {key: 'value'},
+      idx: 17,
+      colVisibleStart: 1,
+      colVisibleEnd: 2,
+      colDisplayStart: 3,
+      colDisplayEnd: 4,
+      isScrolling: true
+    };
+
+    const allProperties = {
+      height: 35,
+      columns: helpers.columns,
+      row: {key: 'value', name: 'name'},
+      cellRenderer: jasmine.createSpy(),
+      cellMetaData: {
+        selected: {idx: 2, rowIdx: 3},
+        dragged: null,
+        onCellClick: jasmine.createSpy(),
+        onCellContextMenu: jasmine.createSpy(),
+        onCellDoubleClick: jasmine.createSpy(),
+        onCommit: jasmine.createSpy(),
+        onCommitCancel: jasmine.createSpy(),
+        copied: null,
+        handleDragEnterRow: jasmine.createSpy(),
+        handleTerminateDrag: jasmine.createSpy(),
+        onColumnEvent: jasmine.createSpy()
+      },
+      isSelected: false,
+      idx: 18,
+      expandedRows: [{key: 'one'}, {key: 'two'}],
+      extraClasses: 'extra-classes',
+      forceUpdate: false,
+      subRowDetails: {name: 'subrowname'},
+      isRowHovered: false,
+      colVisibleStart: 0,
+      colVisibleEnd: 1,
+      colDisplayStart: 2,
+      colDisplayEnd: 3,
+      isScrolling: false
+    };
+
+    it('passes classname property', () => {
+      const wrapper = renderComponent(requiredProperties);
+      const draggableDiv = wrapper.find('div').at(0);
+      expect(draggableDiv.hasClass('react-grid-Row'));
+    });
+    it('passes style property', () => {
+      const wrapper = renderComponent(requiredProperties);
+      const draggableDiv = wrapper.find('div').at(0);
+      expect(draggableDiv.props().style).toBeDefined();
+    });
+    it('passes onDragEnter property', () => {
+      const wrapper = renderComponent(requiredProperties);
+      const draggableDiv = wrapper.find('div');
+      expect(draggableDiv.props().onDragEnter).toBeDefined();
+    });
+    it('passes height property', () => {
+      const wrapper = renderComponent(requiredProperties);
+      const draggableDiv = wrapper.find('div').at(0);
+      expect(draggableDiv.props().height).toBe(30);
+    });
+    it('does not pass unknown properties to the div', () => {
+      const wrapper = renderComponent(allProperties);
+      const draggableDiv = wrapper.find('div').at(0);
+      expect(draggableDiv.props().columns).toBeUndefined();
+      expect(draggableDiv.props().row).toBeUndefined();
+      expect(draggableDiv.props().cellRenderer).toBeUndefined();
+      expect(draggableDiv.props().cellMetaData).toBeUndefined();
+      expect(draggableDiv.props().isSelected).toBeUndefined();
+      expect(draggableDiv.props().idx).toBeUndefined();
+      expect(draggableDiv.props().expandedRows).toBeUndefined();
+      expect(draggableDiv.props().extraClasses).toBeUndefined();
+      expect(draggableDiv.props().forceUpdate).toBeUndefined();
+      expect(draggableDiv.props().subRowDetails).toBeUndefined();
+      expect(draggableDiv.props().isRowHovered).toBeUndefined();
+      expect(draggableDiv.props().colVisibleStart).toBeUndefined();
+      expect(draggableDiv.props().colVisibleEnd).toBeUndefined();
+      expect(draggableDiv.props().colDisplayStart).toBeUndefined();
+      expect(draggableDiv.props().colDisplayEnd).toBeUndefined();
+      expect(draggableDiv.props().isScrolling).toBeUndefined();
     });
   });
 });

--- a/src/addons/editors/EditorContainer.js
+++ b/src/addons/editors/EditorContainer.js
@@ -284,7 +284,7 @@ const EditorContainer = React.createClass({
 
   render(): ?ReactElement {
     return (
-        <div className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} commit={this.commit}>
+        <div className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown}>
           {this.createEditor()}
           {this.renderStatusIcon()}
         </div>

--- a/src/addons/editors/__tests__/EditorContainer.spec.js
+++ b/src/addons/editors/__tests__/EditorContainer.spec.js
@@ -6,6 +6,7 @@ const EditorContainer  = rewire('../EditorContainer.js');
 const TestUtils        = require('react/lib/ReactTestUtils');
 const SimpleTextEditor = require('../SimpleTextEditor');
 const EditorBase       = require('../EditorBase');
+import { shallow } from 'enzyme';
 
 describe('Editor Container Tests', () => {
   let cellMetaData = {
@@ -67,6 +68,26 @@ describe('Editor Container Tests', () => {
       let editor = TestUtils.findRenderedComponentWithType(component, SimpleTextEditor);
       expect(editor.props.value).toEqual('Adwolf');
       expect(editor.props.column).toEqual(fakeColumn);
+    });
+
+    it('should render the editor container div with correct properties', () => {
+      const renderComponent = (props) => {
+        const wrapper = shallow(<EditorContainer {...props} />);
+        return wrapper;
+      };
+      const props = {
+        rowData: rowData,
+        value: 'Adwolf',
+        cellMetaData: cellMetaData,
+        column: fakeColumn,
+        height: 50
+      };
+      let editorDiv = renderComponent(props).find('div').at(0);
+      expect(Object.keys(editorDiv.props()).length).toBe(4);
+      expect(editorDiv.props().className).toBeDefined();
+      expect(editorDiv.props().onBlur).toBeDefined();
+      expect(editorDiv.props().onKeyDown).toBeDefined();
+      expect(editorDiv.props().children).toBeDefined();
     });
   });
 

--- a/src/createObjectWithProperties.js
+++ b/src/createObjectWithProperties.js
@@ -1,0 +1,11 @@
+function createObjectWithProperties(originalObj: any, properties: any): any {
+  let result = {};
+  for (let property of properties) {
+    if (originalObj[property]) {
+      result[property] = originalObj[property];
+    }
+  }
+  return result;
+}
+
+module.exports = createObjectWithProperties;


### PR DESCRIPTION
## Description
Only pass known properties when rendering divs

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [n/a ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
See #418 


**What is the new behavior?**
Only known properties will be passed to divs, so will not print warnings about unknown props to the console.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

