### PR TITLE
Pass sortDirection and onSort to custom sortable header cells

### DIFF
--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -84,10 +84,28 @@ const HeaderRow = React.createClass({
     return <SortableHeaderCell columnKey={column.key} onSort={this.props.onSort} sortDirection={sortDirection}/>;
   },
 
+  getCustomHeaderCell(column) {
+    let props = {};
+    if (this.getHeaderCellType(column) === HeaderCellType.SORTABLE) {
+      let sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
+      props = {
+        onSort: this.props.onSort,
+        sortDirection: sortDirection
+      };
+    }
+    if (React.isValidElement(column.headerRenderer)) {
+      if (typeof column.headerRenderer.type === 'string') {
+        return column.headerRenderer;
+      }
+      return React.cloneElement(column.headerRenderer, props);
+    }
+    return column.headerRenderer(props);
+  },
+
   getHeaderRenderer(column) {
     let renderer;
     if (column.headerRenderer && !this.props.filterable) {
-      renderer = column.headerRenderer;
+      renderer = this.getCustomHeaderCell(column);
     } else {
       let headerCellType = this.getHeaderCellType(column);
       switch (headerCellType) {


### PR DESCRIPTION
https://github.com/adazzle/react-data-grid/issues/804

## Description

When using the `headerRenderer` option, it's not possible to access `sortDirection` and `onSort` callback in the custom component or function.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Doc does not exists for this functionnality (headerRenderer).

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When using the `headerRenderer` option, we cannot access `sortDirection` and `onSort` callback.

**What is the new behavior?**

When using the `headerRenderer` option, `sortDirection` and `onSort` callback are passed to the custom component or function.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
