### PR TITLE
Added an option to set column width on row select columns.

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -100,7 +100,8 @@ const ReactDataGrid = React.createClass({
             rowKey: React.PropTypes.string.isRequired
           }).isRequired
         })
-      ]).isRequired
+      ]).isRequired,
+      columnWidth: React.PropTypes.number
     }),
     onRowClick: React.PropTypes.func,
     onGridKeyUp: React.PropTypes.func,
@@ -840,7 +841,7 @@ const ReactDataGrid = React.createClass({
         onCellChange: this.handleRowSelect,
         filterable: false,
         headerRenderer: headerRenderer,
-        width: 60,
+        width: !!this.props.rowSelection && this.props.rowSelection.columnWidth ? this.props.rowSelection.columnWidth : 60,
         locked: true,
         getRowMetaData: (rowData) => rowData,
         cellClass: this.props.rowActionsCell ? 'rdg-row-actions-cell' : ''


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
This is for issue https://github.com/adazzle/react-data-grid/issues/605


**What is the new behavior?**
Select column width can be set under rowSelection.columnWidth, else it defaults to 60.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
