### PR TITLE
Let Canvas refresh when height is changed

### DIFF
--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -109,6 +109,7 @@ const Canvas = React.createClass({
       || nextProps.rowHeight !== this.props.rowHeight
       || nextProps.columns !== this.props.columns
       || nextProps.width !== this.props.width
+      || nextProps.height !== this.props.height
       || nextProps.cellMetaData !== this.props.cellMetaData
       || this.props.colDisplayStart !== nextProps.colDisplayStart
       || this.props.colDisplayEnd !== nextProps.colDisplayEnd


### PR DESCRIPTION
## Description
When the grid is resized with the window (e.g. it is in a flex box), its height is not updated all the time, because the `shouldComponentUpdate` method is not considering the `height` prop.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When the grid is resized with the window (e.g. it is in a flex box), its height is not updated all the time.
![image](https://cloud.githubusercontent.com/assets/539272/23877621/72127f9a-0843-11e7-9643-27718d917f2b.png)

**What is the new behavior?**

When the grid is resized with the window, its height is updated smoothly
![image](https://cloud.githubusercontent.com/assets/539272/23877612/631707a4-0843-11e7-98e1-58ff0e8bd816.png)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
