### PR TITLE
Copy - Paste support on Macs

### DIFF
--- a/packages/react-data-grid/src/KeyboardHandlerMixin.js
+++ b/packages/react-data-grid/src/KeyboardHandlerMixin.js
@@ -56,7 +56,7 @@ let KeyboardHandlerMixin = {
   },
 
   isCtrlKeyHeldDown(e: SyntheticKeyboardEvent): boolean {
-    return e.ctrlKey === true && e.key !== 'Control';
+    return (e.ctrlKey === true || e.metaKey === true) && e.key !== 'Control';
   },
 
   checkAndCall(methodName: string, args: any) {


### PR DESCRIPTION
## Description

```
check for `e.metaKey` (aka Cmd on Macs) so Cmd + C / Cmd + V works the same as Ctrl + C / Ctrl + V on Windows.
```

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Cmd + C does not work.


**What is the new behavior?**
Cmd + C works.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
