### PR TITLE
Fix Issue 556

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -96,6 +96,7 @@ const Grid = React.createClass({
           onSort={this.props.onSort}
           onScroll={this.onHeaderScroll}
           getValidFilterValues={this.props.getValidFilterValues}
+          cellMetaData={this.props.cellMetaData}
           />
           {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
             <div ref="viewPortContainer" tabIndex="0" onKeyDown={this.props.onViewportKeydown} onKeyUp={this.props.onViewportKeyup} onDoubleClick={this.props.onViewportDoubleClick}   onDragStart={this.props.onViewportDragStart} onDragEnd={this.props.onViewportDragEnd}>

--- a/src/Header.js
+++ b/src/Header.js
@@ -7,6 +7,7 @@ const ColumnUtils         = require('./ColumnUtils');
 const HeaderRow           = require('./HeaderRow');
 const PropTypes           = React.PropTypes;
 const createObjectWithProperties = require('./createObjectWithProperties');
+const cellMetaDataShape    = require('./PropTypeShapes/CellMetaDataShape');
 
 type Column = {
   width: number
@@ -27,7 +28,8 @@ const Header = React.createClass({
     onColumnResize: PropTypes.func,
     onScroll: PropTypes.func,
     draggableHeaderCell: PropTypes.func,
-    getValidFilterValues: PropTypes.func
+    getValidFilterValues: PropTypes.func,
+    cellMetaData: PropTypes.shape(cellMetaDataShape)
   },
 
   getInitialState(): {resizing: any} {
@@ -179,6 +181,11 @@ const Header = React.createClass({
     return createObjectWithProperties(this.props, knownDivPropertyKeys);
   },
 
+  // Set the cell selection to -1 x -1 when clicking on the header
+  onHeaderClick() {
+    this.props.cellMetaData.onCellClick({rowIdx: -1, idx: -1 });
+  },
+
   render(): ?ReactElement {
     let className = joinClasses({
       'react-grid-Header': true,
@@ -187,7 +194,7 @@ const Header = React.createClass({
     let headerRows = this.getHeaderRows();
 
     return (
-      <div {...this.getKnownDivProps()} style={this.getStyle()} className={className}>
+      <div {...this.getKnownDivProps()} style={this.getStyle()} className={className} onClick={this.onHeaderClick}>
         {headerRows}
       </div>
     );

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -189,6 +189,9 @@ const ReactDataGrid = React.createClass({
             this.props.onCellSelected(selected);
           }
         });
+      } else {
+        // When it's outside of the grid, set rowIdx anyway
+        this.setState({selected: { idx, rowIdx }});
       }
     }
   },

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -189,7 +189,7 @@ const ReactDataGrid = React.createClass({
             this.props.onCellSelected(selected);
           }
         });
-      } else {
+      } else if (selected.rowIdx === -1 && selected.idx === -1) {
         // When it's outside of the grid, set rowIdx anyway
         this.setState({selected: { idx, rowIdx }});
       }

--- a/src/__tests__/Header.spec.js
+++ b/src/__tests__/Header.spec.js
@@ -129,7 +129,16 @@ describe('Header Unit Tests', () => {
       onColumnResize: jasmine.createSpy(),
       onScroll: jasmine.createSpy(),
       draggableHeaderCell: jasmine.createSpy(),
-      getValidFilterValues: jasmine.createSpy()
+      getValidFilterValues: jasmine.createSpy(),
+      cellMetaData: {
+        onCommitCancel: () => {},
+        onCommit: () => {},
+        onCellDoubleClick: () => {},
+        onCellClick: () => {},
+        handleDragEnterRow: () => {},
+        handleTerminateDrag: () => {},
+        selected: { rowIdx: 0, id: 1 }
+      }
     };
     it('passes classname property', () => {
       const wrapper = renderComponent(testAllProps);
@@ -168,6 +177,14 @@ describe('Header Unit Tests', () => {
       expect(headerDiv.props().onColumnResize).toBeUndefined();
       expect(headerDiv.props().draggableHeaderCell).toBeUndefined();
       expect(headerDiv.props().getValidFilterValues).toBeUndefined();
+    });
+
+    it('execute onCellClick event on cellMetaData', () => {
+      spyOn(testAllProps.cellMetaData, 'onCellClick');
+      const wrapper = renderComponent(testAllProps);
+      const headerDiv = wrapper.find('div');
+      headerDiv.simulate('click');
+      expect(testAllProps.cellMetaData.onCellClick).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/Header.spec.js
+++ b/src/__tests__/Header.spec.js
@@ -8,7 +8,7 @@ const helpers       = require('./GridPropHelpers');
 import { shallow } from 'enzyme';
 const SCROLL_BAR_SIZE = 20;
 
-fdescribe('Header Unit Tests', () => {
+describe('Header Unit Tests', () => {
   let header;
   // Configure local letiable replacements for the module.
   let HeaderRowStub = new StubComponent('HeaderRow');

--- a/src/__tests__/Header.spec.js
+++ b/src/__tests__/Header.spec.js
@@ -8,7 +8,7 @@ const helpers       = require('./GridPropHelpers');
 import { shallow } from 'enzyme';
 const SCROLL_BAR_SIZE = 20;
 
-describe('Header Unit Tests', () => {
+fdescribe('Header Unit Tests', () => {
   let header;
   // Configure local letiable replacements for the module.
   let HeaderRowStub = new StubComponent('HeaderRow');
@@ -137,7 +137,7 @@ describe('Header Unit Tests', () => {
         onCommitCancel: () => {},
         onCommit: () => {},
         onCellDoubleClick: () => {},
-        onCellClick: () => {},
+        onCellClick: () => { },
         handleDragEnterRow: () => {},
         handleTerminateDrag: () => {},
         selected: { rowIdx: 0, id: 1 }
@@ -188,12 +188,13 @@ describe('Header Unit Tests', () => {
       expect(headerDiv.props().getValidFilterValues).toBeUndefined();
     });
 
-    it('execute onCellClick event on cellMetaData', () => {
+    it('execute onCellClick event on cellMetaData and rowIdx & idx = -1', () => {
       spyOn(testAllProps.cellMetaData, 'onCellClick');
       const wrapper = renderComponent(testAllProps);
       const headerDiv = wrapper.find('div');
       headerDiv.simulate('click');
       expect(testAllProps.cellMetaData.onCellClick).toHaveBeenCalled();
+      expect(testAllProps.cellMetaData.onCellClick.calls.mostRecent().args[0]).toEqual({ rowIdx: -1, idx: -1 });
     });
   });
 });


### PR DESCRIPTION
## Description
Fix https://github.com/adazzle/react-data-grid/issues/556

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
New checkFocus method was implemented recently on Cell component. This method checks the selected cell when filters are selected and used. The problem is that [0,0] is selected when filters are used, causing [0,0] to be focused after filter change.


**What is the new behavior?**
When the user clicks on the Header, we call a new method onHeaderClick which sets [-1,-1] as the current selection of the Grid using onCellClick from cellMetaData (injected as a new prop to the Header component).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```