### PR TITLE
Allow user to navigate out of the grid using Tab & Shift+Tab

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -934,17 +934,6 @@ describe('Grid', function() {
       });
     });
 
-    describe('cell commit after "Tab"', function() {
-      beforeEach(function() {
-        this.component.setState({ selected: { idx: 1, rowIdx: 1, active: true } });
-        this.getCellMetaData().onCommit(this.buildFakeCellUodate({ key: 'Tab' }));
-      });
-
-      it('should select next cell', function() {
-        expect(this.component.state.selected).toEqual({ idx: 2, rowIdx: 1, active: false });
-      });
-    });
-
     describe('Cell click', function() {
       beforeEach(function() {
         this.getCellMetaData().onCellClick({ idx: 2, rowIdx: 2 });

--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -310,7 +310,7 @@ describe('Grid', function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
         });
         it('selection should stay on cell', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
         });
       });
@@ -323,12 +323,12 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
         });
       });
-      describe('when row selection is enabled and positionned on cell before last in row', function() {
+      describe('when row selection is enabled and positioned on cell before last in row', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 2, rowIdx: 1 }, enableRowSelect: true });
         });
         it('selection should move to last cell', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
         });
       });
@@ -344,7 +344,7 @@ describe('Grid', function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
         });
         it('selection should move to first cell in next row', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 2 });
         });
       });
@@ -353,7 +353,7 @@ describe('Grid', function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 999 } });
         });
         it('nothing should happen', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 999 });
         });
       });
@@ -375,12 +375,12 @@ describe('Grid', function() {
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 0 });
         });
       });
-      describe('when row selection is enabled and positionned on cell before last in row', function() {
+      describe('when row selection is enabled and positioned on cell before last in row', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 2, rowIdx: 1 }, enableRowSelect: true });
         });
         it('selection should move to last cell', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
         });
       });
@@ -396,7 +396,7 @@ describe('Grid', function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 1 } });
         });
         it('selection should move to first cell in same row', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 1 });
         });
       });
@@ -405,7 +405,7 @@ describe('Grid', function() {
           this.component.setState({ selected: { idx: 3, rowIdx: 999 } });
         });
         it('selection should move to first cell in same row', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 0, rowIdx: 999 });
         });
       });
@@ -428,12 +428,12 @@ describe('Grid', function() {
         });
       });
 
-      describe('when row selection enabled and positionned on cell before last in row', function() {
+      describe('when row selection enabled and positioned on cell before last in row', function() {
         beforeEach(function() {
           this.component.setState({ selected: { idx: 2, rowIdx: 1 }, enableRowSelect: true });
         });
         it('selection should move to last cell', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.state.selected).toEqual({ idx: 3, rowIdx: 1 });
         });
       });
