### PR TITLE
Revert "Check for existing drag and drop context before creating"

### DIFF
--- a/src/addons/draggable/DragDropContainer.js
+++ b/src/addons/draggable/DragDropContainer.js
@@ -1,16 +1,11 @@
 import React, {Component} from 'react';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { DragDropContext } from 'react-dnd';
 import DraggableHeaderCell from './DraggableHeaderCell';
 import RowDragLayer from './RowDragLayer';
 import isColumnsImmutable from '../../isColumnsImmutable';
-import getDndContext from './dnd-context';
 
 class DraggableContainer extends Component {
-
-  getChildContext() {
-    return {
-      dragDropManager: getDndContext(this.context)
-    };
-  }
 
   getRows(rowsCount, rowGetter) {
     let rows = [];
@@ -39,17 +34,9 @@ class DraggableContainer extends Component {
   }
 }
 
-DraggableContainer.childContextTypes = {
-  dragDropManager: React.PropTypes.object.isRequired
-};
-
-DraggableContainer.contextTypes = {
-  dragDropManager: React.PropTypes.object
-};
-
 DraggableContainer.propTypes = {
   children: React.PropTypes.element.isRequired,
   getDragPreviewRow: React.PropTypes.func
 };
 
-export default DraggableContainer;
+export default DragDropContext(HTML5Backend)(DraggableContainer);

--- a/src/addons/draggable/__tests__/DragDropContainer.spec.js
+++ b/src/addons/draggable/__tests__/DragDropContainer.spec.js
@@ -16,7 +16,7 @@ describe('<DragDropContainer />', () => {
   const GridStub = () => <div/>;
 
   function render(props = {}) {
-    let ComponentUnderTest = DragDropContainer;
+    let ComponentUnderTest = DragDropContainer.DecoratedComponent;
     wrapper = shallow(
       <ComponentUnderTest {...props} >
         <GridStub {...childProps} />

--- a/src/addons/draggable/dnd-context.js
+++ b/src/addons/draggable/dnd-context.js
@@ -1,6 +1,0 @@
-import { DragDropManager } from 'dnd-core';
-import HTML5Backend from 'react-dnd-html5-backend';
-
-export default function getDndContext(context) {
-  return context.dragDropManager || new DragDropManager(HTML5Backend);
-}


### PR DESCRIPTION
Reverts adazzle/react-data-grid#467

This is causing script errors when used alongside React Context Menu

Needs further investigation