### PR TITLE
Issue 512: Correctly Render filter instead of custom header renderer 

### DIFF
--- a/src/HeaderRow.js
+++ b/src/HeaderRow.js
@@ -80,7 +80,7 @@ const HeaderRow = React.createClass({
 
   getHeaderRenderer(column) {
     let renderer;
-    if (column.headerRenderer) {
+    if (column.headerRenderer && !this.props.filterable) {
       renderer = column.headerRenderer;
     } else {
       let headerCellType = this.getHeaderCellType(column);

--- a/src/__tests__/HeaderRow.spec.js
+++ b/src/__tests__/HeaderRow.spec.js
@@ -124,6 +124,13 @@ describe('Header Row Unit Tests', () => {
       expect(TestUtils.isElementOfType(headerCells[customColumnIdx].props.renderer, CustomHeaderStub)).toBe(true);
     });
 
+    it('should render filter if header row if row and column is filterable', () => {
+      testProps.columns[customColumnIdx].filterable = true;
+      headerRow = TestUtils.renderIntoDocument(<HeaderRow {...testProps} filterable={true} />);
+      let headerCells = TestUtils.scryRenderedComponentsWithType(headerRow, HeaderCellStub);
+      expect(TestUtils.isElementOfType(headerCells[customColumnIdx].props.renderer, FilterableHeaderCellStub)).toBe(true);
+    });
+
     afterEach(() => {
       testProps.columns[customColumnIdx].headerRenderer = null;
     });


### PR DESCRIPTION
Linked Issue
https://github.com/adazzle/react-data-grid/issues/512

## Description
This PR fixes the issue where specifying a custom header renderer overrides the filter renderer for a filterable cell.  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When using headerRenderer and filterable, the filterable row just duplicates headerRenderer and does not have an associated input 


**What is the new behavior?**
The filter renderer is displayed correctly


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

…lterable