### PR TITLE
Column should accept zero width

### DIFF
--- a/packages/react-data-grid/src/ColumnMetrics.js
+++ b/packages/react-data-grid/src/ColumnMetrics.js
@@ -32,7 +32,7 @@ function setColumnWidths(columns, totalWidth) {
 function setDefferedColumnWidths(columns, unallocatedWidth, minColumnWidth) {
   let defferedColumns = columns.filter(c => !c.width);
   return columns.map((column) => {
-    if (!column.width) {
+    if (!column.width && column.width !== 0) {
       if (unallocatedWidth <= 0) {
         column.width = minColumnWidth;
       } else {


### PR DESCRIPTION
## Description
Currently if we set column.width: 0, the column still calculated as didn't set width. We should accept 0 width column, which will help in hiding the whole column.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently, if we set column.width = 0, it doesn't take any effects.


**What is the new behavior?**
By setting column.width=0 can hide the column.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
