### PR TITLE
Fix examples related to editing data

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example04-editable.js
+++ b/packages/react-data-grid-examples/src/scripts/example04-editable.js
@@ -75,7 +75,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
+++ b/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
@@ -75,7 +75,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid-examples/src/scripts/example13-all-features.js
+++ b/packages/react-data-grid-examples/src/scripts/example13-all-features.js
@@ -211,7 +211,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 
@@ -219,15 +219,10 @@ class Example extends React.Component {
   };
 
   handleAddRow = ({ newRowIndex }) => {
-    const newRow = {
-      value: newRowIndex,
-      userStory: '',
-      developer: '',
-      epic: ''
-    };
+    const newRow = this.createFakeRowObjectData(newRowIndex);
 
     let rows = this.state.rows.slice();
-    rows = React.addons.update(rows, {$push: [newRow]});
+    rows.push(newRow);
     this.setState({ rows });
   };
 

--- a/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
@@ -54,7 +54,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid-examples/src/scripts/example19-column-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example19-column-events.js
@@ -68,7 +68,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      const updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      const updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 


### PR DESCRIPTION
## Description
Examples related to editing data were broken since `React.addons.update` was removed. This updates the calls to use vanilla javascript functions that give the expected behavior.

Also, after fixing the example where you can add a new row I realized it was adding a blank row so I updated it to use the `createFakeRowObjectData` function to add a row with dummy data.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Broken examples

**What is the new behavior?**
Working examples

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
