### PR TITLE
Fix double-click outside cell

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -662,17 +662,6 @@ describe('Grid', function() {
         this.component = this.createComponent({ columns: this.columns }).node;
       });
 
-      describe('double click on grid', function() {
-        beforeEach(function() {
-          this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
-          this.getBaseGrid().props.onViewportDoubleClick();
-        });
-
-        it('should activate current selected cell', function() {
-          expect(this.component.state.selected).toEqual(jasmine.objectContaining({ idx: 1, rowIdx: 1, active: true }));
-        });
-      });
-
       describe('copy a cell value', function() {
         beforeEach(function() {
           const cCharacterKeyCode = 99;
@@ -778,25 +767,6 @@ describe('Grid', function() {
 
         it('should set grid state active and store the typed value', function() {
           expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1, active: true, initialKeyCode: 66 });
-        });
-      });
-    });
-
-    describe('When column is not editable', function() {
-      beforeEach(function() {
-        const uneditableColumn = Object.assign({ editable: false }, this.columns[1]);
-        this.columns[1] = uneditableColumn;
-        this.component = this.createComponent({ columns: this.columns }).node;
-      });
-
-      describe('double click on grid ', function() {
-        beforeEach(function() {
-          this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
-          this.getBaseGrid().props.onViewportDoubleClick();
-        });
-
-        it('should not activate current selected cell', function() {
-          expect(this.component.state.selected).toEqual({ idx: 1, rowIdx: 1 });
         });
       });
     });

--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -869,6 +869,22 @@ describe('Grid', function() {
         expect(this.columns[1]).toEqual(jasmine.objectContaining({ key: 'count', name: 'Count', width: 100 }));
       });
     });
+
+    describe('outside row/cell', function() {
+      beforeEach(function() {
+        this.component.setState({ selected: { idx: 1, rowIdx: 1 } });
+      });
+
+      it('should deselect currently selected cell on click', function() {
+        this.getBaseGrid().props.onViewportClick();
+        expect(this.component.state.selected).toEqual(jasmine.objectContaining({ idx: -1, rowIdx: -1 }));
+      });
+
+      it('should deselect currently selected cell on double-click', function() {
+        this.getBaseGrid().props.onViewportDoubleClick();
+        expect(this.component.state.selected).toEqual(jasmine.objectContaining({ idx: -1, rowIdx: -1 }));
+      });
+    });
   });
 
   describe('Cell Meta Data', function() {

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -46,6 +46,7 @@ const Grid = createReactClass({
     onViewportKeyup: PropTypes.func,
     onViewportDragStart: PropTypes.func.isRequired,
     onViewportDragEnd: PropTypes.func.isRequired,
+    onViewportClick: PropTypes.func.isRequired,
     onViewportDoubleClick: PropTypes.func.isRequired,
     onColumnResize: PropTypes.func,
     onSort: PropTypes.func,
@@ -105,7 +106,15 @@ const Grid = createReactClass({
           cellMetaData={this.props.cellMetaData}
           />
           {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
-            <div ref={(node) => { this.viewPortContainer = node; } } tabIndex="0" onKeyDown={this.props.onViewportKeydown} onKeyUp={this.props.onViewportKeyup} onDoubleClick={this.props.onViewportDoubleClick}   onDragStart={this.props.onViewportDragStart} onDragEnd={this.props.onViewportDragEnd}>
+            <div
+              ref={(node) => { this.viewPortContainer = node; } }
+              tabIndex="0"
+              onKeyDown={this.props.onViewportKeydown}
+              onKeyUp={this.props.onViewportKeyup}
+              onClick={this.props.onViewportClick}
+              onDoubleClick={this.props.onViewportDoubleClick}
+              onDragStart={this.props.onViewportDragStart}
+              onDragEnd={this.props.onViewportDragEnd}>
                 <Viewport
                   ref={(node) => { this.viewport = node; } }
                   rowKey={this.props.rowKey}

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -219,10 +219,6 @@ const ReactDataGrid = createReactClass({
 
   onCellDoubleClick: function(cell: SelectedType) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
-    this.setActive('DoubleClick');
-  },
-
-  onViewportDoubleClick: function() {
     this.setActive();
   },
 
@@ -964,7 +960,7 @@ const ReactDataGrid = createReactClass({
             onViewportKeyup={this.onKeyUp}
             onViewportDragStart={this.onDragStart}
             onViewportDragEnd={this.handleDragEnd}
-            onViewportDoubleClick={this.onViewportDoubleClick}
+            onViewportDoubleClick={this.onCellDoubleClick}
             onColumnResize={this.onColumnResize}
             rowScrollTimeout={this.props.rowScrollTimeout}
             contextMenu={this.props.contextMenu}

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -202,11 +202,15 @@ const ReactDataGrid = createReactClass({
     }
   },
 
-  onCellClick: function(cell: SelectedType) {
+  onCellClick: function(cell: SelectedType, e: SyntheticEvent) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
 
     if (this.props.onRowClick && typeof this.props.onRowClick === 'function') {
       this.props.onRowClick(cell.rowIdx, this.props.rowGetter(cell.rowIdx), this.getColumn(cell.idx));
+    }
+
+    if (e) {
+      e.stopPropagation();
     }
   },
 
@@ -217,9 +221,12 @@ const ReactDataGrid = createReactClass({
     }
   },
 
-  onCellDoubleClick: function(cell: SelectedType) {
+  onCellDoubleClick: function(cell: SelectedType, e: SyntheticEvent) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
     this.setActive();
+    if (e) {
+      e.stopPropagation();
+    }
   },
 
   onPressArrowUp(e: SyntheticEvent) {
@@ -795,6 +802,11 @@ const ReactDataGrid = createReactClass({
     }
   },
 
+  deselect() {
+    const selected = {rowIdx: -1, idx: -1};
+    this.setState({selected});
+  },
+
   setActive(keyPressed: string) {
     let rowIdx = this.state.selected.rowIdx;
     let row = this.props.rowGetter(rowIdx);
@@ -960,7 +972,8 @@ const ReactDataGrid = createReactClass({
             onViewportKeyup={this.onKeyUp}
             onViewportDragStart={this.onDragStart}
             onViewportDragEnd={this.handleDragEnd}
-            onViewportDoubleClick={this.onCellDoubleClick}
+            onViewportClick={this.deselect}
+            onViewportDoubleClick={this.deselect}
             onColumnResize={this.onColumnResize}
             rowScrollTimeout={this.props.rowScrollTimeout}
             contextMenu={this.props.contextMenu}


### PR DESCRIPTION
## Description
When double clicking in the viewport but not _on_ any row/cell (e.g. in the empty area when there are only a few rows), you can edit the previously selected. This PR changes this behaviour so nothing happens when double-clicking in an empty area of the grid.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Select a cell. When double clicking in the viewport but not _on_ any row (e.g. in the empty area when there are only a few rows), you can edit the previously selected.

**What is the new behavior?**
You shouldn't be able to edit a previously selected cell when double-clicking in an empty area. Nothing should happen.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:
