### PR TITLE
Fix default heigth for header row

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -105,7 +105,7 @@ describe('Grid', function() {
   });
 
   // Set of tests for the props that defined the height of our rows
-  describe('when defininig heigths on props', function() {    
+  describe('when defininig heigths on props', function() {
     describe('for defaults props', function() {
       beforeEach(function() {
         const ToolBarStub = new StubComponent('Toolbar');
@@ -170,8 +170,7 @@ describe('Grid', function() {
       it('passes the correct heigth to the header filter row', function() {
         expect(this.baseGrid.props.headerRows[1].height).toEqual(60);
       });
-    }); 
-    
+    });
   });
 
   describe('if passed in as props to grid', function() {

--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -104,6 +104,76 @@ describe('Grid', function() {
     }, events));
   });
 
+  // Set of tests for the props that defined the height of our rows
+  describe('when defininig heigths on props', function() {    
+    describe('for defaults props', function() {
+      beforeEach(function() {
+        const ToolBarStub = new StubComponent('Toolbar');
+        this.component = this.createComponent({ toolbar: <ToolBarStub /> }).node;
+        this.toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, ToolBarStub);
+        this.toolbarInstance.props.onToggleFilter();
+        this.baseGrid = this.getBaseGrid();
+      });
+
+      it('uses the appropriate default for the grid row height', function() {
+        expect(this.baseGrid.props.rowHeight).toEqual(35);
+      });
+
+      it('uses the appropriate default for the header row height', function() {
+        expect(this.baseGrid.props.headerRows[0].height).toEqual(35);
+      });
+
+      it('uses the appropriate default for the header filter row height', function() {
+        expect(this.baseGrid.props.headerRows[1].height).toEqual(45);
+      });
+    });
+
+    describe('for a given row height prop', function() {
+      beforeEach(function() {
+        const ToolBarStub = new StubComponent('Toolbar');
+        this.component = this.createComponent({ toolbar: <ToolBarStub />, rowHeight: 40 }).node;
+        this.toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, ToolBarStub);
+        this.toolbarInstance.props.onToggleFilter();
+        this.baseGrid = this.getBaseGrid();
+      });
+
+      it('passes the correct heigth to the grid rows', function() {
+        expect(this.baseGrid.props.rowHeight).toEqual(40);
+      });
+
+      it('passes the grid row heigth to the header row when no height to the specific header row is provided', function() {
+        expect(this.baseGrid.props.headerRows[0].height).toEqual(40);
+      });
+
+      it('uses the default prop height for the filter row when none is provided', function() {
+        expect(this.baseGrid.props.headerRows[1].height).toEqual(45);
+      });
+    });
+
+    describe('for given row and header height props', function() {
+      beforeEach(function() {
+        const ToolBarStub = new StubComponent('Toolbar');
+        this.component = this.createComponent({ toolbar: <ToolBarStub />, rowHeight: 40, headerRowHeight: 50, headerFiltersHeight: 60 }).node;
+        this.toolbarInstance = TestUtils.findRenderedComponentWithType(this.component, ToolBarStub);
+        this.toolbarInstance.props.onToggleFilter();
+        this.baseGrid = this.getBaseGrid();
+      });
+
+      it('passes the correct heigth to the grid rows', function() {
+        expect(this.baseGrid.props.rowHeight).toEqual(40);
+      });
+
+      it('passes the correct heigth to the header row', function() {
+        expect(this.baseGrid.props.headerRows[0].height).toEqual(50);
+      });
+
+      it('passes the correct heigth to the header filter row', function() {
+        expect(this.baseGrid.props.headerRows[1].height).toEqual(60);
+      });
+    }); 
+    
+  });
+
   describe('if passed in as props to grid', function() {
     beforeEach(function() {
       const ToolBarStub = new StubComponent('Toolbar');

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -117,7 +117,7 @@ const ReactDataGrid = React.createClass({
       enableCellSelect: false,
       tabIndex: -1,
       rowHeight: 35,
-      headerFiltersRowHeight: 45,
+      headerFiltersHeight: 45,
       enableRowSelect: false,
       minHeight: 350,
       rowKey: 'id',
@@ -621,7 +621,7 @@ const ReactDataGrid = React.createClass({
         ref: 'filterRow',
         filterable: true,
         onFilterChange: this.props.onAddFilter,
-        height: this.props.headerFiltersRowHeight,
+        height: this.props.headerFiltersHeight,
         rowType: 'filter'
       });
     }

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -117,7 +117,7 @@ const ReactDataGrid = React.createClass({
       enableCellSelect: false,
       tabIndex: -1,
       rowHeight: 35,
-      headerRowHeight: 45,
+      headerFiltersRowHeight: 45,
       enableRowSelect: false,
       minHeight: 350,
       rowKey: 'id',
@@ -621,7 +621,7 @@ const ReactDataGrid = React.createClass({
         ref: 'filterRow',
         filterable: true,
         onFilterChange: this.props.onAddFilter,
-        height: this.props.headerFiltersHeight,
+        height: this.props.headerFiltersRowHeight,
         rowType: 'filter'
       });
     }


### PR DESCRIPTION
## Description
Currently if no prop is given for header filters row heigth, it will assume the regular rows' height which is not enough  to render the filters properly. 
We also changed the behaviour of not proving a `headerRowHeight` - from just using the same height as all the others row, to have a default of 45px.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Header row filter's default height is not big enough 


**What is the new behavior?**
When no `headerFiltersHeight` is given, we use the previously hard coded value of 45px. We also don't assume a different value for `headerRowHeight`, which will continue to have the same height as a regular row if no prop for it is given.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
n/a