### PR TITLE
Duplicate Header Fix

### DIFF
--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -66,7 +66,7 @@ const HeaderRow = React.createClass({
       if (this.props.filterable) return HeaderCellType.FILTERABLE;
     }
 
-    if (column.sortable) return HeaderCellType.SORTABLE;
+    if (column.sortable && column.rowType !== 'filter') return HeaderCellType.SORTABLE;
 
     return HeaderCellType.NONE;
   },


### PR DESCRIPTION
## Description
When having  column which are not filterable but are sortable and activating the filter's the grid would still render a filter row but it would render 'Sortable Header' which would duplicate the header name, rather than just leaving the header cells empty cause there is no filter.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
