### PR TITLE
Update scroll for recalculating visible row count after height change

### DIFF
--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -170,11 +170,17 @@ module.exports = {
 
   componentWillReceiveProps(nextProps: { rowHeight: number; rowsCount: number, rowOffsetHeight: number }) {
     if (this.props.rowHeight !== nextProps.rowHeight ||
-      this.props.minHeight !== nextProps.minHeight ||
-      ColumnUtils.getSize(this.props.columnMetrics.columns) !== ColumnUtils.getSize(nextProps.columnMetrics.columns)) {
+      this.props.minHeight !== nextProps.minHeight) {
       const newState = this.getGridState(nextProps);
-      this.setState(newState);
-      this.updateScroll(newState.scrollTop, newState.scrollLeft, newState.height, nextProps.rowHeight, nextProps.rowsCount);
+      this.updateScroll(
+          newState.scrollTop,
+          newState.scrollLeft,
+          newState.height,
+          nextProps.rowHeight,
+          nextProps.rowsCount
+      );
+    } else if (ColumnUtils.getSize(this.props.columnMetrics.columns) !== ColumnUtils.getSize(nextProps.columnMetrics.columns)) {
+      this.setState(this.getGridState(nextProps));
     } else if (this.props.rowsCount !== nextProps.rowsCount) {
       this.updateScroll(
         this.state.scrollTop,

--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -172,7 +172,7 @@ module.exports = {
     if (this.props.rowHeight !== nextProps.rowHeight ||
       this.props.minHeight !== nextProps.minHeight ||
       ColumnUtils.getSize(this.props.columnMetrics.columns) !== ColumnUtils.getSize(nextProps.columnMetrics.columns)) {
-      const newState = this.getGridState(nextProps)
+      const newState = this.getGridState(nextProps);
       this.setState(newState);
       this.updateScroll(newState.scrollTop, newState.scrollLeft, newState.height, nextProps.rowHeight, nextProps.rowsCount);
     } else if (this.props.rowsCount !== nextProps.rowsCount) {

--- a/packages/react-data-grid/src/ViewportScrollMixin.js
+++ b/packages/react-data-grid/src/ViewportScrollMixin.js
@@ -172,7 +172,9 @@ module.exports = {
     if (this.props.rowHeight !== nextProps.rowHeight ||
       this.props.minHeight !== nextProps.minHeight ||
       ColumnUtils.getSize(this.props.columnMetrics.columns) !== ColumnUtils.getSize(nextProps.columnMetrics.columns)) {
-      this.setState(this.getGridState(nextProps));
+      const newState = this.getGridState(nextProps)
+      this.setState(newState);
+      this.updateScroll(newState.scrollTop, newState.scrollLeft, newState.height, nextProps.rowHeight, nextProps.rowsCount);
     } else if (this.props.rowsCount !== nextProps.rowsCount) {
       this.updateScroll(
         this.state.scrollTop,

--- a/packages/react-data-grid/src/__tests__/Viewport.spec.js
+++ b/packages/react-data-grid/src/__tests__/Viewport.spec.js
@@ -129,4 +129,25 @@ describe('<Viewport />', () => {
       visibleStart: 0
     });
   });
+
+  it('should update when given height changed', () => {
+    const wrapper = shallow(<Viewport {...viewportProps} />);
+    const newHeight = 1000;
+    let newProps = Object.assign({}, viewportProps, {minHeight: newHeight});
+    wrapper.setProps(newProps);
+    expect(wrapper.state()).toEqual({
+      colDisplayEnd: helpers.columns.length,
+      colDisplayStart: 0,
+      colVisibleEnd: helpers.columns.length,
+      colVisibleStart: 0,
+      displayEnd: 34,
+      displayStart: 0,
+      height: newHeight,
+      scrollLeft: 0,
+      scrollTop: 0,
+      visibleEnd: 29,
+      visibleStart: 0,
+      isScrolling: true
+    });
+  });
 });


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

getGridState calculate visible row count 4 time higher. If we change height of table it doesn't calculate visible row count properly. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
If we change minHeight after render, getGridState() calculate visible row count 4 times higher


**What is the new behavior?**
After height change component recalculate its state with updateScroll


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
