### PR TITLE
make react-datagrid able to read json recursively

### DIFF
--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -138,7 +138,20 @@ const Row = React.createClass({
       return this.props.isSelected;
     } else if (typeof this.props.row.get === 'function') {
       val = this.props.row.get(key);
-    } else {
+    } else if (key.indexOf('.') >= 0) {
+      val = (function getVal(valchain, subkey) {
+        const tokenIdx = subkey.indexOf('.');
+        if (tokenIdx >= 0) {
+          const token = key.slice(0, tokenIdx);
+          const remain = key.slice(tokenIdx + 1, key.length);
+          if (valchain[token]) {
+            return getVal(valchain[token], remain);
+          }
+          return null;
+        }
+        return valchain[key] || null;
+      })(this.props.row, key);
+    }else {
       val = this.props.row[key];
     }
     return val;

--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -1,5 +1,6 @@
 import OverflowCell from './OverflowCell';
 import rowComparer from './RowComparer';
+import utils from './utils';
 const React = require('react');
 const joinClasses = require('classnames');
 const Cell = require('./Cell');
@@ -139,18 +140,7 @@ const Row = React.createClass({
     } else if (typeof this.props.row.get === 'function') {
       val = this.props.row.get(key);
     } else if (key.indexOf('.') >= 0) {
-      val = (function getVal(valchain, subkey) {
-        const tokenIdx = subkey.indexOf('.');
-        if (tokenIdx >= 0) {
-          const token = key.slice(0, tokenIdx);
-          const remain = key.slice(tokenIdx + 1, key.length);
-          if (valchain[token]) {
-            return getVal(valchain[token], remain);
-          }
-          return null;
-        }
-        return valchain[key] || null;
-      })(this.props.row, key);
+      val = utils.getValueForKey(this.props.row, key);
     }else {
       val = this.props.row[key];
     }

--- a/packages/react-data-grid/src/utils/getValueForKey.js
+++ b/packages/react-data-grid/src/utils/getValueForKey.js
@@ -1,0 +1,12 @@
+const getValueForKey = (key, model) => {
+  let returnVal = model;
+  const keyArray = key.split('.');
+  keyArray.forEach(subkey => {
+    if (subkey && returnVal[subkey]) {
+      returnVal = returnVal[key];
+    }
+  });
+  return returnVal;
+};
+
+module.exports = getValueForKey;

--- a/packages/react-data-grid/src/utils/index.js
+++ b/packages/react-data-grid/src/utils/index.js
@@ -8,6 +8,7 @@ module.exports = {
   getMixedTypeValueRetriever: require('./mixedTypeValueRetriever'),
   isColumnsImmutable: require('./isColumnsImmutable'),
   isImmutableMap: require('./isImmutableMap'),
+  getValueForKey: require('./getValueForKey'),
   last: (arrayOrList) => {
     if (arrayOrList == null) {
       throw new Error('arrayOrCollection is null');


### PR DESCRIPTION
Current grid control unable to read json data into rows recursively, add new data-read logic to read data (valueB) like following: 
[
{"propA":{"propB":"valueB"}
{...}
]

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

unable to get cell value if the row JSON object has more than 2 levels

**What is the new behavior?**

able to get values from any kind of JSON object 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
