### PR TITLE
adding onRowDoubleClick functionality

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -108,6 +108,7 @@ const ReactDataGrid = createReactClass({
       ]).isRequired
     }),
     onRowClick: PropTypes.func,
+    onRowDoubleClick: PropTypes.func,
     onGridKeyUp: PropTypes.func,
     onGridKeyDown: PropTypes.func,
     rowGroupRenderer: PropTypes.func,
@@ -226,6 +227,9 @@ const ReactDataGrid = createReactClass({
 
   onCellDoubleClick: function(cell: SelectedType, e: SyntheticEvent) {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
+    if (this.props.onRowDoubleClick && typeof this.props.onRowDoubleClick === 'function') {
+      this.props.onRowDoubleClick(cell.rowIdx, this.props.rowGetter(cell.rowIdx), this.getColumn(cell.idx));
+    }
     this.setActive();
     if (e) {
       e.stopPropagation();


### PR DESCRIPTION
Description
due to known properties onRowDoubleClick workaround broke. So added it.

Please check if the PR fulfills these requirements

 The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
 Tests for the changes have been added (for bug fixes / features)
 Docs have been added / updated (for bug fixes / features)
What kind of change does this PR introduce? (check one with "x")

[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
What is the current behavior? (You can also link to an open issue here)
It is not supported

What is the new behavior?
onRowDoubleClick gives handler to support double click on row

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[X] No
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Other information: