### PR TITLE
Inject "onCommitCancel" method in editors

### DIFF
--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -59,7 +59,8 @@ const EditorContainer = React.createClass({
       rowData: this.props.rowData,
       height: this.props.height,
       onBlur: this.commit,
-      onOverrideKeyDown: this.onKeyDown
+      onOverrideKeyDown: this.onKeyDown,
+      onCommitCancel: this.props.cellMetaData.onCommitCancel
     };
 
     let CustomEditor = this.props.column.editor;

--- a/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
+++ b/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
@@ -14,7 +14,8 @@ describe('Editor Container Tests', () => {
       idx: 0,
       rowIdx: 0
     },
-    onCommit: function() {}
+    onCommit: function() {},
+    onCommitCancel: function() {}
   };
 
   let component;
@@ -119,6 +120,7 @@ describe('Editor Container Tests', () => {
       expect(editor).toBeDefined();
       expect(editor.props.value).toBeDefined();
       expect(editor.props.onCommit).toBeDefined();
+      expect(editor.props.onCommitCancel).toBeDefined();
     });
 
     it('should render component custom editors', () => {


### PR DESCRIPTION
## Description
Inject "onCommitCancel" method in editors so custom editors can cancel the changes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Editors do not expose "onCommitCancel" method 


**What is the new behavior?**
Editors will expose "onCommitCancel" method


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
