### PR TITLE
Bring back rowDoubleClick support

### DIFF
--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -16,7 +16,7 @@ const CellExpander = React.createClass({
 });
 
 // The list of the propTypes that we want to include in the Row div
-const knownDivPropertyKeys = ['height'];
+const knownDivPropertyKeys = ['height', 'onDoubleClick'];
 
 const Row = React.createClass({
 


### PR DESCRIPTION
## Description
As stated in issue #697, the proposed solution for handling double click on a row doesn't work. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently, the onDoubleClick props is not passed to the row. See issue #697 


**What is the new behavior?**

The onDoubleClick props is now a known props and is passed to the row.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: Since it is a really small change, I figured it wasn't necessary to add a test. 
