### PR TITLE
fix RowGrouperResolver to work with Immutable.List

### DIFF
--- a/packages/react-data-grid-addons/src/data/RowGrouperResolver.js
+++ b/packages/react-data-grid-addons/src/data/RowGrouperResolver.js
@@ -1,7 +1,7 @@
 import {List} from 'immutable';
 import groupBy from 'lodash/groupBy';
 import { utils } from 'react-data-grid';
-const { getMixedTypeValueRetriever } = utils;
+const { getMixedTypeValueRetriever, isImmutableMap } = utils;
 
 export default class RowGrouperResolver {
 
@@ -15,7 +15,7 @@ export default class RowGrouperResolver {
   }
 
   getGroupedRows(rows, columnName) {
-    return this.isImmutable ? rows.groupBy(x => x.get(columnName)) : groupBy(rows, columnName);
+    return this.isImmutable ? rows.groupBy(x => isImmutableMap(x) ? x.get(columnName) : x[columnName]) : groupBy(rows, columnName);
   }
 
   getGroupKeys(groupedRows) {

--- a/packages/react-data-grid-addons/src/data/__tests__/RowGrouper.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/RowGrouper.spec.js
@@ -50,4 +50,12 @@ describe('Row Grouper', () => {
             .slice(0, grpDetails.multiCol.length)
             .every(x => x.__metaData)).toBe(true);
   });
+  it('It can group an Immutable List (not list of immutable maps)', () => {
+    const immutableList = Immutable.List(rows); // eslint-disable-line new-cap
+    const groupingResult = groupRows(immutableList, grpDetails.multiCol, grpDetails.expRows);
+
+    expect(groupingResult
+            .slice(0, grpDetails.multiCol.length)
+            .every(x => x.__metaData)).toBe(true);
+  });
 });

--- a/packages/react-data-grid/src/utils/index.js
+++ b/packages/react-data-grid/src/utils/index.js
@@ -4,5 +4,6 @@ module.exports = {
   isFunction: require('./isFunction'),
   isImmutableCollection: require('./isImmutableCollection'),
   getMixedTypeValueRetriever: require('./mixedTypeValueRetriever'),
-  isColumnsImmutable: require('./isColumnsImmutable')
+  isColumnsImmutable: require('./isColumnsImmutable'),
+  isImmutableMap: require('./isImmutableMap')
 };

--- a/packages/react-data-grid/src/utils/isImmutableMap.js
+++ b/packages/react-data-grid/src/utils/isImmutableMap.js
@@ -1,0 +1,3 @@
+import { Map } from 'immutable';
+
+module.exports = Map.isMap;


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Grouping (RowGrouperResolver) with Immutable.List doesn't work, it expects an Immutable.List of Immutable.Map


**What is the new behavior?**
Checks whether row is an Immutable.Map



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
