### PR TITLE
fix for issue #831 || remove isMounted()

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -59,6 +59,10 @@ const Cell = React.createClass({
     };
   },
 
+  componentWillMount() {
+    this.mounted = true;
+  },
+
   componentDidMount() {
     this.checkFocus();
   },
@@ -102,6 +106,10 @@ const Cell = React.createClass({
       || this.hasChangedDependentValues(nextProps)
       || this.props.column.locked !== nextProps.column.locked;
     return shouldUpdate;
+  },
+
+  componentWillUnmount() {
+    this.mounted = false;
   },
 
   onCellClick(e) {
@@ -294,7 +302,7 @@ const Cell = React.createClass({
 
   setScrollLeft(scrollLeft: number) {
     let ctrl: any = this; // flow on windows has an outdated react declaration, once that gets updated, we can remove this
-    if (ctrl.isMounted()) {
+    if (ctrl.mounted) {
       let node = ReactDOM.findDOMNode(this);
       if (node) {
         let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Replace deprecated React.Component#isMounted()
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/adazzle/react-data-grid/issues/831


**What is the new behavior?**
on componentWillMount, this.mounted = true; on componentWillUnmount, this.mounted = false;


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
