### PR TITLE
Cell.renderCellContent: pass column and rowIdx to formatter

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
+++ b/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
@@ -26,7 +26,8 @@ const Example = React.createClass({
       {
         key: 'id',
         name: 'ID',
-        width: 80
+        width: 80,
+        formatter: props => <span>{props.rowIdx + 1}</span>
       },
       {
         key: 'task',
@@ -66,7 +67,6 @@ const Example = React.createClass({
     let rows = [];
     for (let i = 1; i < 100; i++) {
       rows.push({
-        id: i,
         task: 'Task ' + i,
         complete: Math.min(100, Math.round(Math.random() * 110)),
         priority: ['Critical', 'High', 'Medium', 'Low'][Math.floor((Math.random() * 3) + 1)],

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -466,7 +466,10 @@ const Cell = React.createClass({
       props.dependentValues = this.getFormatterDependencies();
       CellContent = React.cloneElement(Formatter, props);
     } else if (isFunction(Formatter)) {
-      CellContent = <Formatter value={this.props.value} dependentValues={this.getFormatterDependencies()} />;
+      CellContent = (
+        <Formatter value={this.props.value} dependentValues={this.getFormatterDependencies()}
+          column={props.column} rowIdx={props.rowIdx} />
+      );
     } else {
       CellContent = <SimpleCellFormatter value={this.props.value} />;
     }


### PR DESCRIPTION
Passing the rowIdx to the formatter makes it possible to have a column
with the row index, without the need to include the index in the row
data. The column properties might be helpful, too.