### PR TITLE
Use unpkg CDN for create-react-class

### DIFF
--- a/packages/react-data-grid-examples/src/documentation.html
+++ b/packages/react-data-grid-examples/src/documentation.html
@@ -21,8 +21,9 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.3/immutable.min.js"/></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/JSXTransformer.js"></script>
 	<!-- JavaScript srcs are placed at the end of the document so the pages load faster -->
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-with-addons.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
+	<script src="https://unpkg.com/create-react-class@15.6.2/create-react-class.min.js"></script>
 
 	<!-- Custom styles for our template -->
 	<link rel="stylesheet" href="assets/css/bootstrap.min.css">

--- a/packages/react-data-grid-examples/src/examples.html
+++ b/packages/react-data-grid-examples/src/examples.html
@@ -45,7 +45,7 @@
 <script src="scriptDelegator.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/create-react-class@15.6.2/create-react-class.min.js"></script>
+<script src="https://unpkg.com/create-react-class@15.6.2/create-react-class.min.js"></script>
 <script type="text/javascript">
   delegateScript('shared.js');
   delegateScript('examples.js');

--- a/packages/react-data-grid-examples/src/index.html
+++ b/packages/react-data-grid-examples/src/index.html
@@ -17,7 +17,7 @@
 	<link rel="stylesheet" href="assets/css/main.css"></link>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/create-react-class@15.6.2/create-react-class.min.js"></script>
+	<script src="https://unpkg.com/create-react-class@15.6.2/create-react-class.min.js"></script>
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/Faker/3.0.1/faker.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.3/immutable.min.js"/></script>


### PR DESCRIPTION
## Description
Current CDN for `create-react-class` is not reliable and randomly times out. Switching to `unpkg`
Also fixes #1073

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`cdn.jsdelivr.net/npm` is currently used as a CDN for `create-react-class`


**What is the new behavior?**
`https://unpkg.com` is the new CDN 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
