### PR TITLE
Row Grouping cleanup and style changes

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -139,6 +139,33 @@ const CustomToolbar = React.createClass({
   }
 });
 
+const CustomRowGroupRenderer = React.createClass({
+  renderColumns() {
+    return this.props.columns.map(column => {
+      return (
+        <div className="react-grid-Cell" style={{position: 'absolute', width: column.width, height: '35px', left: column.left, contain: 'layout' }}>
+          <div className="react-grid-Cell__value">
+            {column.key === this.props.columnGroupName ? (
+              <div>
+                <span className="row-expand-icon" style={{float: 'left', cursor: 'pointer'}} onClick={this.props.onRowExpandClick} >{this.props.isExpanded ? String.fromCharCode('9660') : String.fromCharCode('9658')}</span>
+                <strong>{this.props.name}</strong>
+              </div>
+              ) : ''}
+          </div>
+        </div>
+      );
+    });
+  },
+
+  render() {
+    return (
+      <div style={{height: '35px', overflow: 'hidden', contain: 'layout'}} >
+        {this.renderColumns()}
+      </div>
+    );
+  }
+});
+
 const Example = React.createClass({
   getInitialState() {
     let fakeRows = createRows(2000);
@@ -193,6 +220,7 @@ const Example = React.createClass({
             toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted}/>}
             rowHeight={50}
             minHeight={600}
+            rowGroupRenderer={CustomRowGroupRenderer}
             />
       </DraggableContainer>
     );

--- a/packages/react-data-grid/src/RowGroup.js
+++ b/packages/react-data-grid/src/RowGroup.js
@@ -80,24 +80,17 @@ class RowGroup extends Component {
   }
 
   render() {
-    const lastColumn = utils.last(this.props.columns);
+    let lastColumn = utils.last(this.props.columns);
 
     let style = {
-      height: '50px',
       overflow: 'hidden',
-      border: '1px solid #dddddd',
-      paddingTop: '15px',
-      paddingLeft: '5px',
       width: lastColumn.left + lastColumn.width
     };
-    let rowGroupRendererProps = Object.assign({ onRowExpandClick: this.onRowExpandClick }, this.props);
 
     return (
-
-      <div style={style} className={this.getClassName()} onClick={this.onClick} onKeyDown={this.onKeyDown} tabIndex={-1}>
-        <this.props.renderer {...rowGroupRendererProps} />
+      <div style={style} className={this.getClassName()} onKeyDown={this.onKeyDown} onClick={this.onClick} tabIndex={-1}>
+         <this.props.renderer {...this.props} onRowExpandClick={this.onRowExpandClick} />
       </div>
-
     );
   }
 }
@@ -118,11 +111,19 @@ const DefaultRowGroupRenderer = (props) => {
   let treeDepth = props.treeDepth || 0;
   let marginLeft = treeDepth * 20;
 
+  let style = {
+    height: '50px',
+    border: '1px solid #dddddd',
+    paddingTop: '15px',
+    paddingLeft: '5px'
+  };
+
   return (
-    <div>
+    <div style={style}>
       <span className="row-expand-icon" style={{float: 'left', marginLeft: marginLeft, cursor: 'pointer'}} onClick={props.onRowExpandClick} >{props.isExpanded ? String.fromCharCode('9660') : String.fromCharCode('9658')}</span>
       <strong>{props.columnGroupName} : {props.name}</strong>
-    </div>);
+    </div>
+  );
 };
 
 DefaultRowGroupRenderer.propTypes = {


### PR DESCRIPTION
## Description
Change Row grouping to only put styles for height, padding and border on the default row group renderer whilst if a custom one is passed in then it would have to handle these styles itself.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
