### PR TITLE
Frozen column fixes for dyanically locking and unlocking columns

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -278,9 +278,11 @@ const Cell = React.createClass({
     let ctrl: any = this; // flow on windows has an outdated react declaration, once that gets updated, we can remove this
     if (ctrl.isMounted()) {
       let node = ReactDOM.findDOMNode(this);
-      let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
-      node.style.webkitTransform = transform;
-      node.style.transform = transform;
+      if (node) {
+        let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
+        node.style.webkitTransform = transform;
+        node.style.transform = transform;
+      }
     }
   },
 

--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -91,6 +91,15 @@ const HeaderCell = React.createClass({
     node.style.transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
   },
 
+  removeScroll() {
+    let node = ReactDOM.findDOMNode(this);
+    if (node) {
+      let transform = 'none';
+      node.style.webkitTransform = transform;
+      node.style.transform = transform;
+    }
+  },
+
   render(): ?ReactElement {
     let resizeHandle;
     if (this.props.column.resizable) {

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -148,6 +148,8 @@ const HeaderRow = React.createClass({
     this.props.columns.forEach( (column, i) => {
       if (column.locked) {
         this.cells[i].setScrollLeft(scrollLeft);
+      } else {
+        this.cells[i].removeScroll();
       }
     });
   },

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -149,7 +149,9 @@ const HeaderRow = React.createClass({
       if (column.locked) {
         this.cells[i].setScrollLeft(scrollLeft);
       } else {
-        this.cells[i].removeScroll();
+        if (this.cells[i]) {
+          this.cells[i].removeScroll();
+        }
       }
     });
   },


### PR DESCRIPTION
## Description
If a user is attempting to unlock columns dynamically while the grid is scrolled to the right - the original locked column header cells will not be visible due to the transform that was applied to it during the "locking".

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Attempting to unlock columns while scrolled causes the the original locked column header cells to not be visible.


**What is the new behavior?**
Unlocking columns will now show the original header cells so you can read the column name.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
