### PR TITLE
Fix for #531

### DIFF
--- a/src/HeaderCell.js
+++ b/src/HeaderCell.js
@@ -4,7 +4,6 @@ const joinClasses    = require('classnames');
 const ExcelColumn    = require('./PropTypeShapes/ExcelColumn');
 const ResizeHandle   = require('./ResizeHandle');
 const PropTypes      = React.PropTypes;
-import shallowCompare from 'react-addons-shallow-compare';
 
 function simpleCellRenderer(objArgs: {column: {name: string}}): ReactElement {
   return <div className="widget-HeaderCell__value">{objArgs.column.name}</div>;
@@ -29,10 +28,6 @@ const HeaderCell = React.createClass({
 
   getInitialState(): {resizing: boolean} {
     return {resizing: false};
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState) && (this.props.column.width !== nextProps.column.width || this.props.column.left !== nextProps.column.left || this.props.column.name !== nextProps.column.name || this.props.column.cellClass !== nextProps.column.cellClass);
   },
 
   onDragStart(e: SyntheticMouseEvent) {

--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -18,8 +18,6 @@ const HeaderRowStyle  = {
   position: React.PropTypes.string
 };
 
-const DEFINE_SORT = ['ASC', 'DESC', 'NONE'];
-
 // The list of the propTypes that we want to include in the HeaderRow div
 const knownDivPropertyKeys = ['width', 'height', 'style', 'onScroll'];
 
@@ -33,7 +31,7 @@ const HeaderRow = React.createClass({
     onColumnResizeEnd: PropTypes.func,
     style: PropTypes.shape(HeaderRowStyle),
     sortColumn: PropTypes.string,
-    sortDirection: React.PropTypes.oneOf(DEFINE_SORT),
+    sortDirection: React.PropTypes.oneOf(SortableHeaderCell.DEFINE_SORT),
     cellRenderer: PropTypes.func,
     headerCellRenderer: PropTypes.func,
     filterable: PropTypes.bool,
@@ -76,7 +74,7 @@ const HeaderRow = React.createClass({
   },
 
   getSortableHeaderCell(column) {
-    let sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : DEFINE_SORT.NONE;
+    let sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
     return <SortableHeaderCell columnKey={column.key} onSort={this.props.onSort} sortDirection={sortDirection}/>;
   },
 

--- a/src/__tests__/HeaderCell.spec.js
+++ b/src/__tests__/HeaderCell.spec.js
@@ -43,27 +43,6 @@ describe('Header Cell Tests', () => {
     );
   });
 
-  describe('shouldComponentUpdate method', () => {
-    it('should return true if the column width property is updated (which can happen if column width is not set explicitly)', () => {
-      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
-      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {width: 100})});
-      let nextState = Object.assign({}, headerCell.state);
-      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true);
-    });
-    it('should return true if the column left property is updated (which can happen if column width is not set explicitly)', () => {
-      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
-      let nextProps = Object.assign({}, testProps, {column: Object.assign({}, testProps.column, {left: 100})});
-      let nextState = Object.assign({}, headerCell.state);
-      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(true);
-    });
-    it('should return false if the column left and width properties are not updated', () => {
-      headerCell = TestUtils.renderIntoDocument(<HeaderCell {...testProps}/>);
-      let nextProps = Object.assign({}, testProps);
-      let nextState = Object.assign({}, headerCell.state);
-      expect(headerCell.shouldComponentUpdate(nextProps, nextState)).toBe(false);
-    });
-  });
-
   describe('When custom render is supplied', () => {
     it('will render', () => {
       let CustomRenderer = new StubComponent('CustomRenderer');

--- a/src/addons/cells/headerCells/SortableHeaderCell.js
+++ b/src/addons/cells/headerCells/SortableHeaderCell.js
@@ -63,3 +63,4 @@ const SortableHeaderCell = React.createClass({
 });
 
 module.exports = SortableHeaderCell;
+module.exports.DEFINE_SORT = DEFINE_SORT;


### PR DESCRIPTION
## Description
Fixes column sorting issue #531 

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
See #531 


**What is the new behavior?**
When grid column is sortable, you should be able to click on the column header and change the sort direction, NONE -> ASC -> DESC -> NONE, which was the previous behaviour

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
* While investigating this issue, I noticed HeaderRow redefined DEFINE_SORT as an array and was using it incorrectly (ie calling DEFINE_SORT.NONE)
* I considered different ways of implementing this - eg pass sortColumn & sortDescription as props to HeaderCell and then checking if these changed, to compare in shouldComponentUpdate method whether the renderers had changed but this always returned true. In the end I thought the best way to do this was to remove the shouldComponentUpdate method because we are allowing users to define different renderers which might change without us being able to accurately detect it in the HeaderCell method.
