### PR TITLE
Column events args - rowId

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -978,6 +978,7 @@ describe('Grid', function() {
       let columnWithEvent;
       const eventColumnIdx = 3;
       const eventColumnRowIdx = 2;
+      const eventColumnRowId = 2;
 
       beforeEach(function() {
         columnWithEvent = this.component.state.columnMetrics.columns[3];
@@ -1011,8 +1012,8 @@ describe('Grid', function() {
       });
 
       it('should call the event when there is one with the correct args', function() {
-        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, name: 'onClick'});
-        expect(columnWithEvent.events.onClick.calls.mostRecent().args).toEqual([{}, {column: columnWithEvent, idx: eventColumnIdx, rowIdx: eventColumnRowIdx }]);
+        this.getCellMetaData().onColumnEvent({}, {idx: eventColumnIdx, rowIdx: eventColumnRowIdx, rowId: eventColumnRowId, name: 'onClick'});
+        expect(columnWithEvent.events.onClick.calls.mostRecent().args).toEqual([{}, {column: columnWithEvent, idx: eventColumnIdx, rowIdx: eventColumnRowIdx, rowId: eventColumnRowId }]);
       });
 
       it('events should work for the first column', function() {
@@ -1020,7 +1021,7 @@ describe('Grid', function() {
         let firstColumn = this.component.state.columnMetrics.columns[firstColumnIdx];
         let firstColumnEvents = this.testProps.columns[firstColumnIdx].events;
         spyOn(firstColumnEvents, 'onClick');
-        this.getCellMetaData().onColumnEvent({}, {idx: firstColumnIdx, rowIdx: eventColumnRowIdx, name: 'onClick'});
+        this.getCellMetaData().onColumnEvent({}, {idx: firstColumnIdx, rowIdx: eventColumnRowIdx, rowId: eventColumnRowId, name: 'onClick'});
 
         expect(firstColumn.events.onClick).toHaveBeenCalled();
       });

--- a/packages/react-data-grid-examples/src/scripts/example19-column-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example19-column-events.js
@@ -20,7 +20,7 @@ const Example = React.createClass({
         resizable: true,
         events: {
           onDoubleClick: function(ev, args) {
-              console.log('The user entered edit mode on title column with rowId: ' + args.rowIdx);
+            console.log('The user entered edit mode on title column with rowIdx: ' + args.rowIdx + ' & rowId: ' + args.rowId);
           }
         }
       },
@@ -80,9 +80,6 @@ const Example = React.createClass({
 
   getColumns: function() {
     let clonedColumns = this._columns.slice();
-    clonedColumns[1].events = {
-      onClick: this.cellEditWithOneClick
-    };
     clonedColumns[3].events = {
       onClick: this.cellEditWithOneClick
     };
@@ -111,7 +108,7 @@ const exampleDescription = (
       and will run only for the specified column.
     </p>
     <p>
-      Every event callback must respect this standard in order to work correctly: <code>function onXxx(ev :SyntheticEvent, (rowIdx, idx, column): args)</code>
+      Every event callback must respect this standard in order to work correctly: <code>function onXxx(ev :SyntheticEvent, (idx, rowIdx, rowId, column): args)</code>
     </p>
   </div>
 );

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -412,7 +412,7 @@ const Cell = React.createClass({
     for (let eventKey in columnEvents) {
       if (columnEvents.hasOwnProperty(eventKey)) {
         let event = columnEvents[event];
-        let eventInfo = { rowIdx: this.props.rowIdx, idx: this.props.idx, name: eventKey };
+        let eventInfo = { idx: this.props.idx, rowIdx: this.props.rowIdx, rowId: this.props.rowData[this.props.cellMetaData.rowKey], name: eventKey };
         let eventCallback = this.createColumEventCallBack(onColumnEvent, eventInfo);
 
         if (allEvents.hasOwnProperty(eventKey)) {

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -164,8 +164,9 @@ const ReactDataGrid = React.createClass({
 
       if (column && column.events && column.events[name] && typeof column.events[name] === 'function') {
         let eventArgs = {
-          rowIdx: columnEvent.rowIdx,
           idx,
+          rowIdx: columnEvent.rowIdx,
+          rowId: columnEvent.rowId,
           column
         };
 
@@ -881,6 +882,7 @@ const ReactDataGrid = React.createClass({
 
   render() {
     let cellMetaData = {
+      rowKey: this.props.rowKey,
       selected: this.state.selected,
       dragged: this.state.dragged,
       hoveredRowIdx: this.state.hoveredRowIdx,
@@ -904,7 +906,6 @@ const ReactDataGrid = React.createClass({
       onAddSubRow: this.props.onAddSubRow,
       isScrollingVerticallyWithKeyboard: this.isKeyDown(KeyCodes.DownArrow) || this.isKeyDown(KeyCodes.UpArrow),
       isScrollingHorizontallyWithKeyboard: this.isKeyDown(KeyCodes.LeftArrow) || this.isKeyDown(KeyCodes.RightArrow) || this.isKeyDown(KeyCodes.Tab)
-
     };
 
     let toolbar = this.renderToolbar();


### PR DESCRIPTION

## Description
Enhance the arguments passed to the function which on called when a column event is fired so that it will include the rowId.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
column event arguments doesnt include the rowId and thus code within the function to handle such events can only rely on a rowIdx to identify the row.


**What is the new behavior?**
The column event arguments now passes the rowId


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
