### PR TITLE
Remove deprecated isMounted check and use refs to get dom node

### DIFF
--- a/packages/react-data-grid-addons/src/formatters/ImageFormatter.js
+++ b/packages/react-data-grid-addons/src/formatters/ImageFormatter.js
@@ -19,6 +19,14 @@ const ImageFormatter = React.createClass({
     this._load(this.props.value);
   },
 
+  componentDidMount() {
+    this._isMounted = true;
+  },
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  },
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
       this.setState({value: null});
@@ -53,7 +61,7 @@ const ImageFormatter = React.createClass({
   },
 
   _onLoad(src) {
-    if (this.isMounted() && src === this.props.value) {
+    if (this._isMounted && src === this.props.value) {
       this.setState({
         value: src
       });

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -1,6 +1,5 @@
 import _ from 'underscore';
 const React = require('react');
-const ReactDOM = require('react-dom');
 const joinClasses = require('classnames');
 const EditorContainer = require('./editors/EditorContainer');
 const ExcelColumn = require('./PropTypeShapes/ExcelColumn');
@@ -279,7 +278,7 @@ const Cell = React.createClass({
     let updateCellClass = this.getUpdateCellClass();
     // -> removing the class
     if (updateCellClass != null && updateCellClass !== '') {
-      let cellDOMNode = ReactDOM.findDOMNode(this);
+      let cellDOMNode = this.node;
       if (cellDOMNode.classList) {
         cellDOMNode.classList.remove(updateCellClass);
         // -> and re-adding the class
@@ -293,19 +292,16 @@ const Cell = React.createClass({
   },
 
   setScrollLeft(scrollLeft: number) {
-    let ctrl: any = this; // flow on windows has an outdated react declaration, once that gets updated, we can remove this
-    if (ctrl.isMounted()) {
-      let node = ReactDOM.findDOMNode(this);
-      if (node) {
-        let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
-        node.style.webkitTransform = transform;
-        node.style.transform = transform;
-      }
+    let node = this.node;
+    if (node) {
+      let transform = `translate3d(${scrollLeft}px, 0px, 0px)`;
+      node.style.webkitTransform = transform;
+      node.style.transform = transform;
     }
   },
 
   removeScroll() {
-    let node = ReactDOM.findDOMNode(this);
+    let node = this.node;
     if (node) {
       node.style.webkitTransform = null;
       node.style.transform = null;
@@ -392,7 +388,7 @@ const Cell = React.createClass({
       // Meaning focus should not be stolen from elements that the grid doesnt control.
       let dataGridDOMNode = this.props.cellMetaData && this.props.cellMetaData.getDataGridDOMNode ? this.props.cellMetaData.getDataGridDOMNode() : null;
       if (this.isFocusedOnCell() || this.isFocusedOnBody() || (dataGridDOMNode && dataGridDOMNode.contains(document.activeElement))) {
-        let cellDOMNode = ReactDOM.findDOMNode(this);
+        let cellDOMNode = this.node;
         if (cellDOMNode) {
           cellDOMNode.focus();
         }
@@ -486,9 +482,9 @@ const Cell = React.createClass({
     let isDeleteSubRowEnabled = this.props.cellMetaData.onDeleteSubRow ? true : false;
 
     if (treeDepth > 0 && isExpandCell) {
-      cellDeleter = <ChildRowDeleteButton treeDepth={treeDepth} cellHeight={this.props.height} siblingIndex={this.props.expandableOptions.subRowDetails.siblingIndex} numberSiblings={this.props.expandableOptions.subRowDetails.numberSiblings} onDeleteSubRow={this.onDeleteSubRow} isDeleteSubRowEnabled={isDeleteSubRowEnabled}/>;
+      cellDeleter = <ChildRowDeleteButton treeDepth={treeDepth} cellHeight={this.props.height} siblingIndex={this.props.expandableOptions.subRowDetails.siblingIndex} numberSiblings={this.props.expandableOptions.subRowDetails.numberSiblings} onDeleteSubRow={this.onDeleteSubRow} isDeleteSubRowEnabled={isDeleteSubRowEnabled} />;
     }
-    return (<div className="react-grid-Cell__value">{cellDeleter}<div  style={{ marginLeft: marginLeft }}><span>{CellContent}</span> {this.props.cellControls} {cellExpander}</div></div>);
+    return (<div className="react-grid-Cell__value">{cellDeleter}<div style={{ marginLeft: marginLeft }}><span>{CellContent}</span> {this.props.cellControls} {cellExpander}</div></div>);
   },
 
   render() {
@@ -513,7 +509,7 @@ const Cell = React.createClass({
 
 
     return (
-      <div {...this.getKnownDivProps() } className={className} style={style} {...events}>
+      <div {...this.getKnownDivProps() } className={className} style={style} {...events} ref={(node) => { this.node = node; }}>
         {cellContent}
         {dragHandle}
         {tooltip}

--- a/packages/react-data-grid/src/__tests__/Cell.spec.js
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.js
@@ -613,5 +613,11 @@ describe('Cell Tests', () => {
       expect(cellDiv.props().expandableOptions).toBeUndefined();
       expect(cellDiv.props().isScrolling).toBeUndefined();
     });
+    it('should set transform style when scrollLeft is called', () => {
+      const wrapper = renderComponent(requiredProperties);
+      wrapper.instance().setScrollLeft(200);
+      const node = wrapper.getDOMNode();
+      expect(node.style.transform).toBe('translate3d(200px, 0px, 0px)');
+    });
   });
 });


### PR DESCRIPTION
## Description
- Remove isMounted check as its usage is an [antipattern](https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html) and it has officially been deprecated. 
- Use refs instead of findDomNode to get a reference to the DOM node. React will call the ref callback with the DOM element when the component mounts, and call it with null when it unmounts. This removes the need to check whether the component is mounted or not as we can simply check the ref node before setting the style.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/adazzle/react-data-grid/issues/831
Deprecation warning: Cell: isMounted is deprecated. Instead, make sure to clean up subscriptions and pending requests in componentWillUnmount to prevent memory leaks.


**What is the new behavior?**
No "isMounted" warnings 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
