### PR TITLE
Fix getCellActions iterator key warning (#1020)

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -468,7 +468,7 @@ class Cell extends React.Component {
       const cellActions = cellMetaData.getCellActions(column, rowData);
       if (cellActions && cellActions.length) {
         return cellActions.map((action, index) => {
-          return <CellAction action={action} isFirst={index === 0} />;
+          return <CellAction key={index} action={action} isFirst={index === 0} />;
         });
       }
       return null;

--- a/packages/react-data-grid/src/CellAction.js
+++ b/packages/react-data-grid/src/CellAction.js
@@ -22,8 +22,8 @@ class CellAction extends React.Component {
   }
 
   onGetMenuOptions = () => {
-    return this.props.action.actions.map(action => {
-      return <span onClick={action.callback}>{action.text}</span>;
+    return this.props.action.actions.map((action, index) => {
+      return <span key={index} onClick={action.callback}>{action.text}</span>;
     });
   }
 

--- a/packages/react-data-grid/src/PropTypeShapes/CellActionShape.js
+++ b/packages/react-data-grid/src/PropTypeShapes/CellActionShape.js
@@ -1,10 +1,14 @@
 import PropTypes from 'prop-types';
-Object.assign = require('object-assign');
 
-const action = {
+const CellActionShape = {
   icon: PropTypes.string.isRequired,
-  text: PropTypes.string,
-  callback: PropTypes.func
+  callback: PropTypes.func,
+  actions: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      callback: PropTypes.func
+    })
+  )
 };
 
-export default Object.assign({}, action, { actions: PropTypes.arrayOf(action) });
+export default CellActionShape;


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The current codes displays 3 warnings when using cell actions

- Two are related to missing 'key' attribute in arrays of react elements used by the API (array of actions and array of action menu items)
- One is related to incorrect PropTypes for actions (an action has one mandatory icon, one callback, and an optional array of (text, callback) pairs for the menu and not one mandatory icon, one text, one callback and one optional array of (mandatory icon, text, callback) triplets for the menu)

**What is the new behavior?**
The fix removes these warnings

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
