### PR TITLE
Distniguish double click event from the enter event

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -210,7 +210,7 @@ const ReactDataGrid = React.createClass({
 
   onCellDoubleClick: function(cell: SelectedType) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
-    this.setActive('Enter');
+    this.setActive('DoubleClick');
   },
 
   onViewportDoubleClick: function() {


### PR DESCRIPTION
## Description
onDoubleClick invokes setActive which activates editor with the 'Enter' argument, which makes it indistinguishable with the enter key. I propose to change here parameter to be 'DoubleClick'. 

The use case for that is when you want to open editor only on double clicking. 
You can make it by using the onCheckCellIsEditable prop function. 
The initialKeyCode paramter will be containing the 'DoubleClick' instead of 'Enter'

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
