### PR TITLE
Checkbox fix for undefined property error

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -514,7 +514,7 @@ const ReactDataGrid = React.createClass({
   },
 
   handleNewRowSelect(rowIdx, rowData) {
-    if (this.selectAllCheckbox.checked === true) {
+    if (this.selectAllCheckbox && this.selectAllCheckbox.checked === true) {
       this.selectAllCheckbox.checked = false;
     }
 


### PR DESCRIPTION
Associated issue: https://github.com/adazzle/react-data-grid/issues/751

## Description
The PR fixes a nondeterministic error relating to a `ref` callback assigned to the `select-all` checkbox.

The `select-all` checkbox has a callback reference assigned to it, which is used when checking an individual checkbox, to determine if the `select-all` checkbox is or is not checked. However, as `ref` callbacks are updated twice with each render - first with null then with the DOM element - it can at times throw an error when attempting to access a property on the `ref` while it is still null.

This PR adds a conditional statement that checks first that the `ref` value is not null/undefined before using it.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Selecting an individual checkbox can throw an `Cannot read property 'checked' of undefined` error.


**What is the new behavior?**
A conditional statement has been added that checks first if the `ref` object exists before attempting to access its `checked` property.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
