### PR TITLE
Avoid mutating state

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -784,7 +784,7 @@ const ReactDataGrid = React.createClass({
     let column = this.getColumn(idx);
 
     if (ColumnUtils.canEdit(column, row, this.props.enableCellSelect) && !this.isActive()) {
-      let selected = Object.assign(this.state.selected, {idx: idx, rowIdx: rowIdx, active: true, initialKeyCode: keyPressed});
+      let selected = Object.assign({}, this.state.selected, {idx: idx, rowIdx: rowIdx, active: true, initialKeyCode: keyPressed});
       let showEditor = true;
       if (typeof this.props.onCheckCellIsEditable === 'function') {
         let args = Object.assign({}, { row, column }, selected);
@@ -805,7 +805,7 @@ const ReactDataGrid = React.createClass({
     let col = this.getColumn(idx);
 
     if (ColumnUtils.canEdit(col, row, this.props.enableCellSelect) && this.isActive()) {
-      let selected = Object.assign(this.state.selected, {idx: idx, rowIdx: rowIdx, active: false});
+      let selected = Object.assign({}, this.state.selected, {idx: idx, rowIdx: rowIdx, active: false});
       this.setState({selected: selected});
     }
   },


### PR DESCRIPTION
## Description
The state is modified indirectly by Object.assign. It causes bugs (more description in current behavior).


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
I've got the grid with onCheckCellIsEditable.
It is not allowing come initalKeyCode to start the editor. 
I am trying to write some prohibited keys on the selected cell and then click on the filter toolbar button.
The editor is activated.


**What is the new behavior?**
The editor shouldn't be activated in such case.
The state should be mutated only by this.setState


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
