### PR TITLE
col.editable should take precedence over col.editor when set to false

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -397,7 +397,13 @@ const Cell = React.createClass({
   },
 
   canEdit() {
-    return (this.props.column.editor != null) || this.props.column.editable;
+    const editorExists = col.editor != null;
+
+    if (this.props.column.editable === false && editorExists) {
+      return false;
+    }
+
+    return editorExists || this.props.column.editable;
   },
 
   canExpand() {

--- a/packages/react-data-grid/src/ColumnUtils.js
+++ b/packages/react-data-grid/src/ColumnUtils.js
@@ -32,7 +32,16 @@ module.exports = {
     if (col.editable != null && typeof(col.editable) === 'function') {
       return enableCellSelect === true && col.editable(rowData);
     }
-    return enableCellSelect === true && (!!col.editor || !!col.editable);
+
+    if (enableCellSelect === true) {
+      if (col.editable === false && col.editor != null) {
+        return false;
+      }
+
+      return !!col.editor || !!col.editable;
+    }
+
+    return false;
   },
 
   getValue(column, property) {

--- a/packages/react-data-grid/src/__tests__/ColumnUtils.spec.js
+++ b/packages/react-data-grid/src/__tests__/ColumnUtils.spec.js
@@ -109,6 +109,22 @@ describe('ColumnUtils tests', () => {
         expect(result).toBe(false);
       });
 
+      it('CanEdit returns false when col.editable is false, col.editor is defined and enableCellSelect is true', () => {
+        // Arrange
+        testProps.col.editable = false;
+        testProps.col.editor = {};
+        testProps.enableCellSelect = true;
+
+        // Act
+        let result = ColumnUtils.canEdit(testProps.col, testProps. RowData, testProps.enableCellSelect);
+
+        // Assert
+        expect(testProps.col.editor).not.toBe(undefined);
+        expect(testProps.col.editable).toBe(false);
+        expect(testProps.enableCellSelect).toBe(true);
+        expect(result).toBe(false);
+      });
+
       it('CanEdit returns false when col.editable is true and enableCellSelect is undefined', () => {
         // Arrange
         testProps.col.editable = true;


### PR DESCRIPTION
## Description
It should be possible to make columns with custom editors readonly by using `editable` prop.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Currently if i have some custom editor and explicitly set `editable` to `false`, the column remains editable which is at least unintuitive.


**What is the new behavior?**

With this change I can set `editable` to `false` and the column will be readonly regardless if the editor is defined or not.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
