### PR TITLE
Change max_old_space_size for running tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm test
+  - npm test --max_old_space_size=8000
   - ps: ./test/uploadResults.ps1
   - gulp coveralls
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm test --max_old_space_size=8000
+  - npm test -- --max_old_space_size=8000
   - ps: ./test/uploadResults.ps1
   - gulp coveralls
 


### PR DESCRIPTION
## Description
AppVeyor failing tests due to not having enough memory available. This is a change to increase the memory size available to karma