### PR TITLE
Fix dragging when reordering rows

### DIFF
--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -174,12 +174,7 @@ const ReactDataGrid = React.createClass({
       || this.state.selected.active === false) {
       let idx = selected.idx;
       let rowIdx = selected.rowIdx;
-      if (
-          idx >= 0
-          && rowIdx >= 0
-          && idx < ColumnUtils.getSize(this.state.columnMetrics.columns)
-          && rowIdx < this.props.rowsCount
-        ) {
+      if (this.isCellWithinBounds(selected)) {
         const oldSelection = this.state.selected;
         this.setState({selected: selected}, () => {
           if (typeof this.props.onCellDeSelected === 'function') {
@@ -189,7 +184,7 @@ const ReactDataGrid = React.createClass({
             this.props.onCellSelected(selected);
           }
         });
-      } else if (selected.rowIdx === -1 && selected.idx === -1) {
+      } else if (rowIdx === -1 && idx === -1) {
         // When it's outside of the grid, set rowIdx anyway
         this.setState({selected: { idx, rowIdx }});
       }
@@ -369,16 +364,18 @@ const ReactDataGrid = React.createClass({
     }
   },
 
+  isCellWithinBounds(cell) {
+    const idx = cell.idx;
+    const rowIdx = cell.rowIdx;
+    return idx >= 0
+      && rowIdx >= 0
+      && idx < ColumnUtils.getSize(this.state.columnMetrics.columns)
+      && rowIdx < this.props.rowsCount;
+  },
+
   handleDragStart(dragged: DraggedType) {
     if (!this.dragEnabled()) { return; }
-    let idx = dragged.idx;
-    let rowIdx = dragged.rowIdx;
-    if (
-        idx >= 0
-        && rowIdx >= 0
-        && idx < this.getSize()
-        && rowIdx < this.props.rowsCount
-      ) {
+    if (this.isCellWithinBounds(dragged)) {
       this.setState({ dragged: dragged });
     }
   },

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -317,7 +317,9 @@ const ReactDataGrid = React.createClass({
 
   onDragStart(e: SyntheticEvent) {
     let idx = this.state.selected.idx;
-    if (idx > -1) {
+    // To prevent dragging down/up when reordering rows.
+    const isDragging = e && e.target && e.target.className === 'drag-handle';
+    if (idx > -1 && isDragging) {
       let value = this.getSelectedValue();
       this.handleDragStart({idx: this.state.selected.idx, rowIdx: this.state.selected.rowIdx, value: value});
       // need to set dummy data for FF

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -327,7 +327,7 @@ const ReactDataGrid = React.createClass({
         if (e.dataTransfer.setData) {
           e.dataTransfer.dropEffect = 'move';
           e.dataTransfer.effectAllowed = 'move';
-          e.dataTransfer.setData('text/plain', 'dummy');
+          e.dataTransfer.setData('text/plain', '');
         }
       }
     }

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -318,8 +318,8 @@ const ReactDataGrid = React.createClass({
   onDragStart(e: SyntheticEvent) {
     let idx = this.state.selected.idx;
     // To prevent dragging down/up when reordering rows.
-    const isDragging = e && e.target && e.target.className;
-    if (idx > -1 && isDragging) {
+    const isViewportDragging = e && e.target && e.target.className;
+    if (idx > -1 && isViewportDragging) {
       let value = this.getSelectedValue();
       this.handleDragStart({idx: this.state.selected.idx, rowIdx: this.state.selected.rowIdx, value: value});
       // need to set dummy data for FF
@@ -366,9 +366,7 @@ const ReactDataGrid = React.createClass({
     }
   },
 
-  isCellWithinBounds(cell) {
-    const idx = cell.idx;
-    const rowIdx = cell.rowIdx;
+  isCellWithinBounds({idx, rowIdx}) {
     return idx >= 0
       && rowIdx >= 0
       && idx < ColumnUtils.getSize(this.state.columnMetrics.columns)
@@ -384,8 +382,7 @@ const ReactDataGrid = React.createClass({
 
   handleDragEnd() {
     if (!this.dragEnabled()) { return; }
-    const selected = this.state.selected;
-    const dragged = this.state.dragged;
+    const { selected, dragged } = this.state;
     const column = this.getColumn(this.state.selected.idx);
     if (selected && dragged && column) {
       let cellKey = column.key;

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -318,7 +318,7 @@ const ReactDataGrid = React.createClass({
   onDragStart(e: SyntheticEvent) {
     let idx = this.state.selected.idx;
     // To prevent dragging down/up when reordering rows.
-    const isDragging = e && e.target && e.target.className === 'drag-handle';
+    const isDragging = e && e.target && e.target.className;
     if (idx > -1 && isDragging) {
       let value = this.getSelectedValue();
       this.handleDragStart({idx: this.state.selected.idx, rowIdx: this.state.selected.rowIdx, value: value});

--- a/src/ReactDataGrid.js
+++ b/src/ReactDataGrid.js
@@ -385,17 +385,19 @@ const ReactDataGrid = React.createClass({
 
   handleDragEnd() {
     if (!this.dragEnabled()) { return; }
-    let selected = this.state.selected;
-    let dragged = this.state.dragged;
-    let cellKey = this.getColumn(this.state.selected.idx).key;
-    let fromRow = selected.rowIdx < dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
-    let toRow   = selected.rowIdx > dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
-    if (this.props.onCellsDragged) {
-      this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
-    }
-
-    if (this.props.onGridRowsUpdated) {
-      this.onGridRowsUpdated(cellKey, fromRow, toRow, {[cellKey]: dragged.value}, AppConstants.UpdateActions.CELL_DRAG);
+    const selected = this.state.selected;
+    const dragged = this.state.dragged;
+    const column = this.getColumn(this.state.selected.idx);
+    if (selected && dragged && column) {
+      let cellKey = column.key;
+      let fromRow = selected.rowIdx < dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
+      let toRow   = selected.rowIdx > dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
+      if (this.props.onCellsDragged) {
+        this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
+      }
+      if (this.props.onGridRowsUpdated) {
+        this.onGridRowsUpdated(cellKey, fromRow, toRow, {[cellKey]: dragged.value}, AppConstants.UpdateActions.CELL_DRAG);
+      }
     }
     this.setState({dragged: {complete: true}});
   },

--- a/src/addons/__tests__/Grid.spec.js
+++ b/src/addons/__tests__/Grid.spec.js
@@ -742,7 +742,8 @@ describe('Grid', function() {
       describe('dragging in grid', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 1, rowIdx: 2 } });
-          this.getBaseGrid().props.onViewportDragStart();
+          const event = { target: { className: 'drag-handle' }};
+          this.getBaseGrid().props.onViewportDragStart(event);
         });
 
         it('should store drag rowIdx, idx and value of cell in state', function() {

--- a/src/addons/__tests__/GridRunner.js
+++ b/src/addons/__tests__/GridRunner.js
@@ -171,7 +171,7 @@ export default class GridRunner {
   drag({from, to, col, beforeDragEnter = null, beforeDragEnd = null}) {
     this.selectCell({cellIdx: col - 1, rowIdx: from});
     let over = [];
-    over.push(this.row);
+    over.push(this.cell);
     let fromIterator = from;
 
     for (let i = fromIterator++; i < to; i++) {
@@ -183,11 +183,11 @@ export default class GridRunner {
     // Act
     // do the drag
     // Important: we need dragStart / dragEnter / dragEnd
-    this.row.simulate('dragStart');
+    this.cell.simulate('dragStart');
     if (beforeDragEnter) {beforeDragEnter();}
 
-    over.forEach((r) => {
-      r.simulate('dragEnter');
+    over.forEach((cell) => {
+      cell.simulate('dragEnter');
     });
     if (beforeDragEnd) {beforeDragEnd();}
     toCell.simulate('dragEnd');


### PR DESCRIPTION
## Description
This PR fixes the bug that when reordering rows, the rows in between the start and destination of the reordering are updated (depending on which cell/column was selected before the reorder). It also fixes #225.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Select a cell other than the drag handler (so not the first column). When reordering a row, the column of the selected cell will be copied for all rows between the row's original position and the new position.


**What is the new behavior?**
The row changes position because of the reorder but no values/columns are overwritten.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
