### PR TITLE
Ablity to not show delete button for child rows

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -470,8 +470,8 @@ const Cell = React.createClass({
 
     let isDeleteSubRowEnabled = this.props.cellMetaData.onDeleteSubRow ? true : false;
 
-    if (isDeleteSubRowEnabled && (treeDepth > 0 && isExpandCell)) {
-      cellDeleter = <ChildRowDeleteButton treeDepth={treeDepth} cellHeight={this.props.height} siblingIndex={this.props.expandableOptions.subRowDetails.siblingIndex} numberSiblings={this.props.expandableOptions.subRowDetails.numberSiblings} onDeleteSubRow={this.onDeleteSubRow}/>;
+    if (treeDepth > 0 && isExpandCell) {
+      cellDeleter = <ChildRowDeleteButton treeDepth={treeDepth} cellHeight={this.props.height} siblingIndex={this.props.expandableOptions.subRowDetails.siblingIndex} numberSiblings={this.props.expandableOptions.subRowDetails.numberSiblings} onDeleteSubRow={this.onDeleteSubRow} isDeleteSubRowEnabled={isDeleteSubRowEnabled}/>;
     }
     return (<div className="react-grid-Cell__value">{cellDeleter}<div  style={{ marginLeft: marginLeft }}><span>{CellContent}</span> {this.props.cellControls} {cellExpander}</div></div>);
   },

--- a/packages/react-data-grid/src/ChildRowDeleteButton.js
+++ b/packages/react-data-grid/src/ChildRowDeleteButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const ChildRowDeleteButton = ({treeDepth, cellHeight, siblingIndex, numberSiblings, onDeleteSubRow, allowAddChildRow = true }) => {
+const ChildRowDeleteButton = ({treeDepth, cellHeight, siblingIndex, numberSiblings, onDeleteSubRow, isDeleteSubRowEnabled, allowAddChildRow = true }) => {
   const lastSibling = siblingIndex === numberSiblings - 1;
   let className = classNames(
     { 'rdg-child-row-action-cross': allowAddChildRow === true || !lastSibling },
@@ -13,9 +13,9 @@ const ChildRowDeleteButton = ({treeDepth, cellHeight, siblingIndex, numberSiblin
   let top = (cellHeight - 12) / 2;
   return (<div>
     <div className={className} />
-    <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={onDeleteSubRow}>
+    {isDeleteSubRowEnabled && <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={onDeleteSubRow}>
       <div className="glyphicon glyphicon-remove-sign"></div>
-    </div></div>);
+    </div>}</div>);
 };
 
 export default ChildRowDeleteButton;


### PR DESCRIPTION
## Description
Ablity to not show delete button for child rows

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
