### PR TITLE
Fix filter retriever

### DIFF
--- a/packages/react-data-grid-addons/src/data/RowFilterer.js
+++ b/packages/react-data-grid-addons/src/data/RowFilterer.js
@@ -2,8 +2,8 @@ import { utils } from 'react-data-grid';
 const { getMixedTypeValueRetriever, isImmutableCollection } = utils;
 
 const filterRows = (filters, rows = []) => {
-  const retriever = getMixedTypeValueRetriever(isImmutableCollection(rows));
   return rows.filter(r => {
+    const retriever = getMixedTypeValueRetriever(isImmutableCollection(r));
     let include = true;
     for (let columnKey in filters) {
       if (filters.hasOwnProperty(columnKey)) {


### PR DESCRIPTION
## Description
This PR will fix a code for filters when checking which kind of object is within a immutable list. The object inside this list can be a normal object, so the retriever should be the normal object retriever.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The filter function looks at the list object instead of the row itself. Considering that the object inside the list can be a normal object, the check should be on the row level.

**What is the new behavior?**
The code will check the row level whether it's an immutable iterable or normal object.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
