### PR TITLE
Remove brittle context menu tests

### DIFF
--- a/packages/react-data-grid-examples/src/__tests__/Grid.integration-spec.js
+++ b/packages/react-data-grid-examples/src/__tests__/Grid.integration-spec.js
@@ -218,39 +218,4 @@ describe('Grid Integration', () => {
       });
     });
   });
-
-  describe('Context Menu', () => {
-    let fakeRowIdx = 3;
-    let fakeIdx = 5;
-
-    it('should show context menu on right click', () => {
-      gridRunner.rightClickCell({cellIdx: fakeIdx, rowIdx: fakeRowIdx});
-      expect(gridRunner.isContextMenuVisible()).toEqual(true);
-    });
-
-    it('should hide context menu on selecting menu item', () => {
-      gridRunner.clickContextMenuLink();
-      expect(gridRunner.isContextMenuVisible()).toEqual(false);
-    });
-
-    // Please note: this test will fail if the MenuItem's inner text in example14-all-features-immutable is changed.
-    it('should get row and column indexes from context menu', () => {
-      gridRunner.rightClickCell({cellIdx: fakeIdx, rowIdx: fakeRowIdx});
-      let menuItem = gridRunner.getContextMenuItem();
-      // Using this alternative for firefox tests
-      let menuItemValue = menuItem.innerText !== undefined ? menuItem.innerText : menuItem.textContent;
-      let idxs = menuItemValue.split(',');
-      expect(fakeRowIdx).toEqual(parseInt(idxs[0], 10));
-      expect(fakeIdx).toEqual(parseInt(idxs[1], 10));
-    });
-
-    // In ContextMenuWrapper's componentWillReceiveProps the function getMenuPosition is called with a delay
-    // (window.requestAnimationFrame || setTimeout). This causes timing issues when you have both 'right click on cell' (open menu)
-    // and 'click on menu item' (close menu) in the same test. To avoid this we need to close the menu after each right click
-    // in a separate test.
-    xit('should hide context menu', () => {
-      gridRunner.clickContextMenuLink();
-      expect(gridRunner.isContextMenuVisible()).toEqual(false);
-    });
-  });
 });

--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -51,9 +51,8 @@ class HeaderCell extends React.Component {
   };
 
   getWidthFromMouseEvent = (e: SyntheticMouseEvent): number => {
-    const node = ReactDOM.findDOMNode(this);
     let right = e.pageX || (e.touches && e.touches[0] && e.touches[0].pageX) || (e.changedTouches && e.changedTouches[e.changedTouches.length - 1].pageX);
-    let left = node ? node.getBoundingClientRect().left : 0;
+    let left = ReactDOM.findDOMNode(this).getBoundingClientRect().left;
     return right - left;
   };
 

--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -51,8 +51,9 @@ class HeaderCell extends React.Component {
   };
 
   getWidthFromMouseEvent = (e: SyntheticMouseEvent): number => {
+    const node = ReactDOM.findDOMNode(this);
     let right = e.pageX || (e.touches && e.touches[0] && e.touches[0].pageX) || (e.changedTouches && e.changedTouches[e.changedTouches.length - 1].pageX);
-    let left = ReactDOM.findDOMNode(this).getBoundingClientRect().left;
+    let left = node ? node.getBoundingClientRect().left : 0;
     return right - left;
   };
 


### PR DESCRIPTION
This PR fixes the broken build as a result of temporarily removing tests that are dependent on the third party context menu. 

The unit tests for context menu are still passing, but there is some issue with clean 
up with the integration tests that is causing the build to fail due to memory problems. This will be investigated, and followed up soon
  