@@ -453,7 +453,7 @@ describe('Grid', function() {
           this.component.setState({ selected: { rowIdx: 1, idx: 2 } });
         });
         it('deselection handler should have been called', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.props.onCellDeSelected).toHaveBeenCalled();
           expect(this.component.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
             rowIdx: 1,
@@ -461,7 +461,7 @@ describe('Grid', function() {
           });
         });
         it('selection handler should have been called', function() {
-          this.simulateGridKeyDown('Tab');
+          this.simulateGridKeyDown('ArrowRight');
           expect(this.component.props.onCellSelected).toHaveBeenCalled();
           expect(this.component.props.onCellSelected.calls.mostRecent().args[0]).toEqual({
             rowIdx: 1,
@@ -608,11 +608,6 @@ describe('Grid', function() {
   });
 
   describe('User Interaction', function() {
-    it('hitting TAB should decrement selected cell index by 1', function() {
-      this.simulateGridKeyDown('Tab');
-      expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 0 });
-    });
-
     describe('When selected cell is in top corner of grid', function() {
       beforeEach(function() {
         this.component.setState({ selected: { idx: 0, rowIdx: 0 } });

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -249,6 +249,10 @@ const ReactDataGrid = createReactClass({
   },
 
   onPressTab(e: SyntheticEvent) {
+    // Allow the user to exit the grid if they are in the right location and they press Tab (with or without shift)
+    if (this.canExitGrid(e)) {
+      return;
+    }
     this.moveSelectedCell(e, 0, e.shiftKey ? -1 : 1);
   },
 
@@ -680,6 +684,39 @@ const ReactDataGrid = createReactClass({
     let cellKey = this.getColumn(idx).key;
     let row = this.props.rowGetter(rowIdx);
     return RowUtils.get(row, cellKey);
+  },
+  canExitGrid(e: SyntheticEvent): boolean {
+    // When the cellNavigationMode is 'none', you can exit the grid if you're at the start or end of the row
+    // When the cellNavigationMode is 'changeRow', you can exit the grid if you're at the first or last cell of the grid
+    // When the cellNavigationMode is 'loopOverRow', there is no logical exit point so you can't exit the grid
+    let atLastCellInRow = this.isAtLastCellInRow(this.getNbrColumns());
+    let atFirstCellInRow = this.isAtFirstCellInRow();
+    let atLastRow = this.isAtLastRow();
+    let atFirstRow = this.isAtFirstRow();
+    let shift = e.shiftKey === true;
+    const { cellNavigationMode } = this.props;
+    if (shift) {
+      if (cellNavigationMode === 'none') {
+        if (atFirstCellInRow) {
+          return true;
+        }
+      } else if (cellNavigationMode === 'changeRow') {
+        if (atFirstCellInRow && atFirstRow) {
+          return true;
+        }
+      }
+    } else {
+      if (cellNavigationMode === 'none') {
+        if (atLastCellInRow) {
+          return true;
+        }
+      } else if (cellNavigationMode === 'changeRow') {
+        if (atLastCellInRow && atLastRow) {
+          return true;
+        }
+      }
+    }
+    return false;
   },
 
   moveSelectedCell(e: SyntheticEvent, rowDelta: number, cellDelta: number) {

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -259,7 +259,7 @@ const ReactDataGrid = createReactClass({
   },
 
   exitGrid(oldSelectedCell, newSelectedValue) {
-    this.setState({ selected: newSelectedValue }, 
+    this.setState({ selected: newSelectedValue },
       () => {
         if (typeof this.props.onCellDeSelected === 'function') {
           this.props.onCellDeSelected(oldSelectedCell);

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -302,7 +302,6 @@ const ReactDataGrid = createReactClass({
       e.preventDefault();
       return;
     }
-    
     this.moveSelectedCell(e, 0, e.shiftKey ? -1 : 1);
   },
 

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -275,13 +275,24 @@ const ReactDataGrid = createReactClass({
   },
 
   onPressTab(e: SyntheticEvent) {
-    // Scenario 0: When there are no rows in the grid, pressing tab needs to allow the browser to handle it
+    // Scenario 0a: When there are no rows in the grid, pressing tab needs to allow the browser to handle it
     if (this.props.rowsCount === 0) {
       return;
     }
-    const shift = e.shiftKey === true;
+    // Scenario 0b: When we're editing a cell
     const idx = this.state.selected.idx;
     const rowIdx = this.state.selected.rowIdx;
+    if (this.state.selected.active === true) {
+      // if we are in a position to leave the grid, stop editing but stay in that cell
+      if (this.canExitGrid(e)) {
+        this.moveSelectedCell(e, 0, 0);
+        return;
+      }
+      // otherwise move left or right as appropriate
+      this.moveSelectedCell(e, 0, e.shiftKey ? -1 : 1);
+      return;
+    }
+    const shift = e.shiftKey === true;
     // Scenario 1: we're at a cell where we can exit the grid
     if (this.canExitGrid(e) && this.isFocusedOnCell()) {
       if (shift && idx >= 0) {
@@ -384,9 +395,6 @@ const ReactDataGrid = createReactClass({
   onCellCommit(commit: RowUpdateEvent) {
     let selected = Object.assign({}, this.state.selected);
     selected.active = false;
-    if (commit.key === 'Tab') {
-      selected.idx += 1;
-    }
     let expandedRows = this.state.expandedRows;
     // if(commit.changed && commit.changed.expandedHeight){
     //   expandedRows = this.expandRow(commit.rowIdx, commit.changed.expandedHeight);

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -1,17 +1,24 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ReactDataGrid from '../ReactDataGrid';
 import { shallow } from 'enzyme';
 import * as helpers from '../helpers/test/GridPropHelpers';
 
 function shallowRenderGrid({
-  enableCellAutoFocus = undefined
+  enableCellAutoFocus = undefined,
+  cellNavigationMode = undefined,
+  numRows = helpers.rowsCount(),
+  onCellSelected, onCellDeSelected
 }) {
   const enzymeWrapper = shallow(<ReactDataGrid
     columns={helpers.columns}
     rowGetter={helpers.rowGetter}
-    rowsCount={helpers.rowsCount()}
+    rowsCount={numRows}
     enableCellSelect
     enableCellAutoFocus={enableCellAutoFocus}
+    cellNavigationMode={cellNavigationMode}
+    onCellSelected={onCellSelected}
+    onCellDeSelected={onCellDeSelected}
   />);
   return {
     enzymeWrapper
@@ -34,30 +41,6 @@ describe('configure enableCellAutoFocus property', () => {
   });
 });
 
-import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactDataGrid from '../ReactDataGrid';
-import { shallow } from 'enzyme';
-import * as helpers from '../helpers/test/GridPropHelpers';
-
-function shallowRenderGrid({
-  cellNavigationMode = undefined,
-  numRows = helpers.rowsCount(),
-  onCellSelected, onCellDeSelected
-}) {
-  const enzymeWrapper = shallow(<ReactDataGrid
-    columns={helpers.columns}
-    rowGetter={helpers.rowGetter}
-    rowsCount={numRows}
-    enableCellSelect
-    cellNavigationMode={cellNavigationMode}
-    onCellSelected={onCellSelected}
-    onCellDeSelected={onCellDeSelected}
-  />);
-  return {
-    enzymeWrapper
-  };
-}
 function shallowRenderGridWithSelectionHandlers() {
   const props = { cellNavigationMode: 'none', onCellSelected: jasmine.createSpy(), onCellDeSelected: jasmine.createSpy() };
   const { enzymeWrapper } = shallowRenderGrid(props);

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -58,109 +58,110 @@ function shallowRenderGrid({
     enzymeWrapper
   };
 }
-describe('Cell Selection/DeSelection handlers', function() {
-  describe('when cell selection/deselection handlers are passed', function() {
-    beforeEach(function() {
+describe('Cell Selection/DeSelection handlers', () => {
+  let testgrid;
+  describe('when cell selection/deselection handlers are passed', () => {
+    beforeEach(() => {
       const props = { cellNavigationMode: 'none', onCellSelected: jasmine.createSpy(), onCellDeSelected: jasmine.createSpy() };
       const { enzymeWrapper } = shallowRenderGrid(props);
-      this.grid = enzymeWrapper.instance();
+      testgrid = enzymeWrapper.instance();
     });
 
-    describe('cell in the middle of the grid is selected', function() {
-      beforeEach(function() {
-        this.grid.setState({ selected: { rowIdx: 1, idx: 1 } });
+    describe('cell in the middle of the grid is selected', () => {
+      beforeEach(() => {
+        testgrid.setState({ selected: { rowIdx: 1, idx: 1 } });
         // override focused on cell/table tests because we're using shallow rendering
-        this.grid.isFocusedOnCell = () => true;
-        this.grid.isFocusedOnTable = () => false;
+        testgrid.isFocusedOnCell = () => true;
+        testgrid.isFocusedOnTable = () => false;
         spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
       });
-      it('deselection handler should have been called when moving to the next cell when press Tab', function() {
-        this.grid.onPressTab({ shiftKey: false, preventDefault: () => {} });
-        expect(this.grid.props.onCellDeSelected).toHaveBeenCalled();
-        expect(this.grid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
+      it('deselection handler should have been called when moving to the next cell when press Tab', () => {
+        testgrid.onPressTab({ shiftKey: false, preventDefault: () => {} });
+        expect(testgrid.props.onCellDeSelected).toHaveBeenCalled();
+        expect(testgrid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
           rowIdx: 1,
           idx: 1
         });
       });
-      it('selection handler should have been called when moving to the next cell', function() {
-        this.grid.onPressTab({ shiftKey: false, preventDefault: () => {} });
-        expect(this.grid.props.onCellSelected).toHaveBeenCalled();
-        expect(this.grid.props.onCellSelected.calls.mostRecent().args[0]).toEqual({
+      it('selection handler should have been called when moving to the next cell', () => {
+        testgrid.onPressTab({ shiftKey: false, preventDefault: () => {} });
+        expect(testgrid.props.onCellSelected).toHaveBeenCalled();
+        expect(testgrid.props.onCellSelected.calls.mostRecent().args[0]).toEqual({
           rowIdx: 1,
           idx: 2
         });
       });
     });
-    describe('user is able to exit the grid to the left', function() {
-      beforeEach(function() {
-        this.grid.setState({ selected: { rowIdx: 0, idx: 0 } });
-        this.grid.isFocusedOnCell = () => true;
-        this.grid.isFocusedOnTable = () => false;
+    describe('user is able to exit the grid to the left', () => {
+      beforeEach(() => {
+        testgrid.setState({ selected: { rowIdx: 0, idx: 0 } });
+        testgrid.isFocusedOnCell = () => true;
+        testgrid.isFocusedOnTable = () => false;
       });
-      it('triggers the deselection handler on press Shift+Tab', function() {
-        this.grid.onPressTab({ shiftKey: true, preventDefault: () => {} });
-        expect(this.grid.props.onCellDeSelected).toHaveBeenCalled();
-        expect(this.grid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
+      it('triggers the deselection handler on press Shift+Tab', () => {
+        testgrid.onPressTab({ shiftKey: true, preventDefault: () => {} });
+        expect(testgrid.props.onCellDeSelected).toHaveBeenCalled();
+        expect(testgrid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
           rowIdx: 0,
           idx: 0
         });
       });
-      it('does not trigger the selection handler on press Shift+Tab', function() {
-        this.grid.onPressTab({ shiftKey: true, preventDefault: () => {} });
-        expect(this.grid.props.onCellSelected).not.toHaveBeenCalled();
+      it('does not trigger the selection handler on press Shift+Tab', () => {
+        testgrid.onPressTab({ shiftKey: true, preventDefault: () => {} });
+        expect(testgrid.props.onCellSelected).not.toHaveBeenCalled();
       });
     });
-    describe('user is able to exit the grid to the right', function() {
-      beforeEach(function() {
-        this.grid.setState({ selected: { rowIdx: 2, idx: 2 } });
-        this.grid.isFocusedOnCell = () => true;
-        this.grid.isFocusedOnTable = () => false;
+    describe('user is able to exit the grid to the right', () => {
+      beforeEach(() => {
+        testgrid.setState({ selected: { rowIdx: 2, idx: 2 } });
+        testgrid.isFocusedOnCell = () => true;
+        testgrid.isFocusedOnTable = () => false;
       });
-      it('triggers the deselection handler on press Tab', function() {
-        this.grid.onPressTab({ shiftKey: false, preventDefault: () => {} });
-        expect(this.grid.props.onCellDeSelected).toHaveBeenCalled();
-        expect(this.grid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
+      it('triggers the deselection handler on press Tab', () => {
+        testgrid.onPressTab({ shiftKey: false, preventDefault: () => {} });
+        expect(testgrid.props.onCellDeSelected).toHaveBeenCalled();
+        expect(testgrid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({
           rowIdx: 2,
           idx: 2
         });
       });
-      it('does not trigger the selection handler on press Tab', function() {
-        this.grid.onPressTab({ shiftKey: false, preventDefault: () => {} });
-        expect(this.grid.props.onCellSelected).not.toHaveBeenCalled();
+      it('does not trigger the selection handler on press Tab', () => {
+        testgrid.onPressTab({ shiftKey: false, preventDefault: () => {} });
+        expect(testgrid.props.onCellSelected).not.toHaveBeenCalled();
       });
     });
     describe('user is able to enter the grid by pressing Tab', () => {
-      beforeEach(function() {
-        this.grid.setState({ selected: { rowIdx: 1, idx: 1 } });
-        this.grid.isFocusedOnCell = () => false;
-        this.grid.isFocusedOnTable = () => true;
+      beforeEach(() => {
+        testgrid.setState({ selected: { rowIdx: 1, idx: 1 } });
+        testgrid.isFocusedOnCell = () => false;
+        testgrid.isFocusedOnTable = () => true;
       });
-      it('does not trigger the deselection handler on press Tab', function() {
-        this.grid.onPressTab({ shiftKey: false, preventDefault: () => {} });
-        expect(this.grid.props.onCellDeSelected).not.toHaveBeenCalled();
+      it('does not trigger the deselection handler on press Tab', () => {
+        testgrid.onPressTab({ shiftKey: false, preventDefault: () => {} });
+        expect(testgrid.props.onCellDeSelected).not.toHaveBeenCalled();
       });
-      it('triggers the selection handler on press Tab', function() {
-        this.grid.onPressTab({ shiftKey: false, preventDefault: () => {} });
-        expect(this.grid.props.onCellSelected).toHaveBeenCalled();
-        const selectedCell = this.grid.props.onCellSelected.calls.mostRecent().args[0];
+      it('triggers the selection handler on press Tab', () => {
+        testgrid.onPressTab({ shiftKey: false, preventDefault: () => {} });
+        expect(testgrid.props.onCellSelected).toHaveBeenCalled();
+        const selectedCell = testgrid.props.onCellSelected.calls.mostRecent().args[0];
         expect(selectedCell.rowIdx).toEqual(1);
         expect(selectedCell.idx).toEqual(1);
       });
     });
     describe('user is able to enter the grid by pressing Shift+Tab', () => {
-      beforeEach(function() {
-        this.grid.setState({ selected: { rowIdx: 1, idx: 1 } });
-        this.grid.isFocusedOnCell = () => false;
-        this.grid.isFocusedOnTable = () => true;
+      beforeEach(() => {
+        testgrid.setState({ selected: { rowIdx: 1, idx: 1 } });
+        testgrid.isFocusedOnCell = () => false;
+        testgrid.isFocusedOnTable = () => true;
       });
-      it('does not trigger the deselection handler on press Shift+Tab', function() {
-        this.grid.onPressTab({ shiftKey: true, preventDefault: () => {} });
-        expect(this.grid.props.onCellDeSelected).not.toHaveBeenCalled();
+      it('does not trigger the deselection handler on press Shift+Tab', () => {
+        testgrid.onPressTab({ shiftKey: true, preventDefault: () => {} });
+        expect(testgrid.props.onCellDeSelected).not.toHaveBeenCalled();
       });
-      it('triggers the selection handler on press Shift+Tab', function() {
-        this.grid.onPressTab({ shiftKey: true, preventDefault: () => {} });
-        expect(this.grid.props.onCellSelected).toHaveBeenCalled();
-        const selectedCell = this.grid.props.onCellSelected.calls.mostRecent().args[0];
+      it('triggers the selection handler on press Shift+Tab', () => {
+        testgrid.onPressTab({ shiftKey: true, preventDefault: () => {} });
+        expect(testgrid.props.onCellSelected).toHaveBeenCalled();
+        const selectedCell = testgrid.props.onCellSelected.calls.mostRecent().args[0];
         expect(selectedCell.rowIdx).toEqual(1);
         expect(selectedCell.idx).toEqual(1);
       });

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -34,6 +34,193 @@ describe('configure enableCellAutoFocus property', () => {
   });
 });
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactDataGrid from '../ReactDataGrid';
+import { shallow } from 'enzyme';
+import * as helpers from '../helpers/test/GridPropHelpers';
+
+function shallowRenderGrid({
+  cellNavigationMode = undefined
+}) {
+  const enzymeWrapper = shallow(<ReactDataGrid
+    columns={helpers.columns}
+    rowGetter={helpers.rowGetter}
+    rowsCount={helpers.rowsCount()}
+    enableCellSelect
+    cellNavigationMode={cellNavigationMode}
+  />);
+  return {
+    enzymeWrapper
+  };
+}
+describe('using keyboard to navigate through the grid', () => {
+  describe('when cellNavigationMode is changeRow', () => {
+    const cellNavigationMode = 'changeRow';
+    it('allows the user to exit the grid when they press Shift+Tab at the first cell of the grid', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      expect(grid.state.selected).toEqual({ idx: 0, rowIdx: 0 });
+      const preventDefault = jasmine.createSpy();
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+    it('allows the user to exit the grid when they press Tab at the last cell in the grid', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: helpers.rowsCount() - 1, idx: helpers.columns.length - 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: helpers.rowsCount() - 1, idx: helpers.columns.length - 1});
+      const preventDefault = jasmine.createSpy();
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+    it('goes to the next cell when the user presses Tab and they are not at the end of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 1 });
+    });
+    it('goes to the beginning of the next row when the user presses Tab and they are at the end of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 0, idx: helpers.columns.length - 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: helpers.columns.length - 1 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 1, idx: 0 });
+    });
+    it('goes to the previous cell when the user presses Shift+Tab and they are not at the beginning of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 0, idx: 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 1 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 0 });
+    });
+    it('goes to the end of the previous row when the user presses Shift+Tab and they are at the beginning of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 2, idx: 0 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 2, idx: 0 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 1, idx: helpers.columns.length - 1 });
+    });
+  });
+  describe('when cellNavigationMode is none', () => {
+    const cellNavigationMode = 'none';
+    it('allows the user to exit the grid when they press Shift+Tab at the first cell of the grid', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      expect(grid.state.selected).toEqual({ idx: 0, rowIdx: 0 });
+      const preventDefault = jasmine.createSpy();
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+    it('allows the user to exit the grid when they press Tab at the last cell in the grid', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: helpers.rowsCount() - 1, idx: helpers.columns.length - 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: helpers.rowsCount() - 1, idx: helpers.columns.length - 1});
+      const preventDefault = jasmine.createSpy();
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+    it('goes to the next cell when the user presses Tab and they are not at the end of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 1 });
+    });
+    it('allows the user to exit the grid when they press Tab and they are at the end of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 0, idx: helpers.columns.length - 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: helpers.columns.length - 1});
+      const preventDefault = jasmine.createSpy();
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+    it('goes to the previous cell when the user presses Shift+Tab and they are not at the beginning of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 0, idx: 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 1 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 0 });
+    });
+    it('allows the user to exit the grid when they press Shift+Tab and they are at the beginning of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 2, idx: 0 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 2, idx: 0 });
+      const preventDefault = jasmine.createSpy();
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+  });
+  describe('when cellNavigationMode is loopOverRow', () => {
+    const cellNavigationMode = 'loopOverRow';
+    it('goes to the first cell in the row when the user presses Tab and they are at the end of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: helpers.rowsCount() - 1, idx: helpers.columns.length - 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: helpers.rowsCount() - 1, idx: helpers.columns.length - 1 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: helpers.rowsCount() - 1, idx: 0 });
+    });
+    it('goes to the last cell in the row when the user presses Shift+Tab and they are at the beginning of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 0 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: helpers.columns.length - 1 });
+    });
+    it('goes to the next cell when the user presses Tab and they are not at the end of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: false, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 1 });
+    });
+    it('goes to the previous cell when the user presses Shift+Tab and they are not at the beginning of a row', () => {
+      const { enzymeWrapper } = shallowRenderGrid({ cellNavigationMode });
+      const grid = enzymeWrapper.instance();
+      grid.setState({selected: { rowIdx: 0, idx: 1 } });
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 1 });
+      const preventDefault = jasmine.createSpy();
+      spyOn(ReactDOM, 'findDOMNode').and.returnValue({ querySelector: () => (false) });
+      expect(grid.onPressTab({ shiftKey: true, preventDefault }));
+      expect(preventDefault).toHaveBeenCalled();
+      expect(grid.state.selected).toEqual({ rowIdx: 0, idx: 0 });
+    });
+  });
+});
+
 //
 //   var testProps = {
 //     enableCellSelect: true,

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -98,7 +98,6 @@ describe('Cell Selection/DeSelection handlers', function() {
         this.grid.isFocusedOnTable = () => false;
       });
       it('triggers the deselection handler on press Shift+Tab', function() {
-        console.log("Amanda")
         this.grid.onPressTab({ shiftKey: true, preventDefault: () => {} });
         expect(this.grid.props.onCellDeSelected).toHaveBeenCalled();
         expect(this.grid.props.onCellDeSelected.calls.mostRecent().args[0]).toEqual({


### PR DESCRIPTION
…igation mode is none or changeRow (#849)

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
See #849 


**What is the new behavior?**
When cellNavigationMode is 'none' the user can press Tab at the end of any row to escape the grid.
When cellNavigationMode is 'none' the user can press Shift+Tab at the beginning of any row to escape the grid.
When cellNavigationMode is 'changeRow' the user can press Tab at the last cell in the grid to escape the grid.
When cellNavigationMode is 'none' the user can press Shift+Tab at the first cell in the grid to escape the grid.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
