### PR TITLE
correctly re-render columns if they are reordered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ test/coverage
 dist
 .npmrc
 npm-debug.log
+lerna-debug.log
 **.orig
 .vscode

--- a/packages/react-data-grid-examples/src/scripts/example24-draggable-header.js
+++ b/packages/react-data-grid-examples/src/scripts/example24-draggable-header.js
@@ -58,15 +58,12 @@ const Example = React.createClass({
       i => i.key === target
     );
 
+    stateCopy.columns = this.state.columns.slice()
+
     stateCopy.columns.splice(
       columnTargetIndex,
       0,
       stateCopy.columns.splice(columnSourceIndex, 1)[0]
-    );
-
-    const emptyColumns = Object.assign({},this.state, { columns: [] });
-    this.setState(
-      emptyColumns
     );
 
     const reorderedColumns = Object.assign({},this.state, { columns: stateCopy.columns });

--- a/packages/react-data-grid/src/ColumnMetrics.js
+++ b/packages/react-data-grid/src/ColumnMetrics.js
@@ -114,34 +114,26 @@ function areColumnsImmutable(prevColumns: Array<Column>, nextColumns: Array<Colu
 }
 
 function compareEachColumn(prevColumns: Array<Column>, nextColumns: Array<Column>, isSameColumn: (a: Column, b: Column) => boolean) {
+  const prevColumnsSize = ColumnUtils.getSize(prevColumns);
+  const nextColumnsSize = ColumnUtils.getSize(nextColumns);
   let i;
   let len;
   let column;
-  let prevColumnsByKey: { [key:string]: Column } = {};
-  let nextColumnsByKey: { [key:string]: Column } = {};
 
-
-  if (ColumnUtils.getSize(prevColumns) !== ColumnUtils.getSize(nextColumns)) {
+  if (prevColumnsSize !== nextColumnsSize) {
     return false;
   }
 
-  for (i = 0, len = ColumnUtils.getSize(prevColumns); i < len; i++) {
-    column = prevColumns[i];
-    prevColumnsByKey[column.key] = column;
-  }
-
-  for (i = 0, len = ColumnUtils.getSize(nextColumns); i < len; i++) {
+  for (i = 0, len = nextColumnsSize; i < len; i++) {
     column = nextColumns[i];
-    nextColumnsByKey[column.key] = column;
-    let prevColumn = prevColumnsByKey[column.key];
+    let prevColumn = prevColumns[i];
     if (prevColumn === undefined || !isSameColumn(prevColumn, column)) {
       return false;
     }
   }
 
-  for (i = 0, len = ColumnUtils.getSize(prevColumns); i < len; i++) {
-    column = prevColumns[i];
-    let nextColumn = nextColumnsByKey[column.key];
+  for (i = 0, len = prevColumnsSize; i < len; i++) {
+    let nextColumn = nextColumns[i];
     if (nextColumn === undefined) {
       return false;
     }

--- a/packages/react-data-grid/src/__tests__/ColumnMetrics.spec.js
+++ b/packages/react-data-grid/src/__tests__/ColumnMetrics.spec.js
@@ -94,10 +94,19 @@ describe('Column Metrics Tests', () => {
 
       it('should call compareEachColumn when comparing columns', () => {
         let compareEachColumnSpy = jasmine.createSpy();
-        ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
+        let reset = ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
         ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
+        reset();
         expect(compareEachColumnSpy).toHaveBeenCalled();
         expect(compareEachColumnSpy.calls.count()).toEqual(1);
+      });
+
+      it('changing columns order will make columns unequal', () => {
+        const nextColumn = nextColumns[0];
+        nextColumns[0] = nextColumns[2];
+        nextColumns[2] = nextColumn;
+        let areColumnsEqual = ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
+        expect(areColumnsEqual).toBeFalsy();
       });
     });
 
@@ -135,8 +144,9 @@ describe('Column Metrics Tests', () => {
 
       it('should not call compareEachColumn when comparing columns', () => {
         let compareEachColumnSpy = jasmine.createSpy();
-        ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
+        let reset = ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
         ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
+        reset()
         expect(compareEachColumnSpy).not.toHaveBeenCalled();
         expect(compareEachColumnSpy.calls.count()).toEqual(0);
       });

--- a/packages/react-data-grid/src/__tests__/ColumnMetrics.spec.js
+++ b/packages/react-data-grid/src/__tests__/ColumnMetrics.spec.js
@@ -146,7 +146,7 @@ describe('Column Metrics Tests', () => {
         let compareEachColumnSpy = jasmine.createSpy();
         let reset = ColumnMetrics.__set__('compareEachColumn', compareEachColumnSpy);
         ColumnMetrics.sameColumns(prevColumns, nextColumns, ColumnMetrics.sameColumn);
-        reset()
+        reset();
         expect(compareEachColumnSpy).not.toHaveBeenCalled();
         expect(compareEachColumnSpy.calls.count()).toEqual(0);
       });


### PR DESCRIPTION
## Description
 - Fixes an issue where columns were not re-rendered when they were re-ordered. Changed the logic of the columns dirtiness compairson by also comparing the columns indexes.
- Fixes issue within the unit tests stubs were not reset, this was preventing subsequent tests to be properly executed.

fixes #709

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
