### PR TITLE
Scrolling fix for locked columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-dnd-html5-backend": "^2.1.2",
     "react-select": "^1.0.0-beta14",
     "reselect": "^2.5.1",
-    "ron-react-autocomplete": "^4.0.2"
+    "ron-react-autocomplete": "^4.0.2",
+    "react-input-autosize": "1.1.0"
   },
   "devDependencies": {
     "avcoveralls": "^1.0.0",

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -676,6 +676,7 @@ const ReactDataGrid = React.createClass({
       rowIdx = this.state.selected.rowIdx + rowDelta;
       idx = this.state.selected.idx + cellDelta;
     }
+    this.scrollToColumn(idx);
     this.onSelect({ idx: idx, rowIdx: rowIdx });
   },
 


### PR DESCRIPTION
Calling scrollToColumn inside moveSelectedCell

## Description
When using locked columns (more than 1 in this case) and the grid is scrolled to the right.

If the user attempts to use the keyboard left arrow or shift + tab, the selected cell will not be visible and still be under the  locked column area.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When using locked columns with a grid that is scrolled to the right.
Scrolling left with the keyboard will not show the cell hidden behind the lock columns. 


**What is the new behavior?**
Scrolling left with the keyboard will cause the grid to scroll to the column to show the selected cell.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
