### PR TITLE
skip lerna git commands, and use our own via publishMaster script so …

### DIFF
--- a/ci/publish/publishMaster.ps1
+++ b/ci/publish/publishMaster.ps1
@@ -10,7 +10,12 @@ Write-Host "Publishing $($currentVersion) to npm"
 
 if($?)
 {
-  ./node_modules/.bin/lerna publish --repo-version $currentVersion --yes
+  ./node_modules/.bin/lerna publish --repo-version $currentVersion --yes --skip-git
+  git commit -m "Version Bump to $($currentVersion) [ci skip]"
+  git fetch
+  git pull --rebase
+  git push
+  git push --tags
   if($?){
     Write-Host "regenerating public site and examples"
     node ./ci/publish/publishExamples.js


### PR DESCRIPTION
## Description
Skip lerna git commands on publish and use our own via publishMaster script so we can pass ci skip param in message

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Lerna exececutes git commands. CI build is triggered for auto generated commit


**What is the new behavior?**
CI build is not triggered for Lerna commit message


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
