### PR TITLE
Pull out PropTypes from React for React 16 transition

### DIFF
--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
@@ -1,5 +1,6 @@
 import 'react-select/dist/react-select.css';
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Select from 'react-select';
 import { utils, shapes } from 'react-data-grid';
 const { isEmptyArray } = utils;
@@ -79,7 +80,7 @@ class AutoCompleteFilter extends React.Component {
 
 AutoCompleteFilter.propTypes = {
   onChange: PropTypes.func.isRequired,
-  column: React.PropTypes.shape(ExcelColumn),
+  column: PropTypes.shape(ExcelColumn),
   getValidFilterValues: PropTypes.func,
   multiSelection: PropTypes.bool
 };

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/NumericFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/NumericFilter.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { shapes } from 'react-data-grid';
 const { ExcelColumn } = shapes;
@@ -134,7 +135,7 @@ class NumericFilter extends React.Component {
 }
 
 NumericFilter.propTypes = {
-  onChange: React.PropTypes.func.isRequired,
-  column: React.PropTypes.shape(ExcelColumn)
+  onChange: PropTypes.func.isRequired,
+  column: PropTypes.shape(ExcelColumn)
 };
 module.exports = NumericFilter;

--- a/packages/react-data-grid-addons/src/draggable-header/DraggableContainer.js
+++ b/packages/react-data-grid-addons/src/draggable-header/DraggableContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import DraggableHeaderCell from './DraggableHeaderCell';

--- a/packages/react-data-grid-addons/src/draggable-header/DraggableHeaderCell.js
+++ b/packages/react-data-grid-addons/src/draggable-header/DraggableHeaderCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { DragSource, DropTarget } from 'react-dnd';
 import { HeaderCell } from 'react-data-grid';
 

--- a/packages/react-data-grid-addons/src/draggable/DragDropContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DragDropContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContext } from 'react-dnd';
@@ -36,8 +37,8 @@ class DraggableContainer extends Component {
 }
 
 DraggableContainer.propTypes = {
-  children: React.PropTypes.element.isRequired,
-  getDragPreviewRow: React.PropTypes.func
+  children: PropTypes.element.isRequired,
+  getDragPreviewRow: PropTypes.func
 };
 
 export default DragDropContext(HTML5Backend)(DraggableContainer);

--- a/packages/react-data-grid-addons/src/draggable/DraggableHeaderCell.js
+++ b/packages/react-data-grid-addons/src/draggable/DraggableHeaderCell.js
@@ -1,5 +1,6 @@
 import { DragSource } from 'react-dnd';
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { _constants, HeaderCell } from 'react-data-grid';
 const { DragItemTypes } = _constants;
 

--- a/packages/react-data-grid-addons/src/draggable/RowActionsCell.js
+++ b/packages/react-data-grid-addons/src/draggable/RowActionsCell.js
@@ -1,5 +1,6 @@
 import '../../../../themes/react-data-grid-row.css';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { DragSource } from 'react-dnd';
 import { editors } from 'react-data-grid';
 const { CheckboxEditor } = editors;

--- a/packages/react-data-grid-addons/src/draggable/RowDragLayer.js
+++ b/packages/react-data-grid-addons/src/draggable/RowDragLayer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { DragLayer } from 'react-dnd';
 import Selectors from '../data/Selectors';
 import '../../../../themes/react-data-grid-cell.css';

--- a/packages/react-data-grid-addons/src/editors/AutoCompleteEditor.js
+++ b/packages/react-data-grid-addons/src/editors/AutoCompleteEditor.js
@@ -1,29 +1,30 @@
+const PropTypes = require('prop-types');
 const React                   = require('react');
 const ReactDOM                = require('react-dom');
 const ReactAutocomplete       = require('ron-react-autocomplete');
 const { shapes: { ExcelColumn } } = require('react-data-grid');
 require('../../../../themes/ron-react-autocomplete.css');
 
