### PR TITLE
Fixed column causes editors to be obscured

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -307,7 +307,7 @@ const Cell = React.createClass({
         node.style.transform = transform;
       }
     }
-  }
+  },
 
   isCopied(): boolean {
     let copied = this.props.cellMetaData.copied;

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -293,6 +293,7 @@ const Cell = React.createClass({
         let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
         node.style.webkitTransform = transform;
         node.style.transform = transform;
+        node.style.transformStyle = 'preserve-3d';
       }
     }
   },

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -94,7 +94,8 @@ const Cell = React.createClass({
       || this.props.forceUpdate === true
       || this.props.className !== nextProps.className
       || this.props.expandableOptions !== nextProps.expandableOptions
-      || this.hasChangedDependentValues(nextProps);
+      || this.hasChangedDependentValues(nextProps)
+      || this.props.column.locked !== nextProps.column.locked;
     return shouldUpdate;
   },
 

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -290,10 +290,9 @@ const Cell = React.createClass({
     if (ctrl.isMounted()) {
       let node = ReactDOM.findDOMNode(this);
       if (node) {
-        let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
+        let transform = `translate(${scrollLeft}px, 0px)`;
         node.style.webkitTransform = transform;
         node.style.transform = transform;
-        node.style.transformStyle = 'preserve-3d';
       }
     }
   },

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -290,7 +290,7 @@ const Cell = React.createClass({
     if (ctrl.isMounted()) {
       let node = ReactDOM.findDOMNode(this);
       if (node) {
-        let transform = `translate(${scrollLeft}px, 0px)`;
+        let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
         node.style.webkitTransform = transform;
         node.style.transform = transform;
       }

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -297,6 +297,18 @@ const Cell = React.createClass({
     }
   },
 
+  removeScroll() {
+    let ctrl: any = this; // flow on windows has an outdated react declaration, once that gets updated, we can remove this
+    if (ctrl.isMounted()) {
+      let node = ReactDOM.findDOMNode(this);
+      if (node) {
+        let transform = 'none';
+        node.style.webkitTransform = transform;
+        node.style.transform = transform;
+      }
+    }
+  }
+
   isCopied(): boolean {
     let copied = this.props.cellMetaData.copied;
     return (

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -297,18 +297,6 @@ const Cell = React.createClass({
     }
   },
 
-  removeScroll() {
-    let ctrl: any = this; // flow on windows has an outdated react declaration, once that gets updated, we can remove this
-    if (ctrl.isMounted()) {
-      let node = ReactDOM.findDOMNode(this);
-      if (node) {
-        let transform = 'none';
-        node.style.webkitTransform = transform;
-        node.style.transform = transform;
-      }
-    }
-  },
-
   isCopied(): boolean {
     let copied = this.props.cellMetaData.copied;
     return (

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -54,7 +54,8 @@ const Cell = React.createClass({
 
   getInitialState() {
     return {
-      isCellValueChanging: false
+      isCellValueChanging: false,
+      isLockChanging: false
     };
   },
 
@@ -64,7 +65,8 @@ const Cell = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      isCellValueChanging: this.props.isCellValueChanging(this.props.value, nextProps.value)
+      isCellValueChanging: this.props.isCellValueChanging(this.props.value, nextProps.value),
+      isLockChanging: this.props.column.locked !== nextProps.column.locked
     });
   },
 
@@ -76,6 +78,9 @@ const Cell = React.createClass({
     }
     if (this.state.isCellValueChanging && this.props.selectedColumn != null) {
       this.applyUpdateClass();
+    }
+    if (this.state.isLockChanging && !this.props.column.locked) {
+      this.removeScroll();
     }
   },
 
@@ -295,6 +300,14 @@ const Cell = React.createClass({
         node.style.webkitTransform = transform;
         node.style.transform = transform;
       }
+    }
+  },
+
+  removeScroll() {
+    let node = ReactDOM.findDOMNode(this);
+    if (node) {
+      node.style.webkitTransform = null;
+      node.style.transform = null;
     }
   },
 

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -805,9 +805,9 @@ const ReactDataGrid = React.createClass({
       }
       if (showEditor !== false) {
         if (column.locked) {
-          this.setState({selected: selected});
+          this.setState({selected});
         } else {
-          this.setState({selected: selected}, this.scrollToColumn(idx));
+          this.setState({selected}, () => { this.scrollToColumn(idx); });
         }
         this.handleCancelCopy();
       }

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -804,7 +804,11 @@ const ReactDataGrid = React.createClass({
         showEditor = this.props.onCheckCellIsEditable(args);
       }
       if (showEditor !== false) {
-        this.setState({selected: selected}, this.scrollToColumn(idx));
+        if (column.locked) {
+          this.setState({selected: selected});
+        } else {
+          this.setState({selected: selected}, this.scrollToColumn(idx));
+        }
         this.handleCancelCopy();
       }
     }

--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -167,6 +167,10 @@ const Row = React.createClass({
       if (column.locked) {
         if (!this[column.key]) return;
         this[column.key].setScrollLeft(scrollLeft);
+      } else {
+        if (this[column.key] && this[column.key].removeScroll) {
+          this[column.key].removeScroll();
+        }
       }
     });
   },

--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -167,10 +167,6 @@ const Row = React.createClass({
       if (column.locked) {
         if (!this[column.key]) return;
         this[column.key].setScrollLeft(scrollLeft);
-      } else {
-        if (this[column.key] && this[column.key].removeScroll) {
-          this[column.key].removeScroll();
-        }
       }
     });
   },

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -58,6 +58,7 @@
 .react-grid-Cell--locked:last-of-type {
   border-right: 1px solid #dddddd;
   box-shadow: none;
+  z-index: 99;
 }
 
 .react-grid-Cell:hover:focus .drag-handle .glyphicon-arrow-down {

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -58,7 +58,6 @@
 .react-grid-Cell--locked:last-of-type {
   border-right: 1px solid #dddddd;
   box-shadow: none;
-  z-index: 99;
 }
 
 .react-grid-Cell:hover:focus .drag-handle .glyphicon-arrow-down {

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -54,7 +54,6 @@
 .react-grid-Cell--locked:last-of-type {
   border-right: 1px solid #dddddd;
   box-shadow: none;
-  z-index:99;
 }
 
 .react-grid-Cell:hover:focus .drag-handle .glyphicon-arrow-down {

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -11,6 +11,10 @@
   outline-offset: -2px;
 }
 
+.react-grid-Cell--locked:focus {
+  z-index: 100;
+}
+
 .react-grid-Cell:focus .drag-handle {
   position: absolute;
   bottom: -5px;
@@ -115,6 +119,10 @@
 .react-grid-Cell.editing {
   padding: 0;
   overflow: visible !important;
+}
+
+.react-grid-Cell--locked.editing {
+  z-index: 100;
 }
 .react-grid-Cell.editing .has-error input {
   border: 2px red solid !important;


### PR DESCRIPTION
## Description
Locked columns can sometimes cause editors to appear behind the grid

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Locked columns will sometimes cause editors to appear behind the grid


**What is the new behavior?**
Editors opened in locked columns should appear normally.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
