### PR TITLE
Fix Scroll to a row and bring it into view (#661)

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example28-scroll-to-row-index.js
+++ b/packages/react-data-grid-examples/src/scripts/example28-scroll-to-row-index.js
@@ -1,0 +1,66 @@
+const ReactDataGrid = require('react-data-grid');
+const exampleWrapper = require('../components/exampleWrapper');
+const React = require('react');
+
+const Example = React.createClass({
+  getInitialState() {
+    this.createRows();
+    this._columns = [
+      { key: 'id', name: 'ID' },
+      { key: 'title', name: 'Title' },
+      { key: 'count', name: 'Count' } ];
+
+    return {
+      value: 10,
+      scrollToRowIndex: 10
+    };
+  },
+
+  createRows() {
+    let rows = [];
+    for (let i = 1; i < 1000; i++) {
+      rows.push({
+        id: i,
+        title: 'Title ' + i,
+        count: i * 1000
+      });
+    }
+
+    this._rows = rows;
+  },
+
+  rowGetter(i) {
+    return this._rows[i];
+  },
+
+  render() {
+    return (
+      <div>
+        <div style={{display: 'flex', marginBottom: '10px', alignItems: 'center'}}>
+          <span style={{marginRight: '10px'}}>Row Index: </span>
+          <input
+            style={{marginRight: '10px', border: '1px outset lightgray', padding: '3px'}}
+            type='text'
+            value={this.state.value}
+            onChange={(event) => { this.setState({value: event.target.value})}} />
+          <button
+            style={{padding: '5px'}}
+            onClick={() => this.setState({scrollToRowIndex: this.state.value})}>Scroll to row</button>
+        </div>
+        <ReactDataGrid
+          columns={this._columns}
+          rowGetter={this.rowGetter}
+          rowsCount={this._rows.length}
+          minHeight={500}
+          scrollToRowIndex={+this.state.scrollToRowIndex} />
+      </div>);
+  }
+});
+
+module.exports = exampleWrapper({
+  WrappedComponent: Example,
+  exampleName: 'Programmatic Scrolling Example',
+  exampleDescription: <p>To programmatically set the vertical scrolling offset, specify the <code>scrollToRowIndex</code> property.</p>,
+  examplePath: './scripts/example27-scroll-to-row-index.js',
+  examplePlaygroundLink: 'https://jsfiddle.net/f6mbnb8z/1/'
+});

--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -46,6 +46,7 @@ const Canvas = createReactClass({
     selectedRows: PropTypes.array,
     rowKey: PropTypes.string,
     rowScrollTimeout: PropTypes.number,
+    scrollToRowIndex: PropTypes.number,
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
     rowSelection: PropTypes.oneOfType([
@@ -108,6 +109,7 @@ const Canvas = createReactClass({
     let shouldUpdate = nextState.displayStart !== this.state.displayStart
       || nextState.displayEnd !== this.state.displayEnd
       || nextState.scrollingTimeout !== this.state.scrollingTimeout
+      || this.props.scrollToRowIndex !== nextProps.scrollToRowIndex
       || nextProps.rowsCount !== this.props.rowsCount
       || nextProps.rowHeight !== this.props.rowHeight
       || nextProps.columns !== this.props.columns
@@ -131,6 +133,12 @@ const Canvas = createReactClass({
   componentDidUpdate() {
     if (this._scroll.scrollTop !== 0 && this._scroll.scrollLeft !== 0) {
       this.setScrollLeft(this._scroll.scrollLeft);
+    }
+    if (this.props.scrollToRowIndex !== 0) {
+      this.div.scrollTop = Math.min(
+        this.props.scrollToRowIndex * this.props.rowHeight,
+        this.props.rowsCount * this.props.rowHeight - this.props.height
+      );
     }
     this.onRows();
   },
@@ -316,6 +324,7 @@ const Canvas = createReactClass({
 
     return (
       <div
+        ref={(div) => {this.div = div;}}
         style={style}
         onScroll={this.onScroll}
         className={joinClasses('react-grid-Canvas', this.props.className, { opaque: this.props.cellMetaData.selected && this.props.cellMetaData.selected.active }) }>

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -54,6 +54,7 @@ const Grid = createReactClass({
     cellMetaData: PropTypes.shape(cellMetaDataShape),
     rowKey: PropTypes.string.isRequired,
     rowScrollTimeout: PropTypes.number,
+    scrollToRowIndex: PropTypes.number,
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
     draggableHeaderCell: PropTypes.func,
@@ -133,6 +134,7 @@ const Grid = createReactClass({
                   rowOffsetHeight={this.props.rowOffsetHeight || this.props.rowHeight * headerRows.length}
                   minHeight={this.props.minHeight}
                   rowScrollTimeout={this.props.rowScrollTimeout}
+                  scrollToRowIndex={this.props.scrollToRowIndex}
                   contextMenu={this.props.contextMenu}
                   rowSelection={this.props.rowSelection}
                   getSubRowDetails={this.props.getSubRowDetails}

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -77,6 +77,7 @@ const ReactDataGrid = createReactClass({
     onRowSelect: PropTypes.func,
     rowKey: PropTypes.string,
     rowScrollTimeout: PropTypes.number,
+    scrollToRowIndex: PropTypes.number,
     onClearFilters: PropTypes.func,
     contextMenu: PropTypes.element,
     cellNavigationMode: PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
@@ -130,6 +131,7 @@ const ReactDataGrid = createReactClass({
       minHeight: 350,
       rowKey: 'id',
       rowScrollTimeout: 0,
+      scrollToRowIndex: 0,
       cellNavigationMode: 'none',
       overScan: {
         colsStart: 5,
@@ -981,6 +983,7 @@ const ReactDataGrid = createReactClass({
             onViewportDoubleClick={this.deselect}
             onColumnResize={this.onColumnResize}
             rowScrollTimeout={this.props.rowScrollTimeout}
+            scrollToRowIndex={this.props.scrollToRowIndex}
             contextMenu={this.props.contextMenu}
             overScan={this.props.overScan} />
           </div>

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -39,6 +39,7 @@ const Viewport = createReactClass({
     cellMetaData: PropTypes.shape(cellMetaDataShape),
     rowKey: PropTypes.string.isRequired,
     rowScrollTimeout: PropTypes.number,
+    scrollToRowIndex: PropTypes.number,
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
     rowGroupRenderer: PropTypes.func
@@ -104,6 +105,7 @@ const Viewport = createReactClass({
           onScroll={this.onScroll}
           onRows={this.props.onRows}
           rowScrollTimeout={this.props.rowScrollTimeout}
+          scrollToRowIndex={this.props.scrollToRowIndex}
           contextMenu={this.props.contextMenu}
           rowSelection={this.props.rowSelection}
           getSubRowDetails={this.props.getSubRowDetails}


### PR DESCRIPTION
## Description
This pull request provides a way to programmatically control the first row to display when the grid is initially rendered.

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When the grid is initially displayed, the first visible row is always row at index 0


**What is the new behavior?**
Enables to programmatically control what is the first visible row when the grid is initially rendered


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
