### PR TITLE
Backward tabbing does not change focus to cells outside of viewport

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -889,7 +889,7 @@ const ReactDataGrid = React.createClass({
       onRowHover: this.onRowHover,
       getDataGridDOMNode: this.getDataGridDOMNode,
       isScrollingVerticallyWithKeyboard: this.isKeyDown(40) || this.isKeyDown(38), // up or down
-      isScrollingHorizontallyWithKeyboard: this.isKeyDown(37) || this.isKeyDown(39) // left or right
+      isScrollingHorizontallyWithKeyboard: this.isKeyDown(37) || this.isKeyDown(39) || this.isKeyDown(9) // left or right or tab
     };
 
     let toolbar = this.renderToolbar();

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -888,8 +888,8 @@ const ReactDataGrid = React.createClass({
       onRowExpandToggle: this.onRowExpandToggle,
       onRowHover: this.onRowHover,
       getDataGridDOMNode: this.getDataGridDOMNode,
-      isScrollingVerticallyWithKeyboard: this.isKeyDown(40) || this.isKeyDown(38), // up or down
-      isScrollingHorizontallyWithKeyboard: this.isKeyDown(37) || this.isKeyDown(39) || this.isKeyDown(9) // left or right or tab
+      isScrollingVerticallyWithKeyboard: this.isKeyDown(KeyCodes.DownArrow) || this.isKeyDown(KeyCodes.UpArrow),
+      isScrollingHorizontallyWithKeyboard: this.isKeyDown(KeyCodes.LeftArrow) || this.isKeyDown(KeyCodes.RightArrow) || this.isKeyDown(KeyCodes.Tab)
     };
 
     let toolbar = this.renderToolbar();

--- a/packages/react-data-grid/src/__tests__/FocusableComponentTestRunner.js
+++ b/packages/react-data-grid/src/__tests__/FocusableComponentTestRunner.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 const COMPONENT_DID_MOUNT_SOURCE = 'CDM';
 const COMPONENT_DID_UPDATE_SOURCE = 'CDU';
 
@@ -115,9 +115,8 @@ class FocusableComponentTestRunner {
 
     it('should focus when scrolling and selected', () => {
       let cellMetaData = Object.assign({ }, this._props.cellMetaData, { isScrollingVerticallyWithKeyboard: true, isScrollingHorizontallyWithKeyboard: true });
-
-      this._componentWrapper = mount(<this._Component {...this._props} cellMetaData={cellMetaData} />);
-
+      this._componentWrapper = shallow(<this._Component {...this._props} cellMetaData={cellMetaData} />, { lifecycleExperimental: true });
+      this._componentWrapper.setProps({cellMetaData});
       expect(this.componentPrototype.focus).toHaveBeenCalled();
     });
   }

--- a/packages/react-data-grid/src/focusableComponentWrapper.js
+++ b/packages/react-data-grid/src/focusableComponentWrapper.js
@@ -8,6 +8,7 @@ const focusableComponentWrapper = WrappedComponent => {
       constructor() {
         super();
         this.checkFocus = this.checkFocus.bind(this);
+        this.state = { isScrolling: false };
       }
 
       shouldComponentUpdate(nextProps) {
@@ -15,6 +16,7 @@ const focusableComponentWrapper = WrappedComponent => {
       }
 
       componentDidMount() {
+        this.setState({isScrolling:WrappedComponent.isScrolling(this.props)});
         this.checkFocus();
       }
 
@@ -23,8 +25,9 @@ const focusableComponentWrapper = WrappedComponent => {
       }
 
       checkFocus() {
-        if (WrappedComponent.isSelected(this.props) && WrappedComponent.isScrolling(this.props)) {
+        if (WrappedComponent.isSelected(this.props) && this.state.isScrolling) {
           this.focus();
+          this.setState({isScrolling: false});
         }
       }
 

--- a/packages/react-data-grid/src/focusableComponentWrapper.js
+++ b/packages/react-data-grid/src/focusableComponentWrapper.js
@@ -15,8 +15,11 @@ const focusableComponentWrapper = WrappedComponent => {
         return WrappedComponent.isSelected(this.props) !== WrappedComponent.isSelected(nextProps);
       }
 
+      componentWillReceiveProps() {
+        this.setState({isScrolling: WrappedComponent.isScrolling(this.props)});
+      }
+
       componentDidMount() {
-        this.setState({isScrolling:WrappedComponent.isScrolling(this.props)});
         this.checkFocus();
       }
 

--- a/packages/react-data-grid/src/focusableComponentWrapper.js
+++ b/packages/react-data-grid/src/focusableComponentWrapper.js
@@ -15,8 +15,11 @@ const focusableComponentWrapper = WrappedComponent => {
         return WrappedComponent.isSelected(this.props) !== WrappedComponent.isSelected(nextProps);
       }
 
-      componentWillReceiveProps() {
-        this.setState({isScrolling: WrappedComponent.isScrolling(this.props)});
+      componentWillReceiveProps(nextProps) {
+        let isScrolling = WrappedComponent.isScrolling(nextProps);
+        if (isScrolling && !this.state.isScrolling) {
+          this.setState({isScrolling: isScrolling});
+        }
       }
 
       componentDidMount() {


### PR DESCRIPTION
- [x] Allow Tab to set isScrollingHorizontallyWithKeyboard
- [x] Set isScrolling state
- [x] Set isScrolling to false when component gets focus

## Description
Fix backward tabbing on grid when focus changes to cell to the left of the viewport

**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Backward tabbing does not move the viewport to the left
Using left arrow does move the viewport
Issue with using horizontal scrollbar immediately after viewport shifts to the left - the cell gets refocused and viewport shifts unexpectedly


**What is the new behavior?**
Backward tabbing will move the viewport to the left
Using horizontal scroll bar after backward tabbing/left arrow functions as expected


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
