### PR TITLE
Don't autofocus if the entire react-data-grid is offscreen

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -347,7 +347,23 @@ const Cell = React.createClass({
     return !this.isSelected() && this.isDraggedOver() && this.props.rowIdx > dragged.rowIdx;
   },
 
-  isFocusedOnBody() {
+  isTableOnScreen(dataGridDOMNode) {
+    // http://stackoverflow.com/a/11193613
+    const docViewTop  = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
+    // http://stackoverflow.com/a/28241682
+    const docViewBottom = docViewTop + (window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight);
+
+    const elemTop = dataGridDOMNode.offsetTop;
+    const elemBottom = elemTop + dataGridDOMNode.offsetHeight;
+
+    if ((elemTop >= docViewTop && elemTop <= docViewBottom) || (elemBottom >= docViewTop && elemBottom <= docViewBottom)) return true;
+    return false;
+  },
+
+  isFocusedOnBody(dataGridDOMNode) {
+    // Make sure the table is on-screen as prerequisite
+    if (!this.isTableOnScreen(dataGridDOMNode)) return false;
+
     return document.activeElement == null || (document.activeElement.nodeName && typeof document.activeElement.nodeName === 'string' && document.activeElement.nodeName.toLowerCase() === 'body');
   },
 
@@ -363,7 +379,7 @@ const Cell = React.createClass({
       // Only focus to the current cell if the currently active node in the document is within the data grid.
       // Meaning focus should not be stolen from elements that the grid doesnt control.
       let dataGridDOMNode = this.props.cellMetaData && this.props.cellMetaData.getDataGridDOMNode ? this.props.cellMetaData.getDataGridDOMNode() : null;
-      if (this.isFocusedOnCell() || this.isFocusedOnBody() || (dataGridDOMNode && dataGridDOMNode.contains(document.activeElement))) {
+      if (this.isFocusedOnCell() || this.isFocusedOnBody(dataGridDOMNode) || (dataGridDOMNode && dataGridDOMNode.contains(document.activeElement))) {
         let cellDOMNode = ReactDOM.findDOMNode(this);
         if (cellDOMNode) {
           cellDOMNode.focus();

--- a/packages/react-data-grid/src/__tests__/Focus.spec.js
+++ b/packages/react-data-grid/src/__tests__/Focus.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import ReactDataGrid from '../ReactDataGrid';
+import { mount } from 'enzyme';
+
+const createRows = () => {
+  let rows = [];
+  for (let i = 1; i < 10; i++) {
+    rows.push({
+      id: i,
+      title: 'Title ' + i,
+      count: i * 1000
+    });
+  }
+  return rows;
+};
+
+const renderContainer = () => {
+  if (document.getElementById('sandbox') === null) {
+    let sbox = document.createElement('div');
+    sbox.id = 'sandbox';
+    sbox.style.width = '600px';
+    sbox.style.height = '5000px'; // Big enough to scroll out of range
+    document.body.appendChild(sbox);
+    sbox.innerHTML += "<div style='width:600px;height:200px' id='gridContainer'></div>";
+  }
+  let gridContainer = document.getElementById('gridContainer');
+  return gridContainer;
+};
+
+const renderComponent = (container, extraProps) => {
+  let rows = createRows();
+  let testProps = {
+    columns: [
+      { key: 'id', name: 'ID', editable: true },
+      { key: 'title', name: 'Title', editable: true },
+      { key: 'count', name: 'Count', editable: true }
+    ],
+    rowGetter: i => { return rows[i]; },
+    rowsCount: rows.length,
+    minHeight: 500,
+    enableCellSelect: true
+  };
+
+  const wrapper = mount(<ReactDataGrid {...testProps} {...extraProps} />, {attachTo: container});
+  return wrapper;
+};
+
+describe('Focus Tests', () => {
+  let container;
+  let testElement;
+
+  beforeEach(() => {
+    container = renderContainer();
+  });
+
+  afterEach(function() {
+    const elem = document.getElementById('sandbox');
+    elem.parentNode.removeChild(elem);
+  });
+
+  describe('with current focus on the body', function() {
+    it('should receive focus when onscreen', function() {
+      document.body.focus(); // IE requires this explicitly (otherwise activeElement is null)
+      expect(document.activeElement).toBe(document.body);
+      testElement = renderComponent(container);
+      expect(document.activeElement).toBe(
+        testElement.find('.react-grid-Cell').first().node
+      );
+    });
+    it('should not receive focus when offscreen', function() {
+      document.body.focus(); // IE requires this explicitly (otherwise activeElement is null)
+      expect(document.activeElement).toBe(document.body);
+      window.scrollTo(0, 2000);
+      expect(document.activeElement).toBe(document.body);
+      testElement = renderComponent(container);
+      expect(document.activeElement).toBe(document.body);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Due to the current autofocus behavior, when the react-data-grid is rerendered the scroll bar 'jumps' up to put the focused cell in view, even if it was a completely different section of the UI that caused the underlying data to change. This would more often occur in applications with complex UIs such as the one I am working on.

I created a short 1-minute video demonstrating the issue & explaining my fix:
https://www.youtube.com/watch?v=xejQdVGJX6w

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When the react-data-grid is rerendered the scroll bar 'jumps' up to put the focused cell in view, even if it was a completely different section of the UI that caused the underlying data to change.


**What is the new behavior?**
In the isFocusedOnBody() method in Cell.js, we simply check if the dataGridDOMNode is currently on screen or off screen. If it's off screen, then don't trigger the autofocus.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Tests have been added. I also ran the linter and that gave a clean output too.

Thanks for taking a look at this PR!