### PR TITLE
Hitting escape should cancel editor changes in Firefox

### DIFF
--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -44,7 +44,7 @@ const EditorContainer = React.createClass({
   },
 
   componentWillUnmount: function() {
-    if (!this.changeCommitted && !this.hasEscapeBeenPressed() && !this.changeCanceled) {
+    if (!this.changeCommitted && !this.changeCanceled) {
       this.commit({key: 'Enter'});
     }
   },
@@ -86,7 +86,7 @@ const EditorContainer = React.createClass({
 
   onPressEscape(e: SyntheticKeyboardEvent) {
     if (!this.editorIsSelectOpen()) {
-      this.props.cellMetaData.onCommitCancel();
+      this.commitCancel();
     } else {
       // prevent event from bubbling if editor has results to select
       e.stopPropagation();
@@ -282,19 +282,6 @@ const EditorContainer = React.createClass({
         inputNode.select();
       }
     }
-  },
-
-  hasEscapeBeenPressed() {
-    let pressed = false;
-    let escapeKey = 27;
-    if (window.event) {
-      if (window.event.keyCode === escapeKey) {
-        pressed = true;
-      } else if (window.event.which === escapeKey) {
-        pressed  = true;
-      }
-    }
-    return pressed;
   },
 
   renderStatusIcon(): ?ReactElement {

--- a/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
+++ b/packages/react-data-grid/src/editors/__tests__/EditorContainer.spec.js
@@ -214,6 +214,7 @@ describe('Editor Container Tests', () => {
     beforeEach(() => {
       cellMetaData.onCommit = function() {};
       spyOn(cellMetaData, 'onCommit');
+      cellMetaData.onCommitCancel = jasmine.createSpy();
 
       // render into an actual div, not a detached one
       // otherwise IE (11) gives an error when we try and setCaretAtEndOfInput
@@ -237,6 +238,20 @@ describe('Editor Container Tests', () => {
       TestUtils.Simulate.keyDown(editor.getInputNode(), {key: 'Enter'});
       expect(cellMetaData.onCommit).toHaveBeenCalled();
       expect(cellMetaData.onCommit.calls.count()).toEqual(1);
+    });
+
+    it('hitting escape should call commitCancel of cellMetaData only once', () => {
+      let editor = TestUtils.findRenderedComponentWithType(component, SimpleTextEditor);
+      TestUtils.Simulate.keyDown(editor.getInputNode(), {key: 'Escape'});
+      expect(cellMetaData.onCommitCancel).toHaveBeenCalled();
+      expect(cellMetaData.onCommitCancel.calls.count()).toEqual(1);
+    });
+
+    it('hitting escape should not call commit changes on componentWillUnmount', () => {
+      let editor = TestUtils.findRenderedComponentWithType(component, SimpleTextEditor);
+      TestUtils.Simulate.keyDown(editor.getInputNode(), {key: 'Escape'});
+      ReactDOM.unmountComponentAtNode(container);
+      expect(cellMetaData.onCommit).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
Canceling editing on escape relies on window.event which is not supported in FF and the new value gets committed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Hitting escape commits editor changes in Firefox


**What is the new behavior?**
Hitting escape does not commit editor changes in Firefox
https://github.com/adazzle/react-data-grid/issues/788


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
