### PR TITLE
Navigate with enter

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example04-editable.js
+++ b/packages/react-data-grid-examples/src/scripts/example04-editable.js
@@ -75,7 +75,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
+++ b/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
@@ -75,7 +75,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid-examples/src/scripts/example13-all-features.js
+++ b/packages/react-data-grid-examples/src/scripts/example13-all-features.js
@@ -211,7 +211,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 
@@ -219,15 +219,10 @@ class Example extends React.Component {
   };
 
   handleAddRow = ({ newRowIndex }) => {
-    const newRow = {
-      value: newRowIndex,
-      userStory: '',
-      developer: '',
-      epic: ''
-    };
+    const newRow = this.createFakeRowObjectData(newRowIndex);
 
     let rows = this.state.rows.slice();
-    rows = React.addons.update(rows, {$push: [newRow]});
+    rows.push(newRow);
     this.setState({ rows });
   };
 

--- a/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
@@ -54,7 +54,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      let updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      let updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid-examples/src/scripts/example19-column-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example19-column-events.js
@@ -68,7 +68,7 @@ class Example extends React.Component {
 
     for (let i = fromRow; i <= toRow; i++) {
       let rowToUpdate = rows[i];
-      const updatedRow = React.addons.update(rowToUpdate, {$merge: updated});
+      const updatedRow = Object.assign({}, rowToUpdate, updated);
       rows[i] = updatedRow;
     }
 

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -251,7 +251,11 @@ const ReactDataGrid = createReactClass({
   },
 
   onPressEnter(e: SyntheticKeyboardEvent) {
-    this.setActive(e.key);
+    const didSetActive = this.setActive(e.key);
+
+    if (!didSetActive) {
+      this.moveSelectedCell(e, e.shiftKey ? -1 : 1, 0);
+    }
   },
 
   onPressDelete(e: SyntheticKeyboardEvent) {
@@ -313,9 +317,6 @@ const ReactDataGrid = createReactClass({
   onCellCommit(commit: RowUpdateEvent) {
     let selected = Object.assign({}, this.state.selected);
     selected.active = false;
-    if (commit.key === 'Tab') {
-      selected.idx += 1;
-    }
     let expandedRows = this.state.expandedRows;
     // if(commit.changed && commit.changed.expandedHeight){
     //   expandedRows = this.expandRow(commit.rowIdx, commit.changed.expandedHeight);
@@ -808,7 +809,7 @@ const ReactDataGrid = createReactClass({
     this.setState({selected});
   },
 
-  setActive(keyPressed: string) {
+  setActive(keyPressed: string): boolean {
     let rowIdx = this.state.selected.rowIdx;
     let row = this.props.rowGetter(rowIdx);
 
@@ -829,8 +830,11 @@ const ReactDataGrid = createReactClass({
           this.setState({selected}, () => { this.scrollToColumn(idx); });
         }
         this.handleCancelCopy();
+        return true;
       }
     }
+
+    return false;
   },
 
   setInactive() {


### PR DESCRIPTION
## Description
Resolves #942

In the most common spreadsheets (I'm on a Mac so I tested in Google Sheets and Numbers), pressing:
- `Tab` moves you right
- `Shift + Tab` moves you left
- `Enter` puts you into edit mode (if editable) then pressing again moves you down.
- `Shift + Enter` puts you into edit mode (if editable) then pressing again then moves you up.

This component already handled the `Tab`-based navigation. This PR adds the `Enter`-based navigation. 

**Google Sheets (pressing enter then shift+enter):**
![nov-04-2017 00-43-07](https://user-images.githubusercontent.com/847027/32403355-1615bf68-c0fd-11e7-99de-879c174c0abc.gif)

**This PR (pressing enter then shift+enter on editable and non-editable cells):**
![nov-04-2017 01-11-35](https://user-images.githubusercontent.com/847027/32403360-27e451f0-c0fd-11e7-89ae-5949db3baf65.gif)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Pressing `Enter` does not navigate.


**What is the new behavior?**
Pressing `Enter` will navigate down and pressing `Shift + Enter` will navigate up.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**
This change won't break anything but it is new default behavior. We could consider putting it behind a config prop like `navigateOnEnter` that defaults to false.


**Other information**:
