### PR TITLE
Fix publishing examples

### DIFF
--- a/ci/publish/publishMaster.ps1
+++ b/ci/publish/publishMaster.ps1
@@ -12,14 +12,14 @@ if($?)
   Write-Host "Publishing $($releaseVersion) to npm"
   $versionBumpMessage = "Version bump to $($releaseVersion) [ci skip]"
 
-  ./node_modules/.bin/lerna publish --repo-version $releaseVersion  --skip-git --yes 
-  git add .
-  git commit -m $versionBumpMessage
-  git push
-  if($?){
+  ./node_modules/.bin/lerna publish --repo-version $releaseVersion  --skip-git --yes
+  if($?) {
     Write-Host "Regenerating public site and examples"
     node ./ci/publish/publishExamples.js
   }
+  git add .
+  git commit -m $versionBumpMessage
+  git push
 }
 
 exit $lastexitcode


### PR DESCRIPTION
## Description
Fix publishing the examples by moving before the commit.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The build doesn't publish the examples as `git push` fails.

**What is the new behavior?**
The build will now publish the examples as expected.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```