### PR TITLE
Do not commit changes on componentWillUnmount if editor cancels editing

### DIFF
--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -26,6 +26,7 @@ const EditorContainer = React.createClass({
   },
 
   changeCommitted: false,
+  changeCanceled: false,
 
   getInitialState() {
     return {isInvalid: false};
@@ -43,7 +44,7 @@ const EditorContainer = React.createClass({
   },
 
   componentWillUnmount: function() {
-    if (!this.changeCommitted && !this.hasEscapeBeenPressed()) {
+    if (!this.changeCommitted && !this.hasEscapeBeenPressed() && !this.changeCanceled) {
       this.commit({key: 'Enter'});
     }
   },
@@ -55,12 +56,12 @@ const EditorContainer = React.createClass({
       column: this.props.column,
       value: this.getInitialValue(),
       onCommit: this.commit,
+      onCommitCancel: this.commitCancel,
       rowMetaData: this.getRowMetaData(),
       rowData: this.props.rowData,
       height: this.props.height,
       onBlur: this.commit,
-      onOverrideKeyDown: this.onKeyDown,
-      onCommitCancel: this.props.cellMetaData.onCommitCancel
+      onOverrideKeyDown: this.onKeyDown
     };
 
     let CustomEditor = this.props.column.editor;
@@ -188,6 +189,12 @@ const EditorContainer = React.createClass({
       this.props.cellMetaData.onCommit({cellKey: cellKey, rowIdx: this.props.rowIdx, updated: updated, key: opts.key});
     }
   },
+
+  commitCancel() {
+    this.changeCanceled = true;
+    this.props.cellMetaData.onCommitCancel();
+  },
+
   isNewValueValid(value: string): boolean {
     if (isFunction(this.getEditor().validate)) {
       let isValid = this.getEditor().validate(value);

--- a/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
+++ b/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
@@ -163,6 +163,51 @@ describe('Editor Container Tests', () => {
       TestUtils.Simulate.click(ReactDOM.findDOMNode(editor));
       expect(component.commit.calls.count()).toEqual(0);
     });
+
+    it('should call onCommitCancel of cellMetaData when editor cancels editing', () => {
+      column.editor = <TestEditor />;
+      let metaData =  {
+        selected: {
+          idx: 0,
+          rowIdx: 0
+        },
+        onCommit: jasmine.createSpy(),
+        onCommitCancel: jasmine.createSpy()
+      };
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={metaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      editor.props.onCommitCancel();
+      expect(metaData.onCommitCancel).toHaveBeenCalled();
+      expect(metaData.onCommitCancel.calls.count()).toEqual(1);
+      expect(metaData.onCommit).not.toHaveBeenCalled();
+    });
+
+    it('should not commit changes on componentWillUnmount if editor cancels editing', () => {
+      column.editor = <TestEditor />;
+      let metaData =  {
+        selected: {
+          idx: 0,
+          rowIdx: 0
+        },
+        onCommit: jasmine.createSpy(),
+        onCommitCancel: jasmine.createSpy()
+      };
+      component = TestUtils.renderIntoDocument(<EditorContainer
+        rowData={rowData}
+        value={'SupernaviX'}
+        cellMetaData={metaData}
+        column={column}
+        height={50}/>);
+      let editor = TestUtils.findRenderedComponentWithType(component, TestEditor);
+      editor.props.onCommitCancel();
+      component.componentWillUnmount();
+      expect(metaData.onCommit).not.toHaveBeenCalled();
+    });
   });
 
   describe('Events', () => {


### PR DESCRIPTION
## Description
Editor changes are erroneously committed when onCommitCancel is called. This happens because EditorContainer commits changes on componentWillUnmount lifecycle hook unless escape key was pressed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Editor changes are committed when onCommitCancel is called. This happens because EditorContainer commits changes on componentWillUnmount lifecycle hook. 


**What is the new behavior?**
A new flag "changeCanceled" has been added to prevent this behavior. Editor changes are correctly canceled and commit method is not called.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
No

**Other information**:
