### PR TITLE
Fix incorrect class name usage on filter inputs

### DIFF
--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/NumericFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/NumericFilter.js
@@ -123,7 +123,7 @@ class NumericFilter extends React.Component {
     return (
       <div>
         <div style={columnStyle}>
-          <input key={inputKey} type="text" placeholder="e.g. 3,10-15,>20" className="form-control input-control-sm" onChange={this.handleChange} onKeyPress={this.handleKeyPress}/>
+          <input key={inputKey} type="text" placeholder="e.g. 3,10-15,>20" className="form-control form-control-sm" onChange={this.handleChange} onKeyPress={this.handleKeyPress}/>
         </div>
         <div className="input-sm">
           <span className="badge" style={badgeStyle} title={tooltipText}>?</span>

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/NumericFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/NumericFilter.js
@@ -123,7 +123,7 @@ class NumericFilter extends React.Component {
     return (
       <div>
         <div style={columnStyle}>
-          <input key={inputKey} type="text" placeholder="e.g. 3,10-15,>20" className="form-control input-sm" onChange={this.handleChange} onKeyPress={this.handleKeyPress}/>
+          <input key={inputKey} type="text" placeholder="e.g. 3,10-15,>20" className="form-control input-control-sm" onChange={this.handleChange} onKeyPress={this.handleKeyPress}/>
         </div>
         <div className="input-sm">
           <span className="badge" style={badgeStyle} title={tooltipText}>?</span>

--- a/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
@@ -24,7 +24,7 @@ const FilterableHeaderCell = React.createClass({
     }
 
     let inputKey = 'header-filter-' + this.props.column.key;
-    return (<input key={inputKey} type="text" className="form-control input-sm" placeholder="Search" value={this.state.filterTerm} onChange={this.handleChange}/>);
+    return (<input key={inputKey} type="text" className="form-control input-control-sm" placeholder="Search" value={this.state.filterTerm} onChange={this.handleChange}/>);
   },
 
   render: function(): ?ReactElement {

--- a/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
@@ -24,7 +24,7 @@ const FilterableHeaderCell = React.createClass({
     }
 
     let inputKey = 'header-filter-' + this.props.column.key;
-    return (<input key={inputKey} type="text" className="form-control input-control-sm" placeholder="Search" value={this.state.filterTerm} onChange={this.handleChange}/>);
+    return (<input key={inputKey} type="text" className="form-control form-control-sm" placeholder="Search" value={this.state.filterTerm} onChange={this.handleChange}/>);
   },
 
   render: function(): ?ReactElement {


### PR DESCRIPTION
## Description
Current filter inputs are too large due to using the erroneous input-sm class - should be using form-control-sm

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Column filter inputs are too large due to incorrect bootstrap class name usage


**What is the new behavior?**
Column filter inputs are smaller


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
