### PR TITLE
Add tabIndex to Grid props

### DIFF
--- a/docs/api/docs.json
+++ b/docs/api/docs.json
@@ -1522,6 +1522,17 @@
         "required": false,
         "description": ""
       },
+      "tabIndex": {
+        "type": {
+          "name": "number"
+        },
+        "defaultValue": {
+          "value": "-1",
+          "computed": false
+        },
+        "required": false,
+        "description": ""
+      },
       "rowOffsetHeight": {
         "type": {
           "name": "number"

--- a/docs/markdowns/Grid.md
+++ b/docs/markdowns/Grid.md
@@ -168,6 +168,11 @@ type: `string`
 type: `enum('ASC'|'DESC'|'NONE')`
 
 
+### `tabIndex`
+
+type: `number`
+
+
 ### `totalWidth`
 
 type: `union(number|string)`

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -14,6 +14,7 @@ const Grid = createReactClass({
   propTypes: {
     rowGetter: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
     columns: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    tabIndex: PropTypes.number,
     columnMetrics: PropTypes.object,
     minHeight: PropTypes.number,
     totalWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -70,7 +71,8 @@ const Grid = createReactClass({
   getDefaultProps() {
     return {
       rowHeight: 35,
-      minHeight: 350
+      minHeight: 350,
+      tabIndex: 0
     };
   },
 
@@ -108,7 +110,7 @@ const Grid = createReactClass({
           {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
             <div
               ref={(node) => { this.viewPortContainer = node; } }
-              tabIndex="0"
+              tabIndex={this.props.tabIndex}
               onKeyDown={this.props.onViewportKeydown}
               onKeyUp={this.props.onViewportKeyup}
               onClick={this.props.onViewportClick}

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -84,6 +84,7 @@ const ReactDataGrid = createReactClass({
     onCellDeSelected: PropTypes.func,
     onCellExpand: PropTypes.func,
     enableDragAndDrop: PropTypes.bool,
+    tabIndex: PropTypes.number,
     onRowExpandToggle: PropTypes.func,
     draggableHeaderCell: PropTypes.func,
     getValidFilterValues: PropTypes.func,

--- a/packages/react-data-grid/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid/src/__tests__/Grid.spec.js
@@ -173,6 +173,7 @@ describe('Rendering Grid component', () => {
       onRows: jasmine.createSpy(),
       sortColumn: 'sortColumn',
       sortDirection: 'ASC',
+      tabIndex: -1,
       rowOffsetHeight: 100,
       onViewportKeydown: jasmine.createSpy(),
       onViewportKeyup: jasmine.createSpy(),
@@ -250,5 +251,6 @@ describe('Rendering Grid component', () => {
     expect(draggableDiv.props().getValidFilterValues).toBeUndefined();
     expect(draggableDiv.props().rowGroupRenderer).toBeUndefined();
     expect(draggableDiv.props().overScan).toBeUndefined();
+    expect(draggableDiv.props().tabIndex).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description
When tabIndex is set to 0, the selection gets stuck in the table and the user cannot exit it.
This adds an option to customize it so that we can set it to -1. This prevents focus on the table using the TAB key.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The Grid component forces tabIndex=0


**What is the new behavior?**
The Grid component defaults to tabIndex=0 but allows the user to override it.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```