### PR TITLE
Pass sort properties to custom header renderer

### DIFF
--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -83,13 +83,26 @@ const HeaderRow = createReactClass({
   },
 
   getSortableHeaderCell(column) {
-    let sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
-    return <SortableHeaderCell columnKey={column.key} onSort={this.props.onSort} sortDirection={sortDirection}/>;
+    let SortableRenderer = SortableHeaderCell;
+    if (column.headerRenderer !== undefined) {
+      SortableRenderer = column.headerRenderer;
+    }
+    const sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
+    const props = { columnKey: column.key, onSort: this.props.onSort, sortDirection: sortDirection };
+
+    if (React.isValidElement(SortableRenderer)) {
+      // a string means it's an HTML element and props we want to pass are not valid, return it as is
+      if (typeof SortableRenderer.type === 'string') {
+        return SortableRenderer;
+      }
+      return React.cloneElement(SortableRenderer, props);
+    }
+    return React.createElement(SortableRenderer, props);
   },
 
   getHeaderRenderer(column) {
     let renderer;
-    if (column.headerRenderer && !this.props.filterable) {
+    if (column.headerRenderer && !this.props.filterable && !column.sortable) {
       renderer = column.headerRenderer;
     } else {
       let headerCellType = this.getHeaderCellType(column);


### PR DESCRIPTION
In order to be able to display current sort order, we need sorting information in header renderer.
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

onSort / sortDirection props are not passed to the custom headerRenderer, hence making it impossible to display sorting information

**What is the new behavior?**

Pass sorting props to headerRenderer

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
