### PR TITLE
Fixed error 'Cannot read property 'editable' of undefined'

### DIFF
--- a/packages/react-data-grid/src/ColumnUtils.js
+++ b/packages/react-data-grid/src/ColumnUtils.js
@@ -28,7 +28,7 @@ module.exports = {
   // Logic extented to allow for functions to be passed down in column.editable
   // this allows us to deicde whether we can be edting from a cell level
   canEdit(col, rowData, enableCellSelect) {
-    if (col.editable != null && typeof(col.editable) === 'function') {
+    if (col && col.editable != null && typeof(col.editable) === 'function') {
       return enableCellSelect === true && col.editable(rowData);
     }
     return enableCellSelect === true && (!!col.editor || !!col.editable);

--- a/packages/react-data-grid/src/ColumnUtils.js
+++ b/packages/react-data-grid/src/ColumnUtils.js
@@ -28,7 +28,8 @@ module.exports = {
   // Logic extented to allow for functions to be passed down in column.editable
   // this allows us to deicde whether we can be edting from a cell level
   canEdit(col, rowData, enableCellSelect) {
-    if (col && col.editable != null && typeof(col.editable) === 'function') {
+    if (!col) return false;
+    if (col.editable != null && typeof(col.editable) === 'function') {
       return enableCellSelect === true && col.editable(rowData);
     }
     return enableCellSelect === true && (!!col.editor || !!col.editable);


### PR DESCRIPTION
## Description
Fixed 'Cannot read property 'editable' of undefined' error.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The error 'Cannot read property 'editable' of undefined' occurs when DataGrid is not yet loaded and the user presses Ctrl + any another button (such as Shift) and clicks by mouse on the DataGrid.


**What is the new behavior?**
The error not occurs


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


**Other information**:
Screenshot of the error: 
![image](https://cloud.githubusercontent.com/assets/12469814/24359457/15e726a6-130d-11e7-843f-7bdab064537a.png)