### PR TITLE
Do not mix production and development version of create-react-class

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -35,6 +35,12 @@ const config = {
       commonjs2: 'react-dom',
       amd: 'react-dom'
     },
+    'create-react-class': {
+      root: 'createReactClass',
+      commonjs: 'create-react-class',
+      commonjs2: 'create-react-class',
+      amd: 'create-react-class'
+    },
     'react/addons': 'React',
     moment: 'moment'
   },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,10 +1,16 @@
 const webpackCommon = require('./webpack.common.config');
 
-const config =  {
+const config = {
   entry: {
-    'react-data-grid/dist/react-data-grid': ['./packages/react-data-grid/src'],
+    'react-data-grid/dist/react-data-grid': [
+      './node_modules/create-react-class/create-react-class.js',
+      './packages/react-data-grid/src'
+    ],
     'react-data-grid-addons/dist/react-data-grid-addons': ['./packages/react-data-grid-addons/src'],
-    'react-data-grid/dist/react-data-grid.min': ['./packages/react-data-grid/src'],
+    'react-data-grid/dist/react-data-grid.min': [
+      './node_modules/create-react-class/create-react-class.min.js',
+      './packages/react-data-grid/src'
+    ],
     'react-data-grid-addons/dist/react-data-grid-addons.min': ['./packages/react-data-grid-addons/src'],
     'react-data-grid-examples/dist/shared': './packages/react-data-grid-examples/src/shared.js',
     'react-data-grid-examples/dist/examples': './packages/react-data-grid-examples/src/examples.js',
@@ -19,4 +25,4 @@ const config =  {
   }
 };
 
-module.exports = Object.assign({ }, webpackCommon, config);
+module.exports = Object.assign({}, webpackCommon, config);


### PR DESCRIPTION
## Description
Fix false positive `getDefaultProps` warnings. Fixed https://github.com/adazzle/react-data-grid/issues/978

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`React 15.5` deprecated `React.createClass` and added a warning when `getDefaultProps()` method is used with class components (`React.component`). These deprecation warnings are only shown in development mode. Components created using `React.createClass` or `createReactClass` still use `getDefaultProps()` method to define `defaultProps`. In development mode, `React` [sets a flag](https://github.com/facebook/react/blob/v15.5.4/addons/create-react-class/create-react-class.js#L718) `isReactClassApproved` to suppress these warnings for components created using `React.createClass` or `createReactClass`.
`react-data-grid.js` bundles the `min` version of `create-react-class` (created using webpack) and because of this `isReactClassApproved` flag is not set anymore on the components created using using `React.createClass` or `createReactClass`.

**What is the new behavior?**
`react-data-grid.js` bundles the `dev` version of `create-react-class`
`react-data-grid.min.js` bundles the `min` version of `create-react-class`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This is a temporary fix, in the future when mixins are removed, remaining components can be converted to class components and `create-react-class` package can be dropped 