### PR TITLE
Make cells properly tabbable

### DIFF
--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -48,7 +48,7 @@ class Cell extends React.Component {
   };
 
   static defaultProps = {
-    tabIndex: -1,
+    tabIndex: 0,
     isExpanded: false,
     value: '',
     isCellValueChanging: (value, nextValue) => value !== nextValue
@@ -108,6 +108,13 @@ class Cell extends React.Component {
     let meta = this.props.cellMetaData;
     if (meta != null && meta.onCellClick && typeof (meta.onCellClick) === 'function') {
       meta.onCellClick({ rowIdx: this.props.rowIdx, idx: this.props.idx }, e);
+    }
+  };
+
+  onCellFocus = () => {
+    let meta = this.props.cellMetaData;
+    if (meta != null && meta.onCellFocus && typeof (meta.onCellFocus) === 'function') {
+      meta.onCellFocus({ rowIdx: this.props.rowIdx, idx: this.props.idx });
     }
   };
 
@@ -446,6 +453,7 @@ class Cell extends React.Component {
     let onColumnEvent = this.props.cellMetaData ? this.props.cellMetaData.onColumnEvent : undefined;
     let gridEvents = {
       onClick: this.onCellClick,
+      onFocus: this.onCellFocus,
       onDoubleClick: this.onCellDoubleClick,
       onContextMenu: this.onCellContextMenu,
       onDragOver: this.onDragOver

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -366,6 +366,10 @@ class ReactDataGrid extends React.Component {
     }
   };
 
+  onCellFocus = (cell: SelectedType) => {
+    this.onSelect(cell);
+  };
+
   onCellContextMenu = (cell: SelectedType) => {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx, contextMenuDisplayed: this.props.contextMenu});
     if (this.props.contextMenu) {
@@ -1177,6 +1181,7 @@ class ReactDataGrid extends React.Component {
       dragged: this.state.dragged,
       hoveredRowIdx: this.state.hoveredRowIdx,
       onCellClick: this.onCellClick,
+      onCellFocus: this.onCellFocus,
       onCellContextMenu: this.onCellContextMenu,
       onCellDoubleClick: this.onCellDoubleClick,
       onCommit: this.onCellCommit,

--- a/packages/react-data-grid/src/__tests__/Cell.spec.js
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.js
@@ -475,7 +475,7 @@ describe('Cell Tests', () => {
       });
 
       it('should not add any extra keys', () => {
-        expect(Object.keys(cellEvents).length).toBe(5);
+        expect(Object.keys(cellEvents).length).toBe(6);
       });
 
       it('should call onKeyPress column event', () => {
@@ -669,7 +669,7 @@ describe('Cell Tests', () => {
     it('passes tabIndex if not available from props, because it is set as a default', () => {
       const wrapper = shallowRenderComponent(requiredProperties);
       const cellDiv = wrapper.find('div').at(0);
-      expect(cellDiv.props().tabIndex).toBe(-1);
+      expect(cellDiv.props().tabIndex).toBe(0);
     });
     it('passes value property', () => {
       const wrapper = shallowRenderComponent(requiredProperties);

--- a/packages/react-data-grid/src/__tests__/Cell.spec.js
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.js
@@ -14,6 +14,7 @@ let testCellMetaData = {
   selected: {idx: 2, rowIdx: 3},
   dragged: null,
   onCellClick: function() {},
+  onCellFocus: function() {},
   onCellContextMenu: function() {},
   onCellDoubleClick: function() {},
   onCommit: function() {},
@@ -45,6 +46,7 @@ const renderComponent = (extraProps) => {
 };
 
 const onCellClick = jasmine.createSpy();
+const onCellFocus = jasmine.createSpy();
 const onDragHandleDoubleClick = jasmine.createSpy();
 const onCellContextMenu = jasmine.createSpy();
 const onCellDoubleClick = jasmine.createSpy();
@@ -58,6 +60,7 @@ const getCellMetaDataWithEvents = () => {
     testCellMetaData,
     {
       onCellClick,
+      onCellFocus,
       onDragHandleDoubleClick,
       onCellContextMenu,
       onCellDoubleClick
@@ -315,6 +318,7 @@ describe('Cell Tests', () => {
 
     beforeEach(() => {
       onCellClick.calls.reset();
+      onCellFocus.calls.reset();
       onCellDoubleClick.calls.reset();
       onCellContextMenu.calls.reset();
       onDragHandleDoubleClick.calls.reset();
@@ -388,6 +392,12 @@ describe('Cell Tests', () => {
             testElement.simulate('click');
 
             expect(onCellClick).toHaveBeenCalled();
+          });
+
+          it('should call metaData onCellFocus when it is defined', () => {
+            testElement.simulate('focus');
+
+            expect(onCellFocus).toHaveBeenCalled();
           });
 
           it('should call metaData onDragHandleDoubleClick when it is defined', () => {
@@ -580,6 +590,7 @@ describe('Cell Tests', () => {
         selected: {idx: 2, rowIdx: 3},
         dragged: null,
         onCellClick: jasmine.createSpy(),
+        onCellFocus: jasmine.createSpy(),
         onCellContextMenu: jasmine.createSpy(),
         onCellDoubleClick: jasmine.createSpy(),
         onCommit: jasmine.createSpy(),
@@ -609,6 +620,7 @@ describe('Cell Tests', () => {
         selected: {idx: 2, rowIdx: 3},
         dragged: null,
         onCellClick: jasmine.createSpy(),
+        onCellFocus: jasmine.createSpy(),
         onCellContextMenu: jasmine.createSpy(),
         onCellDoubleClick: jasmine.createSpy(),
         onCommit: jasmine.createSpy(),
@@ -703,6 +715,7 @@ describe('Cell Tests', () => {
           selected: {idx: 2, rowIdx: 3},
           dragged: null,
           onCellClick: jasmine.createSpy(),
+          onCellFocus: jasmine.createSpy(),
           onCellContextMenu: jasmine.createSpy(),
           onCellDoubleClick: jasmine.createSpy(),
           onCommit: jasmine.createSpy(),
@@ -732,6 +745,7 @@ describe('Cell Tests', () => {
             selected: {idx: 2, rowIdx: 3},
             dragged: null,
             onCellClick: jasmine.createSpy(),
+            onCellFocus: jasmine.createSpy(),
             onCellContextMenu: jasmine.createSpy(),
             onCellDoubleClick: jasmine.createSpy(),
             onCommit: jasmine.createSpy(),

--- a/packages/react-data-grid/src/__tests__/createObjectWithProperties.spec.js
+++ b/packages/react-data-grid/src/__tests__/createObjectWithProperties.spec.js
@@ -1,0 +1,46 @@
+import createObjectFromProperties from '../createObjectWithProperties';
+
+describe('create Object From Properties', () => {
+  it('should create an object with the correct properties', () => {
+    const originalObj = {
+      a: null,
+      b: undefined,
+      c: false,
+      d: true,
+      e: 0,
+      f: 1,
+      g: '',
+      h: 'string',
+      ignore: 'me'
+    };
+    const properties = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'fake'];
+    const result = createObjectFromProperties(originalObj, properties);
+
+    expect(result).toEqual({
+      a: null,
+      b: undefined,
+      c: false,
+      d: true,
+      e: 0,
+      f: 1,
+      g: '',
+      h: 'string'
+    });
+  });
+
+  it('should create an empty object when requesting no properties', () => {
+    const originalObj = { a: 'test' };
+    const properties = [];
+    const result = createObjectFromProperties(originalObj, properties);
+
+    expect(result).toEqual({});
+  });
+
+  it('should create an empty object when requesting properties from an empty source', () => {
+    const originalObj = {};
+    const properties = ['a'];
+    const result = createObjectFromProperties(originalObj, properties);
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/react-data-grid/src/createObjectWithProperties.js
+++ b/packages/react-data-grid/src/createObjectWithProperties.js
@@ -1,7 +1,7 @@
 function createObjectWithProperties(originalObj: any, properties: any): any {
   let result = {};
   for (let property of properties) {
-    if (originalObj[property]) {
+    if (property in originalObj) {
       result[property] = originalObj[property];
     }
   }


### PR DESCRIPTION
We can now tab from outside the grid into a cell, and tab out of the grid. Tabbing from the outter edge of a row will now focus the cell in the next or previous row.

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Couldn't tab into the grid, or from a row to another row/outside the grid.


**What is the new behavior?**
Tabbing works like any other tabbable element on a page.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```