### PR TITLE
Adding configurable filter header height

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -117,6 +117,7 @@ const ReactDataGrid = React.createClass({
       enableCellSelect: false,
       tabIndex: -1,
       rowHeight: 35,
+      headerRowHeight: 45,
       enableRowSelect: false,
       minHeight: 350,
       rowKey: 'id',
@@ -620,7 +621,7 @@ const ReactDataGrid = React.createClass({
         ref: 'filterRow',
         filterable: true,
         onFilterChange: this.props.onAddFilter,
-        height: this.props.headerFiltersHeight || 45,
+        height: this.props.headerFiltersHeight,
         rowType: 'filter'
       });
     }

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -52,6 +52,7 @@ const ReactDataGrid = React.createClass({
   propTypes: {
     rowHeight: React.PropTypes.number.isRequired,
     headerRowHeight: React.PropTypes.number,
+    headerFiltersHeight: React.PropTypes.number,
     minHeight: React.PropTypes.number.isRequired,
     minWidth: React.PropTypes.number,
     enableRowSelect: React.PropTypes.oneOfType([React.PropTypes.bool, React.PropTypes.string]),
@@ -619,7 +620,7 @@ const ReactDataGrid = React.createClass({
         ref: 'filterRow',
         filterable: true,
         onFilterChange: this.props.onAddFilter,
-        height: 45,
+        height: this.props.headerFiltersHeight || 45,
         rowType: 'filter'
       });
     }


### PR DESCRIPTION
## Description
Filter header has fixed height 45px. Added prop for the configurable height with default 45px.

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The height of columns is fixed to 45px.


**What is the new behavior?**
The height of columns can be configured. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
