### PR TITLE
Allow for optional Cell.value prop

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -28,7 +28,7 @@ const Cell = React.createClass({
     height: React.PropTypes.number,
     tabIndex: React.PropTypes.number,
     column: React.PropTypes.shape(ExcelColumn).isRequired,
-    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool]).isRequired,
+    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool]),
     isExpanded: React.PropTypes.bool,
     isRowSelected: React.PropTypes.bool,
     cellMetaData: React.PropTypes.shape(CellMetaDataShape).isRequired,


### PR DESCRIPTION
I want to be able to use this grid with sparse values, rather than needing to have a value in every single cell. Moreover, there is already a defaultProp defined.

Full bug report available in #811.
Fixes #811

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Linking to #811

**What is the new behavior?**

The value prop should not be required and the defaultProp should be used instead.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```