### PR TITLE
Allow developer to configure auto focus on the grid (addresses #813)

### DIFF
--- a/docs/markdowns/ReactDataGrid.md
+++ b/docs/markdowns/ReactDataGrid.md
@@ -27,6 +27,12 @@ type: `element`
 type: `func`
 
 
+### `enableCellAutoFocus`
+
+type: `bool`
+defaultValue: `true`
+
+
 ### `enableCellSelect`
 
 type: `bool`

--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -73,8 +73,6 @@ const Canvas = React.createClass({
     };
   },
 
-  rows: [],
-
   getInitialState() {
     return {
       displayStart: this.props.displayStart,
@@ -84,6 +82,7 @@ const Canvas = React.createClass({
   },
 
   componentWillMount() {
+    this.rows = [];
     this._currentRowsLength = 0;
     this._currentRowsRange = { start: 0, end: 0 };
     this._scroll = { scrollTop: 0, scrollLeft: 0 };

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -374,10 +374,12 @@ const Cell = React.createClass({
       if (this.props.isScrolling && !this.props.cellMetaData.isScrollingVerticallyWithKeyboard && !this.props.cellMetaData.isScrollingHorizontallyWithKeyboard) {
         return;
       }
-      // Only focus to the current cell if the currently active node in the document is within the data grid.
+      // If the enableCellAutoFocus is set in the ReactDataGrid props, it will allow the cell to take focus when the browser is focused on the body.
+      // Otherwise, only focus to the current cell if the currently active node in the document is within the data grid.
       // Meaning focus should not be stolen from elements that the grid doesnt control.
+      const cellAutoFocusEnabled = this.props.cellMetaData && this.props.cellMetaData.enableCellAutoFocus;
       let dataGridDOMNode = this.props.cellMetaData && this.props.cellMetaData.getDataGridDOMNode ? this.props.cellMetaData.getDataGridDOMNode() : null;
-      if (this.isFocusedOnCell() || this.isFocusedOnBody() || (dataGridDOMNode && dataGridDOMNode.contains(document.activeElement))) {
+      if (this.isFocusedOnCell() || (cellAutoFocusEnabled && this.isFocusedOnBody()) || (dataGridDOMNode && dataGridDOMNode.contains(document.activeElement))) {
         let cellDOMNode = ReactDOM.findDOMNode(this);
         if (cellDOMNode) {
           cellDOMNode.focus();

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -111,7 +111,8 @@ const ReactDataGrid = React.createClass({
     /* called before cell is set active, returns a boolean to determine whether cell is editable */
     overScan: React.PropTypes.object,
     onDeleteSubRow: React.PropTypes.func,
-    onAddSubRow: React.PropTypes.func
+    onAddSubRow: React.PropTypes.func,
+    enableCellAutoFocus: React.PropTypes.bool
   },
 
   getDefaultProps(): {enableCellSelect: boolean} {
@@ -130,7 +131,8 @@ const ReactDataGrid = React.createClass({
         colsEnd: 5,
         rowsStart: 5,
         rowsEnd: 5
-      }
+      },
+      enabledCellAutoFocus: true
     };
   },
 
@@ -905,7 +907,8 @@ const ReactDataGrid = React.createClass({
       onDeleteSubRow: this.props.onDeleteSubRow,
       onAddSubRow: this.props.onAddSubRow,
       isScrollingVerticallyWithKeyboard: this.isKeyDown(KeyCodes.DownArrow) || this.isKeyDown(KeyCodes.UpArrow),
-      isScrollingHorizontallyWithKeyboard: this.isKeyDown(KeyCodes.LeftArrow) || this.isKeyDown(KeyCodes.RightArrow) || this.isKeyDown(KeyCodes.Tab)
+      isScrollingHorizontallyWithKeyboard: this.isKeyDown(KeyCodes.LeftArrow) || this.isKeyDown(KeyCodes.RightArrow) || this.isKeyDown(KeyCodes.Tab),
+      enableCellAutoFocus: this.props.enableCellAutoFocus
     };
 
     let toolbar = this.renderToolbar();


### PR DESCRIPTION
## Description
A PR to allow developer to configure whether the grid should steal focus when the browser is focused on the body.  Addresses #813 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The grid steals focus when the browser is focused on the body, see #813 


**What is the new behavior?**
Allow developer to configure whether grid should autofocus when browser is focused on the body


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
