### PR TITLE
Autocomplete Filter does not work with number and undefined values

### DIFF
--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
@@ -38,12 +38,11 @@ class AutoCompleteFilter extends React.Component {
         continue;
       }
 
-      if (typeof columnValue !== 'undefined' && typeof filterTerms[key].value !== 'undefined') {
+      if (columnValue !== undefined && filterTerms[key].value !== undefined) {
+        let strColumnValue = columnValue.toString();
         let filterTermValue = filterTerms[key].value.toString();
-
-        let checkValueIndex = columnValue.toString().trim().toLowerCase().indexOf(filterTermValue.trim().toLowerCase());
-        let columnMatchesSearch = checkValueIndex !== -1 && (checkValueIndex !== 0 || columnValue.toString() === filterTermValue);
-
+        let checkValueIndex = strColumnValue.trim().toLowerCase().indexOf(filterTermValue.trim().toLowerCase());
+        let columnMatchesSearch = checkValueIndex !== -1 && (checkValueIndex !== 0 || strColumnValue === filterTermValue);
         if (columnMatchesSearch === true) {
           columnValueContainsSearchTerms = true;
           break;

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
@@ -38,14 +38,16 @@ class AutoCompleteFilter extends React.Component {
         continue;
       }
 
-      let filterTermValue = filterTerms[key].value;
+      if (typeof columnValue !== 'undefined' && typeof filterTerms[key].value !== 'undefined') {
+        let filterTermValue = filterTerms[key].value.toString();
 
-      let checkValueIndex = columnValue.trim().toLowerCase().indexOf(filterTermValue.trim().toLowerCase());
-      let columnMatchesSearch = checkValueIndex !== -1 && (checkValueIndex !== 0 || columnValue === filterTermValue);
+        let checkValueIndex = columnValue.toString().trim().toLowerCase().indexOf(filterTermValue.trim().toLowerCase());
+        let columnMatchesSearch = checkValueIndex !== -1 && (checkValueIndex !== 0 || columnValue.toString() === filterTermValue);
 
-      if (columnMatchesSearch) {
-        columnValueContainsSearchTerms = true;
-        break;
+        if (columnMatchesSearch === true) {
+          columnValueContainsSearchTerms = true;
+          break;
+        }
       }
     }
 

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -20,7 +20,7 @@ function fakeGetValidFilterValues() {
   return options;
 }
 
-fdescribe('AutoCompleteFilter', () => {
+describe('AutoCompleteFilter', () => {
 
   let component;
   let rows;

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -20,7 +20,8 @@ function fakeGetValidFilterValues() {
   return options;
 }
 
-describe('AutoCompleteFilter', () => {
+fdescribe('AutoCompleteFilter', () => {
+
   let component;
   let rows;
 
@@ -96,6 +97,59 @@ describe('AutoCompleteFilter', () => {
         let request = filterValues(columnFilter);
         expect(request).toBeFalsy();
       });
+
+      it('should transform Integers into string to compare', () => {
+        let columnFilter = { filterTerm: [ {value: 1} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeTruthy();
+      });
+
+      it('should transform Float into string to compare', () => {
+        let columnFilter = { filterTerm: [ {value: 1.1} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeFalsy();
+      });
+
+      it('should transform row values into string to compare data (returns true)', () => {
+        rows = [{ id: 1, title: 0.15, count: 1 }];
+        let columnFilter = { filterTerm: [ {value: '0.15'} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeTruthy();
+      });
+
+      it('should transform row values into string to compare data (returns false)', () => {
+        rows = [{ id: 1, title: 0.15, count: 1 }];
+        let columnFilter = { filterTerm: [ {value: '0.10'} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeFalsy();
+      });
+
+      it('should transform row and filter values into string to compare data', () => {
+        rows = [{ id: 1, title: 0.15, count: 1 }];
+        let columnFilter = { filterTerm: [ {value: 0.15} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeTruthy();
+      });
+
+      it('should trim spaces of the filterTerm values', () => {
+        let columnFilter = { filterTerm: [ {value: '   1   '} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeTruthy();
+      });
+
+      it('should handle undefined row values', () => {
+        rows = [{ id: 1, title: undefined, count: 1 }];
+        let columnFilter = { filterTerm: [ {value: 1} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeFalsy();
+      });
+
+      it('should handle undefined filter values', () => {
+        let columnFilter = { filterTerm: [ {value: undefined} ] };
+        let request = filterValues(columnFilter);
+        expect(request).toBeFalsy();
+      });
+
     });
   });
 });

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -21,7 +21,6 @@ function fakeGetValidFilterValues() {
 }
 
 describe('AutoCompleteFilter', () => {
-
   let component;
   let rows;
 
@@ -149,7 +148,6 @@ describe('AutoCompleteFilter', () => {
         let request = filterValues(columnFilter);
         expect(request).toBeFalsy();
       });
-
     });
   });
 });

--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -8,7 +8,8 @@ require('../../../themes/react-data-grid-header.css');
 const PropTypes      = React.PropTypes;
 
 function simpleCellRenderer(objArgs: {column: {name: string}}): ReactElement {
-  return <div className="widget-HeaderCell__value">{objArgs.column.name}</div>;
+  let headerText = objArgs.column.rowType === 'header' ? objArgs.column.name : '';
+  return <div className="widget-HeaderCell__value">{headerText}</div>;
 }
 
 const HeaderCell = React.createClass({

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -112,7 +112,7 @@ const HeaderRow = React.createClass({
     let cells = [];
     let lockedCells = [];
     for (let i = 0, len = this.getSize(this.props.columns); i < len; i++) {
-      let column = this.getColumn(this.props.columns, i);
+      let column = Object.assign({ rowType: this.props.rowType }, this.getColumn(this.props.columns, i));
       let _renderer = this.getHeaderRenderer(column);
       if (column.key === 'select-row' && this.props.rowType === 'filter') {
         _renderer = <div></div>;


### PR DESCRIPTION
## Description
During the implementation of this filter type, It was not included tests for other value types. Now I included more tests and now the filter can compare other types of data.
Also included a minor fix on the header renderer.

Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When filtering number or undefined values, and exceptions happens. The actual code is only expecting strings to filter.
The simpleCellRenderer for the HeaderRow renders as default the column name even when it is a filter or sortable row.

**What is the new behavior?**
The filter now handles other values types.
The simpleCellRendererdefault now renders column name only for rowType 'header'.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```