### PR TITLE
Allow arrays for cell data

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -27,7 +27,7 @@ const Cell = React.createClass({
     tabIndex: React.PropTypes.number,
     ref: React.PropTypes.string,
     column: React.PropTypes.shape(ExcelColumn).isRequired,
-    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool]).isRequired,
+    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool, React.PropTypes.array]).isRequired,
     isExpanded: React.PropTypes.bool,
     isRowSelected: React.PropTypes.bool,
     cellMetaData: React.PropTypes.shape(CellMetaDataShape).isRequired,


### PR DESCRIPTION
## Description
Allow arrays as data for cells.  Generally only useful for custom renderers, but *really* useful then

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
If you provide an array of data for a cell, you get a console error (although it does work)


**What is the new behavior?**
There is no console error if you provide an array for cell data


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
