### PR TITLE
Add componentWillReceiveProps to CellExpand

### DIFF
--- a/packages/react-data-grid/src/CellExpand.js
+++ b/packages/react-data-grid/src/CellExpand.js
@@ -7,7 +7,10 @@ const CellExpand = React.createClass({
     return { expanded: expanded };
   },
   componentWillReceiveProps(nextProps) {
-    this.setState({expanded: nextProps.expandableOptions && nextProps.expandableOptions.expanded});
+    let expanded = nextProps.expandableOptions && nextProps.expandableOptions.expanded;
+    if (this.state.expanded !== expanded) {
+      this.setState({expanded});
+    }
   },
   propTypes: {
     expandableOptions: PropTypes.object.isRequired,

--- a/packages/react-data-grid/src/CellExpand.js
+++ b/packages/react-data-grid/src/CellExpand.js
@@ -6,6 +6,9 @@ const CellExpand = React.createClass({
     let expanded = this.props.expandableOptions && this.props.expandableOptions.expanded;
     return { expanded: expanded };
   },
+  componentWillReceiveProps(nextProps) {
+    this.setState(this.getInitialState());
+  },
   propTypes: {
     expandableOptions: PropTypes.object.isRequired,
     onCellExpand: PropTypes.func.isRequired

--- a/packages/react-data-grid/src/CellExpand.js
+++ b/packages/react-data-grid/src/CellExpand.js
@@ -7,7 +7,7 @@ const CellExpand = React.createClass({
     return { expanded: expanded };
   },
   componentWillReceiveProps(nextProps) {
-    this.setState(this.getInitialState());
+    this.setState(nextProps.props.expandableOptions && nextProps.props.expandableOptions.expanded);
   },
   propTypes: {
     expandableOptions: PropTypes.object.isRequired,

--- a/packages/react-data-grid/src/CellExpand.js
+++ b/packages/react-data-grid/src/CellExpand.js
@@ -7,7 +7,7 @@ const CellExpand = React.createClass({
     return { expanded: expanded };
   },
   componentWillReceiveProps(nextProps) {
-    this.setState(nextProps.props.expandableOptions && nextProps.props.expandableOptions.expanded);
+    this.setState({expanded: nextProps.expandableOptions && nextProps.expandableOptions.expanded});
   },
   propTypes: {
     expandableOptions: PropTypes.object.isRequired,

--- a/packages/react-data-grid/src/__tests__/CellExpand.spec.js
+++ b/packages/react-data-grid/src/__tests__/CellExpand.spec.js
@@ -66,7 +66,7 @@ describe('CellExpand', () => {
     testElement.simulate('click');
     expect(testElement.state('expanded')).toBeTruthy();
     let secondProps = getFakeProps(false);
-    testElement = renderComponent(secondProps);
+    testElement.setProps(secondProps);
     expect(testElement.state('expanded')).toBeFalsy();
   });
 });

--- a/packages/react-data-grid/src/__tests__/CellExpand.spec.js
+++ b/packages/react-data-grid/src/__tests__/CellExpand.spec.js
@@ -3,7 +3,7 @@ import CellExpand from '../CellExpand';
 import AppConstants from '../AppConstants';
 import { mount } from 'enzyme';
 
-describe('CellExpand', () => {
+fdescribe('CellExpand', () => {
   let testElement;
   let getFakeProps = (expanded) => {
     let expandableOptions = {expanded};
@@ -57,6 +57,16 @@ describe('CellExpand', () => {
     testElement.simulate('click');
     expect(testElement.state('expanded')).toBeTruthy();
     testElement.simulate('click');
+    expect(testElement.state('expanded')).toBeFalsy();
+  });
+
+  it('should correctly set state when receiving data from external source', () => {
+    let fakeProps = getFakeProps(false);
+    testElement = renderComponent(fakeProps);
+    testElement.simulate('click');
+    expect(testElement.state('expanded')).toBeTruthy();
+    let secondProps = getFakeProps(false);
+    testElement = renderComponent(secondProps);
     expect(testElement.state('expanded')).toBeFalsy();
   });
 });

--- a/packages/react-data-grid/src/__tests__/CellExpand.spec.js
+++ b/packages/react-data-grid/src/__tests__/CellExpand.spec.js
@@ -3,7 +3,7 @@ import CellExpand from '../CellExpand';
 import AppConstants from '../AppConstants';
 import { mount } from 'enzyme';
 
-fdescribe('CellExpand', () => {
+describe('CellExpand', () => {
   let testElement;
   let getFakeProps = (expanded) => {
     let expandableOptions = {expanded};


### PR DESCRIPTION
## Description
This PR will add componentWilLReceiveProps to CellExpand in order to update the state when receiving the *expanded" from external data.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
The subrow icon only changes with the click event.

**What is the new behavior?**
It will continue to change on the click event but also change when receiving the information by props.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```