### PR TITLE
Extract CSS assets separately during build phase

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -1,11 +1,15 @@
 const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const argv = require('minimist')(process.argv.slice(2));
 const RELEASE = argv.release;
+
+var extractCSS = new ExtractTextPlugin('[name].css');
 
 function getPlugins() {
   const nodeEnv = RELEASE ? '"production"' : '"development"';
   var pluginsBase =  [
-    new webpack.DefinePlugin({'process.env.NODE_ENV': nodeEnv, 'global': 'window'})
+    new webpack.DefinePlugin({'process.env.NODE_ENV': nodeEnv, 'global': 'window'}),
+    extractCSS
   ];
 
   if (RELEASE) {
@@ -41,7 +45,7 @@ const config = {
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
-      { test: /\.css$/, loader: 'style-loader!css-loader' }
+      { test: /\.css$/, loader: extractCSS.extract('style-loader', 'css-loader') }
     ]
   },
   plugins: getPlugins(),

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint": "^1.10.3",
     "eslint-loader": "^1.2.0",
     "eslint-plugin-react": "^3.15.0",
+    "extract-text-webpack-plugin": "^1.0.1",
     "faker": "^3.0.1",
     "gh-pages": "^0.2.0",
     "gulp": "^3.8.7",


### PR DESCRIPTION
## Description
Modify the webpack build process to split out CSS files instead of inlining them along with a loader into the JS. This allows downstream much more control over how and where to include them.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

CSS is inlined along with webpack's style loader into the npm JS assets. When imported into another project and executed this generates new `<style>` tags in the rendered HTML. Downstream users have no control over this process and it's therefore impossible to override some style properties without using an `!important` because the load order isn't fully under downstream's control.

**What is the new behavior?**

_CSS is split into it's own file during the build phase. This file can then be imported separately._

**Does this PR introduce a breaking change?** (check one with "x")
```
[X] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

_Applications needs to import CSS assets separately._

**Other information**:

It's might be possible to modify the `index.js` files in each package to also import the CSS and load it dynamically (like what happens before this PR) so this change would be entirely unbreaking. I'm not familiar enough with the rest of the build process (I think `lerna` updates that?) or embedding something like `style-loader` outside of `webpack` to know how feasible that is though.