### PR TITLE
Generated unique id for the select all checkbox (Issue #643).

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-dnd-html5-backend": "^2.1.2",
     "react-select": "^1.0.0-beta14",
     "reselect": "^2.5.1",
-    "ron-react-autocomplete": "^4.0.2"
+    "ron-react-autocomplete": "^4.0.2",
+    "lodash.uniqueid": "^4.0.1"
   },
   "devDependencies": {
     "avcoveralls": "^1.0.0",

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -10,6 +10,7 @@ const ColumnMetricsMixin      = require('./ColumnMetricsMixin');
 const RowUtils = require('./RowUtils');
 const ColumnUtils = require('./ColumnUtils');
 const KeyCodes = require('./KeyCodes');
+const uniqueId = require('lodash.uniqueid');
 import AppConstants from './AppConstants';
 require('../../../themes/react-data-grid-core.css');
 require('../../../themes/react-data-grid-checkbox.css');
@@ -824,11 +825,12 @@ const ReactDataGrid = React.createClass({
 
     let cols = columns.slice(0);
     let unshiftedCols = {};
+    let selectAllCheckboxId = uniqueId('select-all-checkbox-');
     if (this.props.rowActionsCell || (props.enableRowSelect && !this.props.rowSelection) || (props.rowSelection && props.rowSelection.showCheckbox !== false)) {
       let headerRenderer = props.enableRowSelect === 'single' ? null :
       <div className="react-grid-checkbox-container">
-        <input className="react-grid-checkbox" type="checkbox" name="select-all-checkbox" id="select-all-checkbox" onChange={this.handleCheckboxChange} />
-        <label htmlFor="select-all-checkbox" className="react-grid-checkbox-label"></label>
+        <input className="react-grid-checkbox" type="checkbox" name={selectAllCheckboxId} id={selectAllCheckboxId} onChange={this.handleCheckboxChange} />
+        <label htmlFor={selectAllCheckboxId} className="react-grid-checkbox-label"></label>
       </div>;
       let Formatter = this.props.rowActionsCell ? this.props.rowActionsCell : CheckboxEditor;
       let selectColumn = {

--- a/themes/react-data-grid-checkbox.css
+++ b/themes/react-data-grid-checkbox.css
@@ -10,6 +10,11 @@
     cursor: pointer;
 }
 
+/* Remove vertical margin */
+.react-grid-checkbox, .react-grid-checkbox-label {
+    margin: 0 10px;
+}
+
 .react-grid-checkbox-label, .radio-custom-label {
     position: relative;
 }
@@ -52,7 +57,9 @@
     box-shadow: inset 0px 0px 0px 4px #fff;
 }
 
+/* Remove padding that mis-aligns the checkbox, also the id is not valid since unique ids will be generated
 label[for=select-all-checkbox]{
     padding-left: 10px;
     padding-top: 5px;
 }
+*/


### PR DESCRIPTION
This allows more than one grid to exist on a page without interfering with each other. See Issue #643 

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

No tests have been added, but existing tests pass.

**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Issue #643 
Multiple grids on the same page results in duplicate checkboxes with the same id

**What is the new behavior?**
Each checkbox gets its own id with the prefix 'select-all-checkbox-'


**Does this PR introduce a breaking change?** (check one with "x")
```
[ x ] Yes
[ ] No
```
Any code/styles that depends on the old id 'select-all-checkbox' will be broken

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Code/styles that depends on the id will have to be changed to use class names instead.

**Other information**:
