### PR TITLE
Clear scroll timer when the Viewport component is unmounted

### DIFF
--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -93,11 +93,14 @@ module.exports = {
     return columnIndex;
   },
 
-  resetScrollStateAfterDelay() {
+  clearScrollTimer() {
     if (this.resetScrollStateTimeoutId) {
       clearTimeout(this.resetScrollStateTimeoutId);
     }
+  },
 
+  resetScrollStateAfterDelay() {
+    this.clearScrollTimer();
     this.resetScrollStateTimeoutId = setTimeout(
       this.resetScrollStateAfterDelayCallback,
       500
@@ -191,5 +194,9 @@ module.exports = {
         nextProps.rowsCount
       );
     }
+  },
+
+  componentWillUnmount() {
+    this.clearScrollTimer();
   }
 };


### PR DESCRIPTION
## Description
Clear scroll timer when the `Viewport` component is unmounted. Fixes https://github.com/adazzle/react-data-grid/issues/764

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`setState` is getting called on an unmounted component


**What is the new behavior?**
Scroll timer will be cleared when the component is unmounted and `setState` will not be called


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
