### PR TITLE
Fix for header scroll when container/grid width cannot be determined

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -92,11 +92,12 @@ const Header = React.createClass({
         rowHeight = '500px';
       }
       let scrollbarSize = getScrollbarSize() > 0 ? getScrollbarSize() : 0;
+      let updatedWidth = isNaN(this.props.totalWidth - scrollbarSize) ? this.props.totalWidth : this.props.totalWidth - scrollbarSize;
       let headerRowStyle = {
         position: 'absolute',
         top: this.getCombinedHeaderHeights(index),
         left: 0,
-        width: this.props.totalWidth - scrollbarSize,
+        width: updatedWidth,
         overflowX: 'hidden',
         minHeight: rowHeight
       };


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When the container width cannot be determined the header will not scroll.

This is because this.props.totalWidth will be 100%.

and when the headerRowStyle gets calculated the code will attempt to do:
"100%" - scrollbarSize
which will result in NaN



**What is the new behavior?**
The header should scroll correctly


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
