### PR TITLE
Revert "Pass sort properties to custom header renderer"

### DIFF
--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -83,26 +83,13 @@ const HeaderRow = createReactClass({
   },
 
   getSortableHeaderCell(column) {
-    let SortableRenderer = SortableHeaderCell;
-    if (column.headerRenderer !== undefined) {
-      SortableRenderer = column.headerRenderer;
-    }
-    const sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
-    const props = { columnKey: column.key, onSort: this.props.onSort, sortDirection: sortDirection };
-
-    if (React.isValidElement(SortableRenderer)) {
-      // a string means it's an HTML element and props we want to pass are not valid, return it as is
-      if (typeof SortableRenderer.type === 'string') {
-        return SortableRenderer;
-      }
-      return React.cloneElement(SortableRenderer, props);
-    }
-    return React.createElement(SortableRenderer, props);
+    let sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
+    return <SortableHeaderCell columnKey={column.key} onSort={this.props.onSort} sortDirection={sortDirection}/>;
   },
 
   getHeaderRenderer(column) {
     let renderer;
-    if (column.headerRenderer && !this.props.filterable && !column.sortable) {
+    if (column.headerRenderer && !this.props.filterable) {
       renderer = column.headerRenderer;
     } else {
       let headerCellType = this.getHeaderCellType(column);


### PR DESCRIPTION
Reverts adazzle/react-data-grid#1080

This issue has introduced another bug, we are seeing the error 
```Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: null. Check the render method of `HeaderRow``` in our testing.

Reverting this PR for now
