### PR TITLE
fix sorting of immutable data

### DIFF
--- a/packages/react-data-grid-addons/src/data/RowSorter.js
+++ b/packages/react-data-grid-addons/src/data/RowSorter.js
@@ -19,7 +19,7 @@ const sortRows = (rows, sortColumn, sortDirection) => {
   if (sortDirection === 'NONE') {
     return rows;
   }
-  return [...rows].sort(rowComparer);
+  return rows.sort(rowComparer);
 };
 
 module.exports = sortRows;

--- a/packages/react-data-grid-addons/src/data/RowSorter.js
+++ b/packages/react-data-grid-addons/src/data/RowSorter.js
@@ -19,7 +19,7 @@ const sortRows = (rows, sortColumn, sortDirection) => {
   if (sortDirection === 'NONE') {
     return rows;
   }
-  return rows.sort(rowComparer);
+  return rows.slice().sort(rowComparer);
 };
 
 module.exports = sortRows;


### PR DESCRIPTION
## Description
Fixes #820 
The code was wrong as it is impossible to destructure an immutable.js iterable.
Also, spreading an array into an array literal is only useful for copying an array, like array.slice(), and given that .slice() is available for Immutable Lists, a simple solution is to use it instead of [...array]

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
sorting is broken with immutable data, see #820 


**What is the new behavior?**
sorting works with immutable data, fixes #820 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
