### PR TITLE
Fix miss align header and not scrolling header row

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -198,7 +198,8 @@ const Cell = React.createClass({
       'is-dragged-over-down': this.isDraggedOverDownwards(),
       'was-dragged-over': this.wasDraggedOver(),
       'cell-tooltip': this.props.tooltip ? true : false,
-      'rdg-child-cell': this.props.expandableOptions && this.props.expandableOptions.subRowDetails && this.props.expandableOptions.treeDepth > 0
+      'rdg-child-cell': this.props.expandableOptions && this.props.expandableOptions.subRowDetails && this.props.expandableOptions.treeDepth > 0,
+      'last-column': this.props.column.isLastColumn
     });
     return joinClasses(className, extraClasses);
   },

--- a/packages/react-data-grid/src/Header.js
+++ b/packages/react-data-grid/src/Header.js
@@ -108,7 +108,7 @@ const Header = React.createClass({
 
       headerRows.push(<HeaderRow
         key={row.ref}
-        ref={(node) => this.row = node}
+        ref={(node) => { return row.rowType === 'filter' ? this.filterRow = node : this.row = node; }}
         rowType={row.rowType}
         style={headerRowStyle}
         onColumnResize={this.onColumnResize}
@@ -177,7 +177,7 @@ const Header = React.createClass({
     node.scrollLeft = scrollLeft;
     this.row.setScrollLeft(scrollLeft);
     if (this.filterRow) {
-      let nodeFilters = this.filterRow;
+      let nodeFilters = ReactDOM.findDOMNode(this.filterRow);
       nodeFilters.scrollLeft = scrollLeft;
       this.filterRow.setScrollLeft(scrollLeft);
     }

--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -107,8 +107,12 @@ const Row = React.createClass({
     let cells = [];
     let lockedCells = [];
     let selectedColumn = this.getSelectedColumn();
+    let lastColumnIdx = this.props.columns.size - 1;
     if (this.props.columns) {
       this.props.columns.forEach((column, i) => {
+        if (i === lastColumnIdx) {
+          column.isLastColumn = true;
+        }
         let cell = this.getCell(column, i, selectedColumn);
         if (column.locked) {
           lockedCells.push(cell);

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -247,3 +247,8 @@
 .rdg-child-row-btn .glyphicon-remove-sign:hover {
   color: red;
 }
+
+.last-column .cell-tooltip-text{
+  right: 100%;
+  left: 20% !important;
+}

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -250,5 +250,5 @@
 
 .last-column .cell-tooltip-text{
   right: 100%;
-  left: 20% !important;
+  left: 0% !important;
 }


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
Keep the header cell width when the last column has the tooltip

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Default tooltip is going to take space when it happens in the last column and miss align with the header row


**What is the new behavior?**
The last column tooltip will move a little left so it won't take extra space.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
