### PR TITLE
getSortByText: String.fromCharCode('') results in square character in newer Chrome

### DIFF
--- a/src/addons/cells/headerCells/SortableHeaderCell.js
+++ b/src/addons/cells/headerCells/SortableHeaderCell.js
@@ -38,10 +38,9 @@ const SortableHeaderCell = React.createClass({
   getSortByText: function() {
     let unicodeKeys = {
       ASC: '9650',
-      DESC: '9660',
-      NONE: ''
+      DESC: '9660'
     };
-    return String.fromCharCode(unicodeKeys[this.props.sortDirection]);
+    return this.props.sortDirection == 'NONE' ? '' : String.fromCharCode(unicodeKeys[this.props.sortDirection]);
   },
 
   render: function(): ?ReactElement {


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When creating the icon for indicating sort direction on each column `String.fromCharCode('')` is called when the sort direction for the column is `NONE`.
In the latest version of Chrome this results in a square, rather than nothing.
![square](https://cloud.githubusercontent.com/assets/769579/21589020/749df9f2-d0ed-11e6-905a-54c4698ca021.png)



**What is the new behavior?**
When determining indicator character sort direction is checked, if it is `NONE` empty string is returned rather than making a call to `String.fromCharCode`


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