-let optionPropType = React.PropTypes.shape({
-  id: React.PropTypes.required,
-  title: React.PropTypes.string
+let optionPropType = PropTypes.shape({
+  id: PropTypes.required,
+  title: PropTypes.string
 });
 
 const AutoCompleteEditor = React.createClass({
 
   propTypes: {
-    onCommit: React.PropTypes.func,
-    options: React.PropTypes.arrayOf(optionPropType),
-    label: React.PropTypes.any,
-    value: React.PropTypes.any,
-    height: React.PropTypes.number,
-    valueParams: React.PropTypes.arrayOf(React.PropTypes.string),
-    column: React.PropTypes.shape(ExcelColumn),
-    resultIdentifier: React.PropTypes.string,
-    search: React.PropTypes.string,
-    onKeyDown: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
-    editorDisplayValue: React.PropTypes.func
+    onCommit: PropTypes.func,
+    options: PropTypes.arrayOf(optionPropType),
+    label: PropTypes.any,
+    value: PropTypes.any,
+    height: PropTypes.number,
+    valueParams: PropTypes.arrayOf(PropTypes.string),
+    column: PropTypes.shape(ExcelColumn),
+    resultIdentifier: PropTypes.string,
+    search: PropTypes.string,
+    onKeyDown: PropTypes.func,
+    onFocus: PropTypes.func,
+    editorDisplayValue: PropTypes.func
   },
 
   getDefaultProps(): {resultIdentifier: string} {

--- a/packages/react-data-grid-addons/src/editors/AutoCompleteTokensEditor.js
+++ b/packages/react-data-grid-addons/src/editors/AutoCompleteTokensEditor.js
@@ -1,21 +1,22 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Select from 'react-select';
 import ReactDOM from 'react-dom';
 import 'react-select/dist/react-select.css';
 
 const ExcelColumn = {
-  name: React.PropTypes.string.isRequired,
-  key: React.PropTypes.string.isRequired,
-  width: React.PropTypes.number.isRequired,
-  filterable: React.PropTypes.bool
+  name: PropTypes.string.isRequired,
+  key: PropTypes.string.isRequired,
+  width: PropTypes.number.isRequired,
+  filterable: PropTypes.bool
 };
 
 class AutoCompleteTokensEditor extends Component {
 
   static propTypes = {
-    options: React.PropTypes.array.isRequired,
-    column: React.PropTypes.shape(ExcelColumn),
-    value: React.PropTypes.array
+    options: PropTypes.array.isRequired,
+    column: PropTypes.shape(ExcelColumn),
+    value: PropTypes.array
   }
 
   constructor(props) {

--- a/packages/react-data-grid-addons/src/editors/DateRangeEditor.js
+++ b/packages/react-data-grid-addons/src/editors/DateRangeEditor.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const Moment = require('moment');
@@ -7,11 +8,11 @@ type DateRangeValue = { startDate: Date; endDate: Date};
 const DateRangeEditor = React.createClass({
 
   propTypes: {
-    format: React.PropTypes.string,
-    ranges: React.PropTypes.arrayOf(React.PropTypes.string),
-    value: React.PropTypes.shape({
-      startDate: React.PropTypes.Date.isRequired,
-      endDate: React.PropTypes.Date.isRequired
+    format: PropTypes.string,
+    ranges: PropTypes.arrayOf(PropTypes.string),
+    value: PropTypes.shape({
+      startDate: PropTypes.Date.isRequired,
+      endDate: PropTypes.Date.isRequired
     }).isRequired
   },
 

--- a/packages/react-data-grid-addons/src/editors/DropDownEditor.js
+++ b/packages/react-data-grid-addons/src/editors/DropDownEditor.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const { editors: { EditorBase } } = require('react-data-grid');
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 class DropDownEditor extends EditorBase {
@@ -37,13 +38,13 @@ class DropDownEditor extends EditorBase {
 }
 
 DropDownEditor.propTypes = {
-  options: React.PropTypes.arrayOf(React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.shape({
-      id: React.PropTypes.string,
-      title: React.PropTypes.string,
-      value: React.PropTypes.string,
-      text: React.PropTypes.string
+  options: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      id: PropTypes.string,
+      title: PropTypes.string,
+      value: PropTypes.string,
+      text: PropTypes.string
     })
   ])).isRequired
 };

--- a/packages/react-data-grid-addons/src/editors/__tests__/ContainerEditorWrapper.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/ContainerEditorWrapper.spec.js
@@ -1,4 +1,5 @@
 const Enzyme = require('enzyme');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 const ContainerEditorWrapper = require('../ContainerEditorWrapper');
@@ -14,7 +15,7 @@ class FakeContainer extends React.Component {
 }
 
 FakeContainer.propTypes = {
-  refCallback: React.PropTypes.func.IsRequired
+  refCallback: PropTypes.func.IsRequired
 };
 
 describe('ContainerEditorWrapper', () => {

--- a/packages/react-data-grid-addons/src/editors/widgets/DateRangeFilter.js
+++ b/packages/react-data-grid-addons/src/editors/widgets/DateRangeFilter.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const Moment 		 = require('moment');
@@ -1141,11 +1142,11 @@ let DateRangeFilter = React.createClass({
   },
 
   propTypes: {
-    format: React.PropTypes.string.isRequired,
-    ranges: React.PropTypes.object.isRequired,
-    onApply: React.PropTypes.func,
-    title: React.PropTypes.string.isRequired,
-    onblur: React.PropTypes.func,
+    format: PropTypes.string.isRequired,
+    ranges: PropTypes.object.isRequired,
+    onApply: PropTypes.func,
+    title: PropTypes.string.isRequired,
+    onblur: PropTypes.func,
     startDate: validateDate,
     endDate: validateDate
   },

--- a/packages/react-data-grid-addons/src/formatters/DateRangeFormatter.js
+++ b/packages/react-data-grid-addons/src/formatters/DateRangeFormatter.js
@@ -1,7 +1,7 @@
 
+const PropTypes = require('prop-types');
 const React          = require('react');
 const moment         = require('moment');
-const PropTypes = React.PropTypes;
 
 const DateRangeFormatter = React.createClass({
 

--- a/packages/react-data-grid-addons/src/formatters/DropDownFormatter.js
+++ b/packages/react-data-grid-addons/src/formatters/DropDownFormatter.js
@@ -1,20 +1,21 @@
+const PropTypes = require('prop-types');
 // Used for displaying the value of a dropdown (using DropDownEditor) when not editing it.
 // Accepts the same parameters as the DropDownEditor.
 const React = require('react');
 
 const DropDownFormatter = React.createClass({
   propTypes: {
-    options: React.PropTypes.arrayOf(
-      React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.shape({
-          id: React.PropTypes.string,
-          title: React.PropTypes.string,
-          value: React.PropTypes.string,
-          text: React.PropTypes.string
+    options: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({
+          id: PropTypes.string,
+          title: PropTypes.string,
+          value: PropTypes.string,
+          text: PropTypes.string
         })
       ])).isRequired,
-    value: React.PropTypes.string.isRequired
+    value: PropTypes.string.isRequired
   },
 
   shouldComponentUpdate(nextProps: any): boolean {

--- a/packages/react-data-grid-addons/src/formatters/ImageFormatter.js
+++ b/packages/react-data-grid-addons/src/formatters/ImageFormatter.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 require('../../../../themes/react-data-grid-image.css');
 
@@ -6,7 +7,7 @@ let ReadyPool = {};
 
 const ImageFormatter = React.createClass({
   propTypes: {
-    value: React.PropTypes.string.isRequired
+    value: PropTypes.string.isRequired
   },
 
   getInitialState() {

--- a/packages/react-data-grid-addons/src/menu/ContextMenu.js
+++ b/packages/react-data-grid-addons/src/menu/ContextMenu.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {ContextMenu} from 'react-contextmenu';
 
 class ReactDataGridContextMenu extends React.Component {

--- a/packages/react-data-grid-addons/src/menu/MenuHeader.js
+++ b/packages/react-data-grid-addons/src/menu/MenuHeader.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class MenuHeader extends React.Component {
   render() {

--- a/packages/react-data-grid-addons/src/toolbars/AdvancedToolbar.js
+++ b/packages/react-data-grid-addons/src/toolbars/AdvancedToolbar.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import '../../../../themes/react-data-grid-toolbar.css';
 
 const propTypes = {

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class GroupedColumnButton extends Component {
   render() {

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnsPanel.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnsPanel.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { DropTarget } from 'react-dnd';
 import GroupedColumnButton from './GroupedColumnButton';
 import { _constants } from 'react-data-grid';

--- a/packages/react-data-grid-addons/src/toolbars/Toolbar.js
+++ b/packages/react-data-grid-addons/src/toolbars/Toolbar.js
@@ -1,15 +1,16 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 require('../../../../themes/react-data-grid-toolbar.css');
 
 const Toolbar = React.createClass({
   propTypes: {
-    onAddRow: React.PropTypes.func,
-    onToggleFilter: React.PropTypes.func,
-    enableFilter: React.PropTypes.bool,
-    numberOfRows: React.PropTypes.number,
-    addRowButtonText: React.PropTypes.string,
-    filterRowsButtonText: React.PropTypes.string,
-    children: React.PropTypes.any
+    onAddRow: PropTypes.func,
+    onToggleFilter: PropTypes.func,
+    enableFilter: PropTypes.bool,
+    numberOfRows: PropTypes.number,
+    addRowButtonText: PropTypes.string,
+    filterRowsButtonText: PropTypes.string,
+    children: PropTypes.any
   },
 
   onAddRow() {

--- a/packages/react-data-grid-examples/src/components/ExampleList.js
+++ b/packages/react-data-grid-examples/src/components/ExampleList.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class ExampleList extends React.Component {
   render() {

--- a/packages/react-data-grid-examples/src/components/Navbar.js
+++ b/packages/react-data-grid-examples/src/components/Navbar.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ExampleList from './ExampleList';
 
 class Navbar extends React.Component {

--- a/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
+++ b/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
@@ -1,11 +1,12 @@
 const ReactDataGrid = require('react-data-grid');
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 // Custom Formatter component
 const PercentCompleteFormatter = React.createClass({
   propTypes: {
-    value: React.PropTypes.number.isRequired
+    value: PropTypes.number.isRequired
   },
 
   render() {

--- a/packages/react-data-grid-examples/src/scripts/example12-customRowRenderer.js
+++ b/packages/react-data-grid-examples/src/scripts/example12-customRowRenderer.js
@@ -1,11 +1,12 @@
 const ReactDataGrid = require('react-data-grid');
 const { Row } = ReactDataGrid;
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 
 const RowRenderer = React.createClass({
   propTypes: {
-    idx: React.PropTypes.string.isRequired
+    idx: PropTypes.string.isRequired
   },
 
   setScrollLeft(scrollBy) {

--- a/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
+++ b/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
@@ -1,5 +1,6 @@
 const ReactDataGrid = require('react-data-grid');
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 const FakeObjectDataStore = require('./FakeObjectDataStore');
 const Immutable = require('immutable');
@@ -166,8 +167,8 @@ const columns = [
 
 const MyContextMenu = React.createClass({
   propTypes: {
-    rowIdx: React.PropTypes.string.isRequired,
-    idx: React.PropTypes.string.isRequired
+    rowIdx: PropTypes.string.isRequired,
+    idx: PropTypes.string.isRequired
   },
 
   onItemClick() {
@@ -184,7 +185,7 @@ const MyContextMenu = React.createClass({
 
 const Component = React.createClass({
   propTypes: {
-    handleCellDrag: React.PropTypes.func.isRequired
+    handleCellDrag: PropTypes.func.isRequired
   },
 
   getInitialState() {

--- a/packages/react-data-grid-examples/src/scripts/example18-context-menu.js
+++ b/packages/react-data-grid-examples/src/scripts/example18-context-menu.js
@@ -1,5 +1,6 @@
 const ReactDataGrid = require('react-data-grid');
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 const { Menu: { ContextMenu, MenuItem, SubMenu } } = require('react-data-grid-addons');
 
@@ -69,11 +70,11 @@ const Example = React.createClass({
 // Use this.props.rowIdx and this.props.idx to get the row/column where the menu is shown.
 const MyContextMenu = React.createClass({
   propTypes: {
-    onRowDelete: React.PropTypes.func.isRequired,
-    onRowInsertAbove: React.PropTypes.func.isRequired,
-    onRowInsertBelow: React.PropTypes.func.isRequired,
-    rowIdx: React.PropTypes.string.isRequired,
-    idx: React.PropTypes.string.isRequired
+    onRowDelete: PropTypes.func.isRequired,
+    onRowInsertAbove: PropTypes.func.isRequired,
+    onRowInsertBelow: PropTypes.func.isRequired,
+    rowIdx: PropTypes.string.isRequired,
+    idx: PropTypes.string.isRequired
   },
 
   onRowDelete(e, data) {

--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -1,6 +1,7 @@
 const faker = require('faker');
 const ReactDataGrid = require('react-data-grid');
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 const {
   ToolsPanel: { AdvancedToolbar: Toolbar, GroupedColumnsPanel },
@@ -127,9 +128,9 @@ const columns = [
 
 const CustomToolbar = React.createClass({
   propTypes: {
-    groupBy: React.PropTypes.array.isRequired,
-    onColumnGroupAdded: React.PropTypes.func.isRequired,
-    onColumnGroupDeleted: React.PropTypes.func.isRequired
+    groupBy: PropTypes.array.isRequired,
+    onColumnGroupAdded: PropTypes.func.isRequired,
+    onColumnGroupDeleted: PropTypes.func.isRequired
   },
 
   render() {

--- a/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
@@ -1,5 +1,6 @@
 const ReactDataGrid = require('react-data-grid');
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 const faker = require('faker');
 const Immutable = require('immutable');
@@ -28,9 +29,9 @@ for (let rowIdx = 1; rowIdx < 100; rowIdx++) {
 
 const CustomToolbar = React.createClass({
   propTypes: {
-    groupBy: React.PropTypes.array.isRequired,
-    onColumnGroupAdded: React.PropTypes.func.isRequired,
-    onColumnGroupDeleted: React.PropTypes.func.isRequired
+    groupBy: PropTypes.array.isRequired,
+    onColumnGroupAdded: PropTypes.func.isRequired,
+    onColumnGroupDeleted: PropTypes.func.isRequired
   },
 
   render() {

--- a/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
@@ -1,5 +1,6 @@
 const ReactDataGrid = require('react-data-grid');
 const exampleWrapper = require('../components/exampleWrapper');
+const PropTypes = require('prop-types');
 const React = require('react');
 const {
    Draggable: { Container: DraggableContainer, RowActionsCell, DropTargetRowContainer },
@@ -10,7 +11,7 @@ const RowRenderer = DropTargetRowContainer(ReactDataGrid.Row);
 
 const Example = React.createClass({
   propTypes: {
-    rowKey: React.PropTypes.string.isRequired
+    rowKey: PropTypes.string.isRequired
   },
 
   getInitialState() {

--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -1,7 +1,7 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const joinClasses = require('classnames');
-const PropTypes = React.PropTypes;
 const ScrollShim = require('./ScrollShim');
 const Row = require('./Row');
 const cellMetaDataShape = require('./PropTypeShapes/CellMetaDataShape');
@@ -42,26 +42,26 @@ const Canvas = React.createClass({
     columns: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
     cellMetaData: PropTypes.shape(cellMetaDataShape).isRequired,
     selectedRows: PropTypes.array,
-    rowKey: React.PropTypes.string,
-    rowScrollTimeout: React.PropTypes.number,
+    rowKey: PropTypes.string,
+    rowScrollTimeout: PropTypes.number,
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
-    rowSelection: React.PropTypes.oneOfType([
-      React.PropTypes.shape({
-        indexes: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
+    rowSelection: PropTypes.oneOfType([
+      PropTypes.shape({
+        indexes: PropTypes.arrayOf(PropTypes.number).isRequired
       }),
-      React.PropTypes.shape({
-        isSelectedKey: React.PropTypes.string.isRequired
+      PropTypes.shape({
+        isSelectedKey: PropTypes.string.isRequired
       }),
-      React.PropTypes.shape({
-        keys: React.PropTypes.shape({
-          values: React.PropTypes.array.isRequired,
-          rowKey: React.PropTypes.string.isRequired
+      PropTypes.shape({
+        keys: PropTypes.shape({
+          values: PropTypes.array.isRequired,
+          rowKey: PropTypes.string.isRequired
         }).isRequired
       })
     ]),
-    rowGroupRenderer: React.PropTypes.func,
-    isScrolling: React.PropTypes.bool
+    rowGroupRenderer: PropTypes.func,
+    isScrolling: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 const React = require('react');
 const joinClasses = require('classnames');
@@ -18,28 +19,28 @@ const knownDivPropertyKeys = ['height', 'tabIndex', 'value'];
 const Cell = React.createClass({
 
   propTypes: {
-    rowIdx: React.PropTypes.number.isRequired,
-    idx: React.PropTypes.number.isRequired,
-    selected: React.PropTypes.shape({
-      idx: React.PropTypes.number.isRequired
+    rowIdx: PropTypes.number.isRequired,
+    idx: PropTypes.number.isRequired,
+    selected: PropTypes.shape({
+      idx: PropTypes.number.isRequired
     }),
-    selectedColumn: React.PropTypes.object,
-    height: React.PropTypes.number,
-    tabIndex: React.PropTypes.number,
-    column: React.PropTypes.shape(ExcelColumn).isRequired,
-    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool]),
-    isExpanded: React.PropTypes.bool,
-    isRowSelected: React.PropTypes.bool,
-    cellMetaData: React.PropTypes.shape(CellMetaDataShape).isRequired,
-    handleDragStart: React.PropTypes.func,
-    className: React.PropTypes.string,
-    cellControls: React.PropTypes.any,
-    rowData: React.PropTypes.object.isRequired,
-    forceUpdate: React.PropTypes.bool,
-    expandableOptions: React.PropTypes.object.isRequired,
-    isScrolling: React.PropTypes.bool.isRequired,
-    tooltip: React.PropTypes.string,
-    isCellValueChanging: React.PropTypes.func
+    selectedColumn: PropTypes.object,
+    height: PropTypes.number,
+    tabIndex: PropTypes.number,
+    column: PropTypes.shape(ExcelColumn).isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object, PropTypes.bool]),
+    isExpanded: PropTypes.bool,
+    isRowSelected: PropTypes.bool,
+    cellMetaData: PropTypes.shape(CellMetaDataShape).isRequired,
+    handleDragStart: PropTypes.func,
+    className: PropTypes.string,
+    cellControls: PropTypes.any,
+    rowData: PropTypes.object.isRequired,
+    forceUpdate: PropTypes.bool,
+    expandableOptions: PropTypes.object.isRequired,
+    isScrolling: PropTypes.bool.isRequired,
+    tooltip: PropTypes.string,
+    isCellValueChanging: PropTypes.func
   },
 
   getDefaultProps() {

--- a/packages/react-data-grid/src/CellExpand.js
+++ b/packages/react-data-grid/src/CellExpand.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import AppConstants from './AppConstants';
 
 const CellExpand = React.createClass({

--- a/packages/react-data-grid/src/DOMMetrics.js
+++ b/packages/react-data-grid/src/DOMMetrics.js
@@ -1,5 +1,4 @@
 const PropTypes = require('prop-types');
-const React               = require('react');
 const shallowCloneObject  = require('./shallowCloneObject');
 
 let contextTypes = {

--- a/packages/react-data-grid/src/DOMMetrics.js
+++ b/packages/react-data-grid/src/DOMMetrics.js
@@ -1,8 +1,9 @@
+const PropTypes = require('prop-types');
 const React               = require('react');
 const shallowCloneObject  = require('./shallowCloneObject');
 
 let contextTypes = {
-  metricsComputator: React.PropTypes.object
+  metricsComputator: PropTypes.object
 };
 
 let MetricsComputatorMixin = {

--- a/packages/react-data-grid/src/Draggable.js
+++ b/packages/react-data-grid/src/Draggable.js
@@ -1,5 +1,5 @@
+const PropTypes = require('prop-types');
 const React         = require('react');
-const PropTypes     = React.PropTypes;
 const createObjectWithProperties = require('./createObjectWithProperties');
 require('../../../themes/react-data-grid-header.css');
 

--- a/packages/react-data-grid/src/EmptyChildRow.js
+++ b/packages/react-data-grid/src/EmptyChildRow.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ColumnUtils from './ColumnUtils';
 
 class EmptyChildRow extends React.Component {

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -1,5 +1,5 @@
+const PropTypes = require('prop-types');
 const React                = require('react');
-const PropTypes            = React.PropTypes;
 const Header               = require('./Header');
 const Viewport             = require('./Viewport');
 const GridScrollMixin      = require('./GridScrollMixin');
@@ -20,24 +20,24 @@ const Grid = React.createClass({
     emptyRowsView: PropTypes.func,
     expandedRows: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
     selectedRows: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
-    rowSelection: React.PropTypes.oneOfType([
-      React.PropTypes.shape({
-        indexes: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
+    rowSelection: PropTypes.oneOfType([
+      PropTypes.shape({
+        indexes: PropTypes.arrayOf(PropTypes.number).isRequired
       }),
-      React.PropTypes.shape({
-        isSelectedKey: React.PropTypes.string.isRequired
+      PropTypes.shape({
+        isSelectedKey: PropTypes.string.isRequired
       }),
-      React.PropTypes.shape({
-        keys: React.PropTypes.shape({
-          values: React.PropTypes.array.isRequired,
-          rowKey: React.PropTypes.string.isRequired
+      PropTypes.shape({
+        keys: PropTypes.shape({
+          values: PropTypes.array.isRequired,
+          rowKey: PropTypes.string.isRequired
         }).isRequired
       })
     ]),
     rowsCount: PropTypes.number,
     onRows: PropTypes.func,
-    sortColumn: React.PropTypes.string,
-    sortDirection: React.PropTypes.oneOf(['ASC', 'DESC', 'NONE']),
+    sortColumn: PropTypes.string,
+    sortDirection: PropTypes.oneOf(['ASC', 'DESC', 'NONE']),
     rowOffsetHeight: PropTypes.number.isRequired,
     onViewportKeydown: PropTypes.func.isRequired,
     onViewportKeyup: PropTypes.func,

--- a/packages/react-data-grid/src/Header.js
+++ b/packages/react-data-grid/src/Header.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React               = require('react');
 const ReactDOM            = require('react-dom');
 const joinClasses         = require('classnames');
@@ -6,7 +7,6 @@ const ColumnMetrics       = require('./ColumnMetrics');
 const ColumnUtils         = require('./ColumnUtils');
 const HeaderRow           = require('./HeaderRow');
 const getScrollbarSize  = require('./getScrollbarSize');
-const PropTypes           = React.PropTypes;
 const createObjectWithProperties = require('./createObjectWithProperties');
 const cellMetaDataShape    = require('./PropTypeShapes/CellMetaDataShape');
 require('../../../themes/react-data-grid-header.css');

--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -1,11 +1,10 @@
+const PropTypes = require('prop-types');
 const React          = require('react');
 const ReactDOM      = require('react-dom');
 const joinClasses    = require('classnames');
 const ExcelColumn    = require('./PropTypeShapes/ExcelColumn');
 const ResizeHandle   = require('./ResizeHandle');
 require('../../../themes/react-data-grid-header.css');
-
-const PropTypes      = React.PropTypes;
 
 function simpleCellRenderer(objArgs: {column: {name: string}}): ReactElement {
   let headerText = objArgs.column.rowType === 'header' ? objArgs.column.name : '';

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React             = require('react');
 const shallowEqual    = require('fbjs/lib/shallowEqual');
 const BaseHeaderCell        = require('./HeaderCell');
@@ -10,13 +11,11 @@ const HeaderCellType = require('./HeaderCellType');
 const createObjectWithProperties = require('./createObjectWithProperties');
 require('../../../themes/react-data-grid-header.css');
 
-const PropTypes         = React.PropTypes;
-
 const HeaderRowStyle  = {
-  overflow: React.PropTypes.string,
+  overflow: PropTypes.string,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  height: React.PropTypes.number,
-  position: React.PropTypes.string
+  height: PropTypes.number,
+  position: PropTypes.string
 };
 
 // The list of the propTypes that we want to include in the HeaderRow div
@@ -32,7 +31,7 @@ const HeaderRow = React.createClass({
     onColumnResizeEnd: PropTypes.func,
     style: PropTypes.shape(HeaderRowStyle),
     sortColumn: PropTypes.string,
-    sortDirection: React.PropTypes.oneOf(Object.keys(SortableHeaderCell.DEFINE_SORT)),
+    sortDirection: PropTypes.oneOf(Object.keys(SortableHeaderCell.DEFINE_SORT)),
     cellRenderer: PropTypes.func,
     headerCellRenderer: PropTypes.func,
     filterable: PropTypes.bool,

--- a/packages/react-data-grid/src/OverflowCell.js
+++ b/packages/react-data-grid/src/OverflowCell.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import focusableComponentWrapper from './focusableComponentWrapper';
 import '../../../themes/react-data-grid-cell.css';
@@ -31,11 +32,11 @@ OverflowCell.isSelected = (props) => {
 OverflowCell.isScrolling = props => props.cellMetaData.isScrollingHorizontallyWithKeyboard;
 
 OverflowCell.propTypes = {
-  rowIdx: React.PropTypes.number,
-  idx: React.PropTypes.number,
-  height: React.PropTypes.number,
-  column: React.PropTypes.object,
-  cellMetaData: React.PropTypes.object
+  rowIdx: PropTypes.number,
+  idx: PropTypes.number,
+  height: PropTypes.number,
+  column: PropTypes.object,
+  cellMetaData: PropTypes.object
 };
 
 OverflowCell.displayName = 'Cell';

--- a/packages/react-data-grid/src/OverflowRow.js
+++ b/packages/react-data-grid/src/OverflowRow.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import focusableComponentWrapper from './focusableComponentWrapper';
 import '../../../themes/react-data-grid-row.css';
@@ -20,9 +21,9 @@ OverflowRow.isSelected = props => {
 OverflowRow.isScrolling = props => props.cellMetaData.isScrollingVerticallyWithKeyboard;
 
 OverflowRow.propTypes = {
-  idx: React.PropTypes.number,
-  height: React.PropTypes.number,
-  cellMetaData: React.PropTypes.object
+  idx: PropTypes.number,
+  height: PropTypes.number,
+  cellMetaData: PropTypes.object
 };
 
 const OverflowRowComponent = OverflowRow;

--- a/packages/react-data-grid/src/PropTypeShapes/ExcelColumn.js
+++ b/packages/react-data-grid/src/PropTypeShapes/ExcelColumn.js
@@ -1,11 +1,12 @@
+const PropTypes = require('prop-types');
 /* @flow */
 const React = require('react');
 
 const ExcelColumnShape = {
-  name: React.PropTypes.node.isRequired,
-  key: React.PropTypes.string.isRequired,
-  width: React.PropTypes.number.isRequired,
-  filterable: React.PropTypes.bool
+  name: PropTypes.node.isRequired,
+  key: PropTypes.string.isRequired,
+  width: PropTypes.number.isRequired,
+  filterable: PropTypes.bool
 };
 
 module.exports = ExcelColumnShape;

--- a/packages/react-data-grid/src/PropTypeShapes/ExcelColumn.js
+++ b/packages/react-data-grid/src/PropTypeShapes/ExcelColumn.js
@@ -1,6 +1,5 @@
-const PropTypes = require('prop-types');
 /* @flow */
-const React = require('react');
+const PropTypes = require('prop-types');
 
 const ExcelColumnShape = {
   name: PropTypes.node.isRequired,

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React                 = require('react');
 const ReactDOM = require('react-dom');
 const BaseGrid              = require('./Grid');
@@ -51,68 +52,68 @@ const ReactDataGrid = React.createClass({
   ],
 
   propTypes: {
-    rowHeight: React.PropTypes.number.isRequired,
-    headerRowHeight: React.PropTypes.number,
-    headerFiltersHeight: React.PropTypes.number,
-    minHeight: React.PropTypes.number.isRequired,
-    minWidth: React.PropTypes.number,
-    enableRowSelect: React.PropTypes.oneOfType([React.PropTypes.bool, React.PropTypes.string]),
-    onRowUpdated: React.PropTypes.func,
-    rowGetter: React.PropTypes.func.isRequired,
-    rowsCount: React.PropTypes.number.isRequired,
-    toolbar: React.PropTypes.element,
-    enableCellSelect: React.PropTypes.bool,
-    columns: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]).isRequired,
-    onFilter: React.PropTypes.func,
-    onCellCopyPaste: React.PropTypes.func,
-    onCellsDragged: React.PropTypes.func,
-    onAddFilter: React.PropTypes.func,
-    onGridSort: React.PropTypes.func,
-    onDragHandleDoubleClick: React.PropTypes.func,
-    onGridRowsUpdated: React.PropTypes.func,
-    onRowSelect: React.PropTypes.func,
-    rowKey: React.PropTypes.string,
-    rowScrollTimeout: React.PropTypes.number,
-    onClearFilters: React.PropTypes.func,
-    contextMenu: React.PropTypes.element,
-    cellNavigationMode: React.PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
-    onCellSelected: React.PropTypes.func,
-    onCellDeSelected: React.PropTypes.func,
-    onCellExpand: React.PropTypes.func,
-    enableDragAndDrop: React.PropTypes.bool,
-    onRowExpandToggle: React.PropTypes.func,
-    draggableHeaderCell: React.PropTypes.func,
-    getValidFilterValues: React.PropTypes.func,
-    rowSelection: React.PropTypes.shape({
-      enableShiftSelect: React.PropTypes.bool,
-      onRowsSelected: React.PropTypes.func,
-      onRowsDeselected: React.PropTypes.func,
-      showCheckbox: React.PropTypes.bool,
-      selectBy: React.PropTypes.oneOfType([
-        React.PropTypes.shape({
-          indexes: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
+    rowHeight: PropTypes.number.isRequired,
+    headerRowHeight: PropTypes.number,
+    headerFiltersHeight: PropTypes.number,
+    minHeight: PropTypes.number.isRequired,
+    minWidth: PropTypes.number,
+    enableRowSelect: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    onRowUpdated: PropTypes.func,
+    rowGetter: PropTypes.func.isRequired,
+    rowsCount: PropTypes.number.isRequired,
+    toolbar: PropTypes.element,
+    enableCellSelect: PropTypes.bool,
+    columns: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+    onFilter: PropTypes.func,
+    onCellCopyPaste: PropTypes.func,
+    onCellsDragged: PropTypes.func,
+    onAddFilter: PropTypes.func,
+    onGridSort: PropTypes.func,
+    onDragHandleDoubleClick: PropTypes.func,
+    onGridRowsUpdated: PropTypes.func,
+    onRowSelect: PropTypes.func,
+    rowKey: PropTypes.string,
+    rowScrollTimeout: PropTypes.number,
+    onClearFilters: PropTypes.func,
+    contextMenu: PropTypes.element,
+    cellNavigationMode: PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
+    onCellSelected: PropTypes.func,
+    onCellDeSelected: PropTypes.func,
+    onCellExpand: PropTypes.func,
+    enableDragAndDrop: PropTypes.bool,
+    onRowExpandToggle: PropTypes.func,
+    draggableHeaderCell: PropTypes.func,
+    getValidFilterValues: PropTypes.func,
+    rowSelection: PropTypes.shape({
+      enableShiftSelect: PropTypes.bool,
+      onRowsSelected: PropTypes.func,
+      onRowsDeselected: PropTypes.func,
+      showCheckbox: PropTypes.bool,
+      selectBy: PropTypes.oneOfType([
+        PropTypes.shape({
+          indexes: PropTypes.arrayOf(PropTypes.number).isRequired
         }),
-        React.PropTypes.shape({
-          isSelectedKey: React.PropTypes.string.isRequired
+        PropTypes.shape({
+          isSelectedKey: PropTypes.string.isRequired
         }),
-        React.PropTypes.shape({
-          keys: React.PropTypes.shape({
-            values: React.PropTypes.array.isRequired,
-            rowKey: React.PropTypes.string.isRequired
+        PropTypes.shape({
+          keys: PropTypes.shape({
+            values: PropTypes.array.isRequired,
+            rowKey: PropTypes.string.isRequired
           }).isRequired
         })
       ]).isRequired
     }),
-    onRowClick: React.PropTypes.func,
-    onGridKeyUp: React.PropTypes.func,
-    onGridKeyDown: React.PropTypes.func,
-    rowGroupRenderer: React.PropTypes.func,
-    rowActionsCell: React.PropTypes.func,
-    onCheckCellIsEditable: React.PropTypes.func,
+    onRowClick: PropTypes.func,
+    onGridKeyUp: PropTypes.func,
+    onGridKeyDown: PropTypes.func,
+    rowGroupRenderer: PropTypes.func,
+    rowActionsCell: PropTypes.func,
+    onCheckCellIsEditable: PropTypes.func,
     /* called before cell is set active, returns a boolean to determine whether cell is editable */
-    overScan: React.PropTypes.object,
-    onDeleteSubRow: React.PropTypes.func,
-    onAddSubRow: React.PropTypes.func
+    overScan: PropTypes.object,
+    onDeleteSubRow: PropTypes.func,
+    onAddSubRow: PropTypes.func
   },
 
   getDefaultProps(): {enableCellSelect: boolean} {

--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -1,11 +1,11 @@
 import OverflowCell from './OverflowCell';
 import rowComparer from './RowComparer';
+const PropTypes = require('prop-types');
 const React = require('react');
 const joinClasses = require('classnames');
 const Cell = require('./Cell');
 const ColumnUtilsMixin = require('./ColumnUtils');
 const cellMetaDataShape = require('./PropTypeShapes/CellMetaDataShape');
-const PropTypes = React.PropTypes;
 const createObjectWithProperties = require('./createObjectWithProperties');
 require('../../../themes/react-data-grid-row.css');
 
@@ -37,7 +37,7 @@ const Row = React.createClass({
     colVisibleEnd: PropTypes.number.isRequired,
     colDisplayStart: PropTypes.number.isRequired,
     colDisplayEnd: PropTypes.number.isRequired,
-    isScrolling: React.PropTypes.bool.isRequired
+    isScrolling: PropTypes.bool.isRequired
   },
 
   mixins: [ColumnUtilsMixin],

--- a/packages/react-data-grid/src/RowGroup.js
+++ b/packages/react-data-grid/src/RowGroup.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import utils from './utils';
 const cellMetaDataShape = require('./PropTypeShapes/CellMetaDataShape');
 
@@ -61,7 +62,7 @@ RowGroup.propTypes = {
   colVisibleEnd: PropTypes.number.isRequired,
   colDisplayStart: PropTypes.number.isRequired,
   colDisplayEnd: PropTypes.number.isRequired,
-  isScrolling: React.PropTypes.bool.isRequired,
+  isScrolling: PropTypes.bool.isRequired,
   columnGroupName: PropTypes.string.isRequired,
   isExpanded: PropTypes.bool.isRequired,
   treeDepth: PropTypes.number.isRequired,

--- a/packages/react-data-grid/src/RowsContainer.js
+++ b/packages/react-data-grid/src/RowsContainer.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const SimpleRowsContainer = (props) => {
   return (

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -1,8 +1,8 @@
+const PropTypes = require('prop-types');
 const React                = require('react');
 const Canvas               = require('./Canvas');
 const ViewportScroll       = require('./ViewportScrollMixin');
 const cellMetaDataShape    = require('./PropTypeShapes/CellMetaDataShape');
-const PropTypes            = React.PropTypes;
 
 const Viewport = React.createClass({
   mixins: [ViewportScroll],
@@ -13,17 +13,17 @@ const Viewport = React.createClass({
     columnMetrics: PropTypes.object.isRequired,
     rowGetter: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
     selectedRows: PropTypes.array,
-    rowSelection: React.PropTypes.oneOfType([
-      React.PropTypes.shape({
-        indexes: React.PropTypes.arrayOf(React.PropTypes.number).isRequired
+    rowSelection: PropTypes.oneOfType([
+      PropTypes.shape({
+        indexes: PropTypes.arrayOf(PropTypes.number).isRequired
       }),
-      React.PropTypes.shape({
-        isSelectedKey: React.PropTypes.string.isRequired
+      PropTypes.shape({
+        isSelectedKey: PropTypes.string.isRequired
       }),
-      React.PropTypes.shape({
-        keys: React.PropTypes.shape({
-          values: React.PropTypes.array.isRequired,
-          rowKey: React.PropTypes.string.isRequired
+      PropTypes.shape({
+        keys: PropTypes.shape({
+          values: PropTypes.array.isRequired,
+          rowKey: PropTypes.string.isRequired
         }).isRequired
       })
     ]),

--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -1,6 +1,5 @@
 import ColumnUtils from './ColumnUtils';
 const PropTypes = require('prop-types');
-const React = require('react');
 const ReactDOM = require('react-dom');
 const DOMMetrics = require('./DOMMetrics');
 const min = Math.min;

--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -1,4 +1,5 @@
 import ColumnUtils from './ColumnUtils';
+const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const DOMMetrics = require('./DOMMetrics');
@@ -28,8 +29,8 @@ module.exports = {
   },
 
   propTypes: {
-    rowHeight: React.PropTypes.number,
-    rowsCount: React.PropTypes.number.isRequired
+    rowHeight: PropTypes.number,
+    rowsCount: PropTypes.number.isRequired
   },
 
   getDefaultProps(): { rowHeight: number } {

--- a/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
@@ -1,11 +1,12 @@
+const PropTypes = require('prop-types');
 const React              = require('react');
 const ExcelColumn        = require('../../PropTypeShapes/ExcelColumn');
 
 const FilterableHeaderCell = React.createClass({
 
   propTypes: {
-    onChange: React.PropTypes.func.isRequired,
-    column: React.PropTypes.shape(ExcelColumn)
+    onChange: PropTypes.func.isRequired,
+    column: PropTypes.shape(ExcelColumn)
   },
 
   getInitialState(): {filterTerm: string} {

--- a/packages/react-data-grid/src/cells/headerCells/SortableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/SortableHeaderCell.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React              = require('react');
 const joinClasses         = require('classnames');
 const DEFINE_SORT = {
@@ -8,10 +9,10 @@ const DEFINE_SORT = {
 
 const SortableHeaderCell = React.createClass({
   propTypes: {
-    columnKey: React.PropTypes.string.isRequired,
-    column: React.PropTypes.shape({ name: React.PropTypes.node }),
-    onSort: React.PropTypes.func.isRequired,
-    sortDirection: React.PropTypes.oneOf(Object.keys(DEFINE_SORT))
+    columnKey: PropTypes.string.isRequired,
+    column: PropTypes.shape({ name: PropTypes.node }),
+    onSort: PropTypes.func.isRequired,
+    sortDirection: PropTypes.oneOf(Object.keys(DEFINE_SORT))
   },
 
   onClick: function() {

--- a/packages/react-data-grid/src/editors/CheckboxEditor.js
+++ b/packages/react-data-grid/src/editors/CheckboxEditor.js
@@ -1,16 +1,17 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 require('../../../../themes/react-data-grid-checkbox.css');
 
 const CheckboxEditor = React.createClass({
 
   propTypes: {
-    value: React.PropTypes.bool,
-    rowIdx: React.PropTypes.number,
-    column: React.PropTypes.shape({
-      key: React.PropTypes.string,
-      onCellChange: React.PropTypes.func
+    value: PropTypes.bool,
+    rowIdx: PropTypes.number,
+    column: PropTypes.shape({
+      key: PropTypes.string,
+      onCellChange: PropTypes.func
     }),
-    dependentValues: React.PropTypes.object
+    dependentValues: PropTypes.object
   },
 
   handleChange(e: Event) {

--- a/packages/react-data-grid/src/editors/EditorBase.js
+++ b/packages/react-data-grid/src/editors/EditorBase.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React                   = require('react');
 const ReactDOM = require('react-dom');
 const ExcelColumn             = require('../PropTypeShapes/ExcelColumn');
@@ -32,11 +33,11 @@ class EditorBase extends React.Component {
 }
 
 EditorBase.propTypes = {
-  onKeyDown: React.PropTypes.func.isRequired,
-  value: React.PropTypes.any.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
-  column: React.PropTypes.shape(ExcelColumn).isRequired,
-  commit: React.PropTypes.func.isRequired
+  onKeyDown: PropTypes.func.isRequired,
+  value: PropTypes.any.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  column: PropTypes.shape(ExcelColumn).isRequired,
+  commit: PropTypes.func.isRequired
 };
 
 module.exports = EditorBase;

--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React                   = require('react');
 const joinClasses              = require('classnames');
 const keyboardHandlerMixin    = require('../KeyboardHandlerMixin');
@@ -9,20 +10,20 @@ const EditorContainer = React.createClass({
   mixins: [keyboardHandlerMixin],
 
   propTypes: {
-    rowIdx: React.PropTypes.number,
-    rowData: React.PropTypes.object.isRequired,
-    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool]).isRequired,
-    cellMetaData: React.PropTypes.shape({
-      selected: React.PropTypes.object.isRequired,
-      copied: React.PropTypes.object,
-      dragged: React.PropTypes.object,
-      onCellClick: React.PropTypes.func,
-      onCellDoubleClick: React.PropTypes.func,
-      onCommitCancel: React.PropTypes.func,
-      onCommit: React.PropTypes.func
+    rowIdx: PropTypes.number,
+    rowData: PropTypes.object.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object, PropTypes.bool]).isRequired,
+    cellMetaData: PropTypes.shape({
+      selected: PropTypes.object.isRequired,
+      copied: PropTypes.object,
+      dragged: PropTypes.object,
+      onCellClick: PropTypes.func,
+      onCellDoubleClick: PropTypes.func,
+      onCommitCancel: PropTypes.func,
+      onCommit: PropTypes.func
     }).isRequired,
-    column: React.PropTypes.object.isRequired,
-    height: React.PropTypes.number.isRequired
+    column: PropTypes.object.isRequired,
+    height: PropTypes.number.isRequired
   },
 
   changeCommitted: false,

--- a/packages/react-data-grid/src/formatters/SimpleCellFormatter.js
+++ b/packages/react-data-grid/src/formatters/SimpleCellFormatter.js
@@ -1,8 +1,9 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 
 const SimpleCellFormatter = React.createClass({
   propTypes: {
-    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.object, React.PropTypes.bool]).isRequired
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object, PropTypes.bool]).isRequired
   },
 
   shouldComponentUpdate(nextProps: any): boolean {


### PR DESCRIPTION
## Description
Fixes #744 

Using jscodeshift script from:
https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Uses PropTypes from React <16


**What is the new behavior?**
Uses the individual `prop-types` package so that this can be used for React 16+


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: