### PR TITLE
Fix #620: Sort arrow does not appear on screen

### DIFF
--- a/packages/react-data-grid/src/cells/headerCells/SortableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/SortableHeaderCell.js
@@ -54,8 +54,8 @@ const SortableHeaderCell = React.createClass({
       <div className={className}
         onClick={this.onClick}
         style={{cursor: 'pointer'}}>
-        {this.props.column.name}
         <span className="pull-right">{this.getSortByText()}</span>
+        {this.props.column.name}
       </div>
     );
   }


### PR DESCRIPTION
## Description
Sort arrow does not appear in at least firefox 49–51.
Putting the span.pull-right before the text fixes it, without breaking it in at least chrome.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Current behavior makes the sort arrow overflow in firefox.
Described in #620 

**What is the new behavior?**
The sort arrow does not overflow anymore.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
