### PR TITLE
Load js/css from CDNs via HTTPS

### DIFF
--- a/packages/react-data-grid-examples/src/documentation.html
+++ b/packages/react-data-grid-examples/src/documentation.html
@@ -10,7 +10,7 @@
 
 	<link rel="shortcut icon" href="examples/assets/images/gt_favicon.png">
 
-	<link rel="stylesheet" media="screen" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
+	<link rel="stylesheet" media="screen" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"/>
 
 

--- a/packages/react-data-grid-examples/src/examples.html
+++ b/packages/react-data-grid-examples/src/examples.html
@@ -8,7 +8,7 @@
 <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
 <title>React Data Grid - Excel-like grid component built with React</title>
 <link rel="shortcut icon" href="examples/assets/images/gt_favicon.png">
-<link rel="stylesheet" media="screen" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
+<link rel="stylesheet" media="screen" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
 <script src="assets/js/jquery-1.11.2.min.js"></script>
 <link rel="stylesheet" href="assets/js/font-awesome.min.css">
 <script src="assets/js/faker.js"></script>

--- a/packages/react-data-grid-examples/src/index.html
+++ b/packages/react-data-grid-examples/src/index.html
@@ -9,14 +9,14 @@
 	<title>ReactData Grid - Excel-like grid component built with React</title>
 
 	<link rel="shortcut icon" href="examples/assets/images/gt_favicon.png">
-	<link rel="stylesheet" media="screen" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700"></link>
+	<link rel="stylesheet" media="screen" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700"></link>
 	<link rel="stylesheet" href="assets/css/bootstrap.min.css"></link>
 
 	<!-- Custom styles for our template -->
 	<link rel="stylesheet" href="assets/css/bootstrap-theme.css" media="screen" ></link>
 	<link rel="stylesheet" href="assets/css/main.css"></link>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-with-addons.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-with-addons.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/Faker/3.0.1/faker.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.3/immutable.min.js"/></script>


### PR DESCRIPTION
## Description
This should fix the asset loading issues on the HTTPS github.io page, hopefully fixing the list of examples not being displayed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
HTTP assets not loading on HTTPS.


**What is the new behavior?**
HTTP assets now changed to HTTPS so it loads on the HTTPS site.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```