### PR TITLE
fix checked select checkbox background color not support in IE11

### DIFF
--- a/themes/react-data-grid.less
+++ b/themes/react-data-grid.less
@@ -288,7 +288,7 @@ textareaselect.editor-main {
 }
 
 .react-grid-checkbox:checked + .react-grid-checkbox-label:before {
-    background: rebeccapurple;
+    background: #663399;
     box-shadow: inset 0px 0px 0px 4px #fff;
 }
 


### PR DESCRIPTION
## Description
Fix checked select checkbox background color ‘rebeccapurple’ not support in IE11

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The select checkbox background color is not change when checked in IE11

**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
