### PR TITLE
584 Column resizing causes cell data to disappear

### DIFF
--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -63,7 +63,7 @@ module.exports = {
   },
 
   getRenderedColumnCount(displayStart, width) {
-    let remainingWidth = width > 0 ? width : this.props.columnMetrics.totalWidth;
+    let remainingWidth = width && width > 0 ? width : this.props.columnMetrics.width;
     if (remainingWidth === 0) {
       remainingWidth = ReactDOM.findDOMNode(this).offsetWidth;
     }


### PR DESCRIPTION
Use width instead when width is undefined

## Description
To resolve the issues listed in https://github.com/adazzle/react-data-grid/issues/584

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/adazzle/react-data-grid/issues/584

**What is the new behavior?**
To properly render cells underneath the correct columns.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
