### PR TITLE
Prevent context menu when editor is open

### DIFF
--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -245,7 +245,6 @@ const EditorContainer = React.createClass({
 
   handleRightClick(e) {
     e.stopPropagation();
-    e.preventDefault();
   },
 
   handleBlur(e) {

--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -243,6 +243,11 @@ const EditorContainer = React.createClass({
             document.activeElement; // IE11
   },
 
+  handleRightClick(e) {
+    e.stopPropagation();
+    e.preventDefault();
+  },
+
   handleBlur(e) {
     e.stopPropagation();
     if (this.isBodyClicked(e)) {
@@ -293,7 +298,7 @@ const EditorContainer = React.createClass({
 
   render(): ?ReactElement {
     return (
-        <div className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown}>
+        <div className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} onContextMenu={this.handleRightClick}>
           {this.createEditor()}
           {this.renderStatusIcon()}
         </div>

--- a/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
+++ b/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
@@ -83,7 +83,7 @@ describe('Editor Container Tests', () => {
         height: 50
       };
       let editorDiv = renderComponent(props).find('div').at(0);
-      expect(Object.keys(editorDiv.props()).length).toBe(4);
+      expect(Object.keys(editorDiv.props()).length).toBe(5);
       expect(editorDiv.props().className).toBeDefined();
       expect(editorDiv.props().onBlur).toBeDefined();
       expect(editorDiv.props().onKeyDown).toBeDefined();


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Right click in any editor trigger the RDG context menu.


**What is the new behavior?**
Right click in any editor trigger the browser context menu.



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
