### PR TITLE
Convert createReactClass components to ES6 classes

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -35,12 +35,6 @@ const config = {
       commonjs2: 'react-dom',
       amd: 'react-dom'
     },
-    'create-react-class': {
-      root: 'createReactClass',
-      commonjs: 'create-react-class',
-      commonjs2: 'create-react-class',
-      amd: 'create-react-class'
-    },
     'react/addons': 'React',
     moment: 'moment'
   },

--- a/migrations/v2-v3.md
+++ b/migrations/v2-v3.md
@@ -2,10 +2,10 @@
 
 ### Differences
 ### 2.0.0
- - ~~Bundles `create-react-class` package with `react-data-grid`; ~~ ReactDataGrid is not longer dependent on `create-react-class` as all the components have been migrated to ES6 Classes ([#1078](https://github.com/adazzle/react-data-grid/pull/1078) and [#1094](https://github.com/adazzle/react-data-grid/pull/1094))
+ - <del>Bundles `create-react-class` package with `react-data-grid`;</del> ReactDataGrid is not longer dependent on `create-react-class` as all the components have been migrated to ES6 Classes ([#1078](https://github.com/adazzle/react-data-grid/pull/1078) and [#1094](https://github.com/adazzle/react-data-grid/pull/1094))
 
 ### 3.0.0
- - ~~Does not bundle `create-react-class` package with `react-data-grid`. It is specified as a peer dependency now [1065](https://github.com/adazzle/react-data-grid/pull/1065); ~~ peer dependency is no longer required.
+ - <del>Does not bundle `create-react-class` package with `react-data-grid`. It is specified as a peer dependency now [1065](https://github.com/adazzle/react-data-grid/pull/1065);</del> peer dependency is no longer required.
 
 ### Steps for a sucessfull migration
- - ~~Install create-react-class package (```npm install create-react-class```)~~ This is no longer required
+ - <del>Install create-react-class package (```npm install create-react-class```)</del> This is no longer required

--- a/migrations/v2-v3.md
+++ b/migrations/v2-v3.md
@@ -2,10 +2,10 @@
 
 ### Differences
 ### 2.0.0
- - <del>Bundles `create-react-class` package with `react-data-grid`;</del> ReactDataGrid is not longer dependent on `create-react-class` as all the components have been migrated to ES6 Classes ([#1078](https://github.com/adazzle/react-data-grid/pull/1078) and [#1094](https://github.com/adazzle/react-data-grid/pull/1094))
+ - Bundles `create-react-class` package with `react-data-grid`;
 
 ### 3.0.0
- - <del>Does not bundle `create-react-class` package with `react-data-grid`. It is specified as a peer dependency now [1065](https://github.com/adazzle/react-data-grid/pull/1065);</del> peer dependency is no longer required.
+ - <del>Does not bundle `create-react-class` package with `react-data-grid`. It is specified as a peer dependency now [1065](https://github.com/adazzle/react-data-grid/pull/1065);</del> ReactDataGrid is not longer dependent on `create-react-class` as all the components have been migrated to ES6 Classes ([#1078](https://github.com/adazzle/react-data-grid/pull/1078) and [#1094](https://github.com/adazzle/react-data-grid/pull/1094))
 
 ### Steps for a sucessfull migration
  - <del>Install create-react-class package (```npm install create-react-class```)</del> This is no longer required

--- a/migrations/v2-v3.md
+++ b/migrations/v2-v3.md
@@ -2,10 +2,10 @@
 
 ### Differences
 ### 2.0.0
- - Bundles `create-react-class` package with `react-data-grid`; 
+ - ~~Bundles `create-react-class` package with `react-data-grid`; ~~ ReactDataGrid is not longer dependent on `create-react-class` as all the components have been migrated to ES6 Classes ([#1078](https://github.com/adazzle/react-data-grid/pull/1078) and [#1094](https://github.com/adazzle/react-data-grid/pull/1094))
 
 ### 3.0.0
- - Does not bundle `create-react-class` package with `react-data-grid`. It is specified as a peer dependency now;
+ - ~~Does not bundle `create-react-class` package with `react-data-grid`. It is specified as a peer dependency now [1065](https://github.com/adazzle/react-data-grid/pull/1065); ~~ peer dependency is no longer required.
 
 ### Steps for a sucessfull migration
- - Install create-react-class package (```npm install create-react-class```)
+ - ~~Install create-react-class package (```npm install create-react-class```)~~ This is no longer required

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-component"
   ],
   "peerDependencies": {
-    "create-react-class": "^15.6.2",
     "react": "^15.6.2",
     "react-dom": "^15.6.2"
   },
@@ -56,7 +55,6 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.3.13",
     "copy-dir": "^0.3.0",
-    "create-react-class": "^15.6.2",
     "css-loader": "^0.26.0",
     "del": "^1.2.1",
     "enzyme": "2.8.0",

--- a/packages/react-data-grid-addons/src/editors/DateRangeEditor.js
+++ b/packages/react-data-grid-addons/src/editors/DateRangeEditor.js
@@ -1,63 +1,42 @@
 const React = require('react');
 import PropTypes from 'prop-types';
-const ReactDOM = require('react-dom');
 const Moment = require('moment');
 const DateRangeFilter = require('./widgets/DateRangeFilter');
 type DateRangeValue = { startDate: Date; endDate: Date};
 
-const DateRangeEditor = React.createClass({
-  displayName: 'DateRangeEditor',
+class DateRangeEditor extends React.Component {
+  static displayName = 'DateRangeEditor';
 
-  propTypes: {
+  static propTypes = {
     format: PropTypes.string,
     ranges: PropTypes.arrayOf(PropTypes.string),
     value: PropTypes.shape({
       startDate: PropTypes.Date.isRequired,
       endDate: PropTypes.Date.isRequired
     }).isRequired
-  },
+  };
 
-  getDefaultProps(): {format: string; ranges: Array<Date>} {
-    return {
-      format: 'YYYY-MM-DD',
-      ranges: []
-    };
-  },
+  static defaultProps = {
+    format: 'YYYY-MM-DD',
+    ranges: []
+  };
 
-  rangeSeparatorChar: ' - ',
+  rangeSeparatorChar = ' - ';
 
-  overrides: {
-    checkFocus: function() {
-      this.setTextInputFocus();
-    },
-    getInputNode(): HTMLElement {
-      return ReactDOM.findDOMNode(this.refs.datepicker);
-    },
-    getValue(): DateRangeValue {
-      let dateToParse = this.getInputNode().value;
-      let dateRanges = dateToParse.split(this.rangeSeparatorChar);
-      if (dateRanges.length !== 2) {
-        throw new Error('DateRangeEditor.getValue error : ' + dateToParse + ' is not in the correct format');
-      }
-
-      return {startDate: dateRanges[0].trim(), endDate: dateRanges[1].trim()};
-    }
-  },
-
-  isDateValid(date: Date): boolean {
+  isDateValid = (date: Date): boolean => {
     return new Moment(date, this.props.format, true).isValid();
-  },
+  };
 
-  validate(value: DateRangeValue): boolean {
+  validate = (value: DateRangeValue): boolean => {
     return this.isDateValid(value.startDate)
     && this.isDateValid(value.endDate)
     && (new Moment(value.startDate, this.props.format).isBefore(value.endDate)
     || new Moment(value.startDate, this.props.format).isSame(value.endDate));
-  },
+  };
 
-  handleDateFilterApply(startDate: string, endDate: string) {
+  handleDateFilterApply = (startDate: string, endDate: string) => {
     this.commit({value: {startDate: startDate, endDate: endDate}});
-  },
+  };
 
   render(): ?ReactElement {
     return (
@@ -66,6 +45,6 @@ const DateRangeEditor = React.createClass({
       </div>
     );
   }
-});
+}
 
 module.exports = DateRangeEditor;

--- a/packages/react-data-grid-addons/src/editors/DateRangeEditor.js
+++ b/packages/react-data-grid-addons/src/editors/DateRangeEditor.js
@@ -1,12 +1,11 @@
 const React = require('react');
 import PropTypes from 'prop-types';
-const createReactClass = require('create-react-class');
 const ReactDOM = require('react-dom');
 const Moment = require('moment');
 const DateRangeFilter = require('./widgets/DateRangeFilter');
 type DateRangeValue = { startDate: Date; endDate: Date};
 
-const DateRangeEditor = createReactClass({
+const DateRangeEditor = React.createClass({
   displayName: 'DateRangeEditor',
 
   propTypes: {

--- a/packages/react-data-grid-examples/src/documentation.html
+++ b/packages/react-data-grid-examples/src/documentation.html
@@ -23,7 +23,6 @@
 	<!-- JavaScript srcs are placed at the end of the document so the pages load faster -->
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
-	<script src="https://unpkg.com/create-react-class@15.6.2/create-react-class.min.js"></script>
 
 	<!-- Custom styles for our template -->
 	<link rel="stylesheet" href="assets/css/bootstrap.min.css">

--- a/packages/react-data-grid-examples/src/examples.html
+++ b/packages/react-data-grid-examples/src/examples.html
@@ -45,7 +45,6 @@
 <script src="scriptDelegator.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
-<script src="https://unpkg.com/create-react-class@15.6.2/create-react-class.min.js"></script>
 <script type="text/javascript">
   delegateScript('shared.js');
   delegateScript('examples.js');

--- a/packages/react-data-grid-examples/src/index.html
+++ b/packages/react-data-grid-examples/src/index.html
@@ -17,7 +17,6 @@
 	<link rel="stylesheet" href="assets/css/main.css"></link>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
-	<script src="https://unpkg.com/create-react-class@15.6.2/create-react-class.min.js"></script>
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/Faker/3.0.1/faker.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.3/immutable.min.js"/></script>

--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -1,5 +1,4 @@
 const React = require('react');
-const createReactClass = require('create-react-class');
 const joinClasses = require('classnames');
 import PropTypes from 'prop-types';
 const Row = require('./Row');
@@ -12,10 +11,10 @@ import shallowEqual from 'fbjs/lib/shallowEqual';
 import RowsContainer from './RowsContainer';
 import RowGroup from './RowGroup';
 
-const Canvas = createReactClass({
-  displayName: 'Canvas',
+class Canvas extends React.Component {
+  static displayName = 'Canvas';
 
-  propTypes: {
+  static propTypes = {
     rowRenderer: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
     rowHeight: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
@@ -62,10 +61,28 @@ const Canvas = createReactClass({
       })
     ]),
     rowGroupRenderer: PropTypes.func,
-    isScrolling: PropTypes.bool
-  },
+    isScrolling: PropTypes.bool,
+    length: PropTypes.number
+  };
 
-  appendScrollShim() {
+  static defaultProps = {
+    rowRenderer: Row,
+    onRows: () => { },
+    selectedRows: [],
+    rowScrollTimeout: 0
+  };
+
+  state = {
+    displayStart: this.props.displayStart,
+    displayEnd: this.props.displayEnd,
+    scrollingTimeout: null
+  };
+
+  _currentRowsLength = 0;
+  _currentRowsRange = { start: 0, end: 0 };
+  _scroll = { scrollTop: 0, scrollLeft: 0 };
+
+  appendScrollShim = () => {
     if (!this._scrollShim) {
       const size = this._scrollShimSize();
       const shim = createScrollShim(size);
@@ -73,57 +90,40 @@ const Canvas = createReactClass({
       this._scrollShim = shim;
     }
     this._scheduleRemoveScrollShim();
-  },
+  };
 
-  _scrollShimSize(): { width: number; height: number } {
+  _scrollShimSize = (): { width: number; height: number } => {
     return {
       width: this.props.width,
       height: this.props.length * this.props.rowHeight
     };
-  },
+  };
 
-  _scheduleRemoveScrollShim() {
+  _scheduleRemoveScrollShim = () => {
     if (this._scheduleRemoveScrollShimTimer) {
       clearTimeout(this._scheduleRemoveScrollShimTimer);
     }
     this._scheduleRemoveScrollShimTimer = setTimeout(
       this._removeScrollShim, 200);
-  },
+  };
 
-  _removeScrollShim() {
+  _removeScrollShim = () => {
     if (this._scrollShim) {
       this._scrollShim.parentNode.removeChild(this._scrollShim);
       this._scrollShim = undefined;
     }
-  },
-
-  getDefaultProps() {
-    return {
-      rowRenderer: Row,
-      onRows: () => { },
-      selectedRows: [],
-      rowScrollTimeout: 0
-    };
-  },
-
-  getInitialState() {
-    return {
-      displayStart: this.props.displayStart,
-      displayEnd: this.props.displayEnd,
-      scrollingTimeout: null
-    };
-  },
+  };
 
   componentWillMount() {
     this.rows = [];
     this._currentRowsLength = 0;
     this._currentRowsRange = { start: 0, end: 0 };
     this._scroll = { scrollTop: 0, scrollLeft: 0 };
-  },
+  }
 
   componentDidMount() {
     this.onRows();
-  },
+  }
 
   componentWillReceiveProps(nextProps: any) {
     if (nextProps.displayStart !== this.state.displayStart
@@ -133,7 +133,7 @@ const Canvas = createReactClass({
         displayEnd: nextProps.displayEnd
       });
     }
-  },
+  }
 
   shouldComponentUpdate(nextProps: any, nextState: any): boolean {
     let shouldUpdate = nextState.displayStart !== this.state.displayStart
@@ -153,13 +153,13 @@ const Canvas = createReactClass({
       || !shallowEqual(nextProps.style, this.props.style)
       || this.props.isScrolling !== nextProps.isScrolling;
     return shouldUpdate;
-  },
+  }
 
   componentWillUnmount() {
     this._currentRowsLength = 0;
     this._currentRowsRange = { start: 0, end: 0 };
     this._scroll = { scrollTop: 0, scrollLeft: 0 };
-  },
+  }
 
   componentDidUpdate() {
     if (this._scroll.scrollTop !== 0 && this._scroll.scrollLeft !== 0) {
@@ -172,16 +172,16 @@ const Canvas = createReactClass({
       );
     }
     this.onRows();
-  },
+  }
 
-  onRows() {
+  onRows = () => {
     if (this._currentRowsRange !== { start: 0, end: 0 }) {
       this.props.onRows(this._currentRowsRange);
       this._currentRowsRange = { start: 0, end: 0 };
     }
-  },
+  };
 
-  onScroll(e: any) {
+  onScroll = (e: any) => {
     if (this.canvas !== e.target) {
       return;
     }
@@ -191,9 +191,9 @@ const Canvas = createReactClass({
     let scroll = { scrollTop, scrollLeft };
     this._scroll = scroll;
     this.props.onScroll(scroll);
-  },
+  };
 
-  getRows(displayStart, displayEnd) {
+  getRows = (displayStart, displayEnd) => {
     this._currentRowsRange = { start: displayStart, end: displayEnd };
     if (Array.isArray(this.props.rowGetter)) {
       return this.props.rowGetter.slice(displayStart, displayEnd);
@@ -210,20 +210,20 @@ const Canvas = createReactClass({
       i++;
     }
     return rows;
-  },
+  };
 
-  getScrollbarWidth() {
+  getScrollbarWidth = () => {
     // Get the scrollbar width
     const scrollbarWidth = this.canvas.offsetWidth - this.canvas.clientWidth;
     return scrollbarWidth;
-  },
+  };
 
-  getScroll() {
+  getScroll = () => {
     const { scrollTop, scrollLeft } = this.canvas;
     return { scrollTop, scrollLeft };
-  },
+  };
 
-  isRowSelected(idx, row) {
+  isRowSelected = (idx, row) => {
     // Use selectedRows if set
     if (this.props.selectedRows !== null) {
       let selectedRows = this.props.selectedRows.filter(r => {
@@ -240,13 +240,9 @@ const Canvas = createReactClass({
     }
 
     return false;
-  },
+  };
 
-  _currentRowsLength: 0,
-  _currentRowsRange: { start: 0, end: 0 },
-  _scroll: { scrollTop: 0, scrollLeft: 0 },
-
-  setScrollLeft(scrollLeft) {
+  setScrollLeft = (scrollLeft) => {
     if (this._currentRowsLength !== 0) {
       if (!this.rows) return;
       for (let i = 0, len = this._currentRowsLength; i < len; i++) {
@@ -258,18 +254,18 @@ const Canvas = createReactClass({
         }
       }
     }
-  },
+  };
 
-  getRowByRef(i) {
+  getRowByRef = (i) => {
     // check if wrapped with React DND drop target
     let wrappedRow = this.rows[i].getDecoratedComponentInstance ? this.rows[i].getDecoratedComponentInstance(i) : null;
     if (wrappedRow) {
       return wrappedRow.row;
     }
     return this.rows[i];
-  },
+  };
 
-  renderRow(props: any) {
+  renderRow = (props: any) => {
     let row = props.row;
     if (row.__metaData && row.__metaData.getRowRenderer) {
       return row.__metaData.getRowRenderer(this.props, props.idx);
@@ -289,9 +285,9 @@ const Canvas = createReactClass({
     if (React.isValidElement(this.props.rowRenderer)) {
       return React.cloneElement(this.props.rowRenderer, props);
     }
-  },
+  };
 
-  renderPlaceholder(key: string, height: number): ?ReactElement {
+  renderPlaceholder = (key: string, height: number) => {
     // just renders empty cells
     // if we wanted to show gridlines, we'd need classes and position as with renderScrollingPlaceholder
     return (<div key={key} style={{ height: height }}>
@@ -302,7 +298,7 @@ const Canvas = createReactClass({
       }
     </div >
     );
-  },
+  };
 
   render() {
     const { displayStart, displayEnd } = this.state;
@@ -366,6 +362,6 @@ const Canvas = createReactClass({
       </div>
     );
   }
-});
+}
 
 module.exports = Canvas;

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -1,16 +1,15 @@
 const React                = require('react');
 const ReactDOM             = require('react-dom');
 import PropTypes from 'prop-types';
-const createReactClass = require('create-react-class');
 const Header               = require('./Header');
 const Viewport             = require('./Viewport');
 const cellMetaDataShape    = require('./PropTypeShapes/CellMetaDataShape');
 require('../../../themes/react-data-grid-core.css');
 
-const Grid = createReactClass({
-  displayName: 'Grid',
+class Grid extends React.Component {
+  static displayName = 'Grid';
 
-  propTypes: {
+  static propTypes = {
     rowGetter: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
     columns: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     tabIndex: PropTypes.number,
@@ -61,42 +60,40 @@ const Grid = createReactClass({
     getValidFilterValues: PropTypes.func,
     rowGroupRenderer: PropTypes.func,
     overScan: PropTypes.object
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      rowHeight: 35,
-      minHeight: 350,
-      tabIndex: 0
-    };
-  },
+  static defaultProps = {
+    rowHeight: 35,
+    minHeight: 350,
+    tabIndex: 0
+  };
 
-  getStyle: function(): { overflow: string; outline: number; position: string; minHeight: number } {
+  getStyle = (): { overflow: string; outline: number; position: string; minHeight: number } => {
     return {
       overflow: 'hidden',
       outline: 0,
       position: 'relative',
       minHeight: this.props.minHeight
     };
-  },
+  };
 
-  _onScroll() {
+  _onScroll = () => {
     if (this._scrollLeft !== undefined) {
       this.header.setScrollLeft(this._scrollLeft);
       if (this.viewport) {
         this.viewport.setScrollLeft(this._scrollLeft);
       }
     }
-  },
+  };
 
-  onScroll(props) {
+  onScroll = (props) => {
     if (this._scrollLeft !== props.scrollLeft) {
       this._scrollLeft = props.scrollLeft;
       this._onScroll();
     }
-  },
+  };
 
-  onHeaderScroll(e) {
+  onHeaderScroll = (e) => {
     let scrollLeft = e.target.scrollLeft;
     if (this._scrollLeft !== scrollLeft) {
       this._scrollLeft = scrollLeft;
@@ -105,24 +102,24 @@ const Grid = createReactClass({
       canvas.scrollLeft = scrollLeft;
       this.viewport.canvas.setScrollLeft(scrollLeft);
     }
-  },
+  };
 
   componentDidMount() {
     this._scrollLeft = this.viewport ? this.viewport.getScroll().scrollLeft : 0;
     this._onScroll();
-  },
+  }
 
   componentDidUpdate() {
     this._onScroll();
-  },
+  }
 
   componentWillMount() {
     this._scrollLeft = undefined;
-  },
+  }
 
   componentWillUnmount() {
     this._scrollLeft = undefined;
-  },
+  }
 
   render(): ?ReactElement {
     let headerRows = this.props.headerRows || [{ref: (node) => this.row = node}];
@@ -190,6 +187,6 @@ const Grid = createReactClass({
       </div>
     );
   }
-});
+}
 
 module.exports = Grid;

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -1,5 +1,4 @@
 const React             = require('react');
-const createReactClass = require('create-react-class');
 const shallowEqual    = require('fbjs/lib/shallowEqual');
 const BaseHeaderCell        = require('./HeaderCell');
 const getScrollbarSize  = require('./getScrollbarSize');
@@ -23,10 +22,10 @@ const HeaderRowStyle  = {
 // The list of the propTypes that we want to include in the HeaderRow div
 const knownDivPropertyKeys = ['width', 'height', 'style', 'onScroll'];
 
-const HeaderRow = createReactClass({
-  displayName: 'HeaderRow',
+class HeaderRow extends React.Component {
+  static displayName = 'HeaderRow';
 
-  propTypes: {
+  static propTypes = {
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     height: PropTypes.number.isRequired,
     columns: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
@@ -45,13 +44,15 @@ const HeaderRow = createReactClass({
     rowType: PropTypes.string,
     draggableHeaderCell: PropTypes.func,
     onHeaderDrop: PropTypes.func
-  },
+  };
 
   componentWillMount() {
     this.cells = [];
-  },
+  }
 
-  shouldComponentUpdate(nextProps: {width: ?(number | string); height: number; columns: Array<ExcelColumn>; style: ?HeaderRowStyle; onColumnResize: ?any}): boolean {
+  shouldComponentUpdate(
+    nextProps: {width: ?(number | string); height: number; columns: Array<ExcelColumn>; style: ?HeaderRowStyle; onColumnResize: ?any},
+  ): boolean {
     return (
       nextProps.width !== this.props.width
       || nextProps.height !== this.props.height
@@ -60,9 +61,9 @@ const HeaderRow = createReactClass({
       || this.props.sortColumn !== nextProps.sortColumn
       || this.props.sortDirection !== nextProps.sortDirection
     );
-  },
+  }
 
-  getHeaderCellType(column) {
+  getHeaderCellType = (column) => {
     if (column.filterable) {
       if (this.props.filterable) return HeaderCellType.FILTERABLE;
     }
@@ -70,22 +71,22 @@ const HeaderRow = createReactClass({
     if (column.sortable && column.rowType !== 'filter') return HeaderCellType.SORTABLE;
 
     return HeaderCellType.NONE;
-  },
+  };
 
-  getFilterableHeaderCell(column) {
+  getFilterableHeaderCell = (column) => {
     let FilterRenderer = FilterableHeaderCell;
     if (column.filterRenderer !== undefined) {
       FilterRenderer = column.filterRenderer;
     }
     return <FilterRenderer {...this.props} onChange={this.props.onFilterChange} />;
-  },
+  };
 
-  getSortableHeaderCell(column) {
+  getSortableHeaderCell = (column) => {
     let sortDirection = (this.props.sortColumn === column.key) ? this.props.sortDirection : SortableHeaderCell.DEFINE_SORT.NONE;
     return <SortableHeaderCell columnKey={column.key} onSort={this.props.onSort} sortDirection={sortDirection}/>;
-  },
+  };
 
-  getHeaderRenderer(column) {
+  getHeaderRenderer = (column) => {
     let renderer;
     if (column.headerRenderer && !this.props.filterable) {
       renderer = column.headerRenderer;
@@ -103,18 +104,18 @@ const HeaderRow = createReactClass({
       }
     }
     return renderer;
-  },
+  };
 
-  getStyle(): HeaderRowStyle {
+  getStyle = (): HeaderRowStyle => {
     return {
       overflow: 'hidden',
       width: '100%',
       height: this.props.height,
       position: 'absolute'
     };
-  },
+  };
 
-  getCells(): Array<HeaderCell> {
+  getCells = (): Array<HeaderCell> => {
     let cells = [];
     let lockedCells = [];
     for (let i = 0, len = columnUtils.getSize(this.props.columns); i < len; i++) {
@@ -145,9 +146,9 @@ const HeaderRow = createReactClass({
     }
 
     return cells.concat(lockedCells);
-  },
+  };
 
-  setScrollLeft(scrollLeft: number) {
+  setScrollLeft = (scrollLeft: number) => {
     this.props.columns.forEach( (column, i) => {
       if (column.locked) {
         this.cells[i].setScrollLeft(scrollLeft);
@@ -157,11 +158,11 @@ const HeaderRow = createReactClass({
         }
       }
     });
-  },
+  };
 
-  getKnownDivProps() {
+  getKnownDivProps = () => {
     return createObjectWithProperties(this.props, knownDivPropertyKeys);
-  },
+  };
 
   render(): ?ReactElement {
     let cellsStyle = {
@@ -181,6 +182,6 @@ const HeaderRow = createReactClass({
       </div>
     );
   }
-});
+}
 
 module.exports = HeaderRow;

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -1,6 +1,5 @@
 const React                 = require('react');
 import PropTypes from 'prop-types';
-const createReactClass = require('create-react-class');
 const BaseGrid              = require('./Grid');
 const Row                   = require('./Row');
 const ExcelColumn           = require('./PropTypeShapes/ExcelColumn');
@@ -49,10 +48,10 @@ type ColumnMetricsType = {
   minColumnWidth: number;
 };
 
-const ReactDataGrid = createReactClass({
-  displayName: 'ReactDataGrid',
+class ReactDataGrid extends React.Component {
+  static displayName = 'ReactDataGrid';
 
-  propTypes: {
+  static propTypes = {
     rowHeight: PropTypes.number.isRequired,
     headerRowHeight: PropTypes.number,
     headerFiltersHeight: PropTypes.number,
@@ -122,11 +121,46 @@ const ReactDataGrid = createReactClass({
     enableCellAutoFocus: PropTypes.bool,
     onBeforeEdit: PropTypes.func,
     selectAllRenderer: PropTypes.object
-  },
+  };
+
+  static defaultProps = {
+    enableCellSelect: false,
+    tabIndex: -1,
+    rowHeight: 35,
+    headerFiltersHeight: 45,
+    enableRowSelect: false,
+    minHeight: 350,
+    rowKey: 'id',
+    rowScrollTimeout: 0,
+    scrollToRowIndex: 0,
+    cellNavigationMode: 'none',
+    overScan: {
+      colsStart: 5,
+      colsEnd: 5,
+      rowsStart: 5,
+      rowsEnd: 5
+    },
+    enableCellAutoFocus: true,
+    onBeforeEdit: () => {},
+    minColumnWidth: 80,
+    columnEquality: ColumnMetrics.sameColumn
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    let columnMetrics = this.createColumnMetrics();
+    let initialState = {columnMetrics, selectedRows: [], copied: null, expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, dragged: null, scrollOffset: 0, lastRowIdxUiSelected: -1};
+    if (props.enableCellSelect) {
+      initialState.selected = {rowIdx: 0, idx: 0};
+    } else {
+      initialState.selected = {rowIdx: -1, idx: -1};
+    }
+    this.state = initialState;
+  }
 
   componentWillMount() {
     this._mounted = true;
-  },
+  }
 
   componentDidMount() {
     if (window.addEventListener) {
@@ -135,12 +169,12 @@ const ReactDataGrid = createReactClass({
       window.attachEvent('resize', this.metricsUpdated);
     }
     this.metricsUpdated();
-  },
+  }
 
   componentWillUnmount() {
     this._mounted = false;
     window.removeEventListener('resize', this.metricsUpdated);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.columns) {
@@ -150,13 +184,13 @@ const ReactDataGrid = createReactClass({
         this.setState({columnMetrics: columnMetrics});
       }
     }
-  },
+  }
 
-  gridWidth(): number {
+  gridWidth = (): number => {
     return this.grid ? this.grid.parentElement.offsetWidth : 0;
-  },
+  };
 
-  getTotalWidth() {
+  getTotalWidth = () => {
     let totalWidth = 0;
     if (this._mounted) {
       totalWidth = this.gridWidth();
@@ -164,9 +198,9 @@ const ReactDataGrid = createReactClass({
       totalWidth = ColumnUtils.getSize(this.props.columns) * this.props.minColumnWidth;
     }
     return totalWidth;
-  },
+  };
 
-  getColumnMetricsType(metrics: ColumnMetricsType): { columns: ColumnMetricsType } {
+  getColumnMetricsType = (metrics: ColumnMetricsType): { columns: ColumnMetricsType } => {
     let totalWidth = metrics.totalWidth || this.getTotalWidth();
     let currentMetrics = {
       columns: metrics.columns,
@@ -175,85 +209,49 @@ const ReactDataGrid = createReactClass({
     };
     let updatedMetrics = ColumnMetrics.recalculate(currentMetrics);
     return updatedMetrics;
-  },
+  };
 
-  getColumn(idx) {
+  getColumn = (idx) => {
     let columns = this.state.columnMetrics.columns;
     if (Array.isArray(columns)) {
       return columns[idx];
     }else if (typeof Immutable !== 'undefined') {
       return columns.get(idx);
     }
-  },
+  };
 
-  getSize() {
+  getSize = () => {
     let columns = this.state.columnMetrics.columns;
     if (Array.isArray(columns)) {
       return columns.length;
     }else if (typeof Immutable !== 'undefined') {
       return columns.size;
     }
-  },
+  };
 
-  metricsUpdated() {
+  metricsUpdated = () => {
     let columnMetrics = this.createColumnMetrics();
     this.setState({columnMetrics});
-  },
+  };
 
-  createColumnMetrics(props = this.props) {
+  createColumnMetrics = (props = this.props) => {
     let gridColumns = this.setupGridColumns(props);
     return this.getColumnMetricsType({
       columns: gridColumns,
       minColumnWidth: this.props.minColumnWidth,
       totalWidth: props.minWidth
     });
-  },
+  };
 
-  onColumnResize(index: number, width: number) {
+  onColumnResize = (index: number, width: number) => {
     let columnMetrics = ColumnMetrics.resizeColumn(this.state.columnMetrics, index, width);
     this.setState({columnMetrics});
     if (this.props.onColumnResize) {
       this.props.onColumnResize(index, width);
     }
-  },
+  };
 
-  getDefaultProps(): {enableCellSelect: boolean} {
-    return {
-      enableCellSelect: false,
-      tabIndex: -1,
-      rowHeight: 35,
-      headerFiltersHeight: 45,
-      enableRowSelect: false,
-      minHeight: 350,
-      rowKey: 'id',
-      rowScrollTimeout: 0,
-      scrollToRowIndex: 0,
-      cellNavigationMode: 'none',
-      overScan: {
-        colsStart: 5,
-        colsEnd: 5,
-        rowsStart: 5,
-        rowsEnd: 5
-      },
-      enableCellAutoFocus: true,
-      onBeforeEdit: () => {},
-      minColumnWidth: 80,
-      columnEquality: ColumnMetrics.sameColumn
-    };
-  },
-
-  getInitialState: function(): {selected: SelectedType; copied: ?{idx: number; rowIdx: number}; selectedRows: Array<Row>; expandedRows: Array<Row>; canFilter: boolean; columnFilters: any; sortDirection: ?SortType; sortColumn: ?ExcelColumn; dragged: ?DraggedType;  } {
-    let columnMetrics = this.createColumnMetrics();
-    let initialState = {columnMetrics, selectedRows: [], copied: null, expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, dragged: null, scrollOffset: 0, lastRowIdxUiSelected: -1};
-    if (this.props.enableCellSelect) {
-      initialState.selected = {rowIdx: 0, idx: 0};
-    } else {
-      initialState.selected = {rowIdx: -1, idx: -1};
-    }
-    return initialState;
-  },
-
-  onKeyDown(e: SyntheticKeyboardEvent) {
+  onKeyDown = (e: SyntheticKeyboardEvent) => {
     if (isCtrlKeyHeldDown(e)) {
       this.checkAndCall('onPressKeyWithCtrl', e);
     } else if (this.isKeyExplicitlyHandled(e.key)) {
@@ -270,9 +268,9 @@ const ReactDataGrid = createReactClass({
     if (isFunction(this.props.onGridKeyDown)) {
       this.props.onGridKeyDown(e);
     }
-  },
+  };
 
-  onKeyUp(e) {
+  onKeyUp = (e) => {
     // Track which keys are currently down for shift clicking etc
     this._keysDown = this._keysDown || {};
     delete this._keysDown[e.keyCode];
@@ -280,40 +278,40 @@ const ReactDataGrid = createReactClass({
     if (isFunction(this.props.onGridKeyUp)) {
       this.props.onGridKeyUp(e);
     }
-  },
+  };
 
-  isKeyDown(keyCode) {
+  isKeyDown = (keyCode) => {
     if (!this._keysDown) return false;
     return keyCode in this._keysDown;
-  },
+  };
 
-  isSingleKeyDown(keyCode) {
+  isSingleKeyDown = (keyCode) => {
     if (!this._keysDown) return false;
     return keyCode in this._keysDown && Object.keys(this._keysDown).length === 1;
-  },
+  };
 
-  checkAndCall(methodName: string, args: any) {
+  checkAndCall = (methodName: string, args: any) => {
     if (typeof this[methodName] === 'function') {
       this[methodName](args);
     }
-  },
+  };
 
-  isKeyExplicitlyHandled(key: string): boolean {
+  isKeyExplicitlyHandled = (key: string): boolean => {
     return typeof this['onPress' + key] === 'function';
-  },
+  };
 
-  hasSelectedCellChanged: function(selected: SelectedType) {
+  hasSelectedCellChanged = (selected: SelectedType) => {
     let previouslySelected = Object.assign({}, this.state.selected);
     return previouslySelected.rowIdx !== selected.rowIdx || previouslySelected.idx !== selected.idx || previouslySelected.active === false;
-  },
+  };
 
-  onContextMenuHide: function() {
+  onContextMenuHide = () => {
     document.removeEventListener('click', this.onContextMenuHide);
     let newSelected = Object.assign({}, this.state.selected, {contextMenuDisplayed: false});
     this.setState({selected: newSelected});
-  },
+  };
 
-  onColumnEvent: function(ev :SyntheticEvent, columnEvent: ColumnEvent) {
+  onColumnEvent = (ev :SyntheticEvent, columnEvent: ColumnEvent) => {
     let {idx, name} = columnEvent;
 
     if (name && typeof idx !== 'undefined') {
@@ -330,9 +328,9 @@ const ReactDataGrid = createReactClass({
         column.events[name](ev, eventArgs);
       }
     }
-  },
+  };
 
-  onSelect: function(selected: SelectedType) {
+  onSelect = (selected: SelectedType) => {
     if (this.state.selected.rowIdx !== selected.rowIdx
       || this.state.selected.idx !== selected.idx
       || this.state.selected.active === false) {
@@ -353,9 +351,9 @@ const ReactDataGrid = createReactClass({
         this.setState({selected: { idx, rowIdx }});
       }
     }
-  },
+  };
 
-  onCellClick: function(cell: SelectedType, e: SyntheticEvent) {
+  onCellClick = (cell: SelectedType, e: SyntheticEvent) => {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
 
     if (this.props.onRowClick && typeof this.props.onRowClick === 'function') {
@@ -365,16 +363,16 @@ const ReactDataGrid = createReactClass({
     if (e) {
       e.stopPropagation();
     }
-  },
+  };
 
-  onCellContextMenu: function(cell: SelectedType) {
+  onCellContextMenu = (cell: SelectedType) => {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx, contextMenuDisplayed: this.props.contextMenu});
     if (this.props.contextMenu) {
       document.addEventListener('click', this.onContextMenuHide);
     }
-  },
+  };
 
-  onCellDoubleClick: function(cell: SelectedType, e: SyntheticEvent) {
+  onCellDoubleClick = (cell: SelectedType, e: SyntheticEvent) => {
     this.onSelect({rowIdx: cell.rowIdx, idx: cell.idx});
     if (this.props.onRowDoubleClick && typeof this.props.onRowDoubleClick === 'function') {
       this.props.onRowDoubleClick(cell.rowIdx, this.props.rowGetter(cell.rowIdx), this.getColumn(cell.idx));
@@ -383,51 +381,51 @@ const ReactDataGrid = createReactClass({
     if (e) {
       e.stopPropagation();
     }
-  },
+  };
 
-  onPressArrowUp(e: SyntheticEvent) {
+  onPressArrowUp = (e: SyntheticEvent) => {
     this.moveSelectedCell(e, -1, 0);
-  },
+  };
 
-  onPressArrowDown(e: SyntheticEvent) {
+  onPressArrowDown = (e: SyntheticEvent) => {
     this.moveSelectedCell(e, 1, 0);
-  },
+  };
 
-  onPressArrowLeft(e: SyntheticEvent) {
+  onPressArrowLeft = (e: SyntheticEvent) => {
     this.moveSelectedCell(e, 0, -1);
-  },
+  };
 
-  onPressArrowRight(e: SyntheticEvent) {
+  onPressArrowRight = (e: SyntheticEvent) => {
     this.moveSelectedCell(e, 0, 1);
-  },
+  };
 
-  isFocusedOnCell() {
+  isFocusedOnCell = () => {
     return document.activeElement && document.activeElement.classList &&
       document.activeElement.classList.contains('react-grid-Cell');
-  },
+  };
 
-  isFocusedOnTable() {
+  isFocusedOnTable = () => {
     const domNode = this.getDataGridDOMNode();
     return domNode && domNode.contains(document.activeElement);
-  },
+  };
 
-  exitGrid(oldSelectedCell, newSelectedValue) {
+  exitGrid = (oldSelectedCell, newSelectedValue) => {
     this.setState({ selected: newSelectedValue },
       () => {
         if (typeof this.props.onCellDeSelected === 'function') {
           this.props.onCellDeSelected(oldSelectedCell);
         }});
-  },
+  };
 
-  enterGrid(newSelectedValue) {
+  enterGrid = (newSelectedValue) => {
     this.setState({ selected: newSelectedValue },
       () => {
         if (typeof this.props.onCellSelected === 'function') {
           this.props.onCellSelected(newSelectedValue);
         }});
-  },
+  };
 
-  onPressTab(e: SyntheticEvent) {
+  onPressTab = (e: SyntheticEvent) => {
     // Scenario 0a: When there are no rows in the grid, pressing tab needs to allow the browser to handle it
     if (this.props.rowsCount === 0) {
       return;
@@ -483,32 +481,32 @@ const ReactDataGrid = createReactClass({
       return;
     }
     this.moveSelectedCell(e, 0, e.shiftKey ? -1 : 1);
-  },
+  };
 
-  onPressEnter(e: SyntheticKeyboardEvent) {
+  onPressEnter = (e: SyntheticKeyboardEvent) => {
     this.setActive(e.key);
-  },
+  };
 
-  onPressDelete(e: SyntheticKeyboardEvent) {
+  onPressDelete = (e: SyntheticKeyboardEvent) => {
     this.setActive(e.key);
-  },
+  };
 
-  onPressEscape(e: SyntheticKeyboardEvent) {
+  onPressEscape = (e: SyntheticKeyboardEvent) => {
     this.setInactive(e.key);
     this.handleCancelCopy();
-  },
+  };
 
-  onPressBackspace(e: SyntheticKeyboardEvent) {
+  onPressBackspace = (e: SyntheticKeyboardEvent) => {
     this.setActive(e.key);
-  },
+  };
 
-  onPressChar(e: SyntheticKeyboardEvent) {
+  onPressChar = (e: SyntheticKeyboardEvent) => {
     if (isKeyPrintable(e.keyCode)) {
       this.setActive(e.keyCode);
     }
-  },
+  };
 
-  onPressKeyWithCtrl(e: SyntheticKeyboardEvent) {
+  onPressKeyWithCtrl = (e: SyntheticKeyboardEvent) => {
     let keys = {
       KeyCode_c: 99,
       KeyCode_C: 67,
@@ -530,9 +528,9 @@ const ReactDataGrid = createReactClass({
         this.handlePaste();
       }
     }
-  },
+  };
 
-  onGridRowsUpdated(cellKey, fromRow, toRow, updated, action, originRow) {
+  onGridRowsUpdated = (cellKey, fromRow, toRow, updated, action, originRow) => {
     let rowIds = [];
 
     for (let i = fromRow; i <= toRow; i++) {
@@ -543,9 +541,9 @@ const ReactDataGrid = createReactClass({
     let fromRowId = fromRowData[this.props.rowKey];
     let toRowId = this.props.rowGetter(toRow)[this.props.rowKey];
     this.props.onGridRowsUpdated({cellKey, fromRow, toRow, fromRowId, toRowId, rowIds, updated, action, fromRowData});
-  },
+  };
 
-  onCellCommit(commit: RowUpdateEvent) {
+  onCellCommit = (commit: RowUpdateEvent) => {
     let selected = Object.assign({}, this.state.selected);
     selected.active = false;
     let expandedRows = this.state.expandedRows;
@@ -563,9 +561,9 @@ const ReactDataGrid = createReactClass({
     if (this.props.onGridRowsUpdated) {
       this.onGridRowsUpdated(commit.cellKey, targetRow, targetRow, commit.updated, AppConstants.UpdateActions.CELL_UPDATE);
     }
-  },
+  };
 
-  onDragStart(e: SyntheticEvent) {
+  onDragStart = (e: SyntheticEvent) => {
     let idx = this.state.selected.idx;
     // To prevent dragging down/up when reordering rows.
     const isViewportDragging = e && e.target && e.target.className;
@@ -581,9 +579,9 @@ const ReactDataGrid = createReactClass({
         }
       }
     }
-  },
+  };
 
-  onToggleFilter() {
+  onToggleFilter = () => {
     // setState() does not immediately mutate this.state but creates a pending state transition.
     // Therefore if you want to do something after the state change occurs, pass it in as a callback function.
     this.setState({ canFilter: !this.state.canFilter }, () => {
@@ -591,9 +589,9 @@ const ReactDataGrid = createReactClass({
         this.props.onClearFilters();
       }
     });
-  },
+  };
 
-  onDragHandleDoubleClick(e) {
+  onDragHandleDoubleClick = (e) => {
     if (this.props.onDragHandleDoubleClick) {
       this.props.onDragHandleDoubleClick(e);
     }
@@ -602,35 +600,35 @@ const ReactDataGrid = createReactClass({
       let cellKey = this.getColumn(e.idx).key;
       this.onGridRowsUpdated(cellKey, e.rowIdx, this.props.rowsCount - 1, {[cellKey]: e.rowData[cellKey]}, AppConstants.UpdateActions.COLUMN_FILL);
     }
-  },
+  };
 
-  onCellExpand(args) {
+  onCellExpand = (args) => {
     if (this.props.onCellExpand) {
       this.props.onCellExpand(args);
     }
-  },
+  };
 
-  onRowExpandToggle(args) {
+  onRowExpandToggle = (args) => {
     if (typeof this.props.onRowExpandToggle === 'function') {
       this.props.onRowExpandToggle(args);
     }
-  },
+  };
 
-  isCellWithinBounds({idx, rowIdx}) {
+  isCellWithinBounds = ({idx, rowIdx}) => {
     return idx >= 0
       && rowIdx >= 0
       && idx < ColumnUtils.getSize(this.state.columnMetrics.columns)
       && rowIdx < this.props.rowsCount;
-  },
+  };
 
-  handleDragStart(dragged: DraggedType) {
+  handleDragStart = (dragged: DraggedType) => {
     if (!this.dragEnabled()) { return; }
     if (this.isCellWithinBounds(dragged)) {
       this.setState({ dragged: dragged });
     }
-  },
+  };
 
-  handleDragEnd() {
+  handleDragEnd = () => {
     if (!this.dragEnabled()) { return; }
     const { selected, dragged } = this.state;
     const column = this.getColumn(this.state.selected.idx);
@@ -646,21 +644,21 @@ const ReactDataGrid = createReactClass({
       }
     }
     this.setState({dragged: {complete: true}});
-  },
+  };
 
-  handleDragEnter(row: any) {
+  handleDragEnter = (row: any) => {
     if (!this.dragEnabled() || this.state.dragged == null) { return; }
     let dragged = this.state.dragged;
     dragged.overRowIdx = row;
     this.setState({dragged: dragged});
-  },
+  };
 
-  handleTerminateDrag() {
+  handleTerminateDrag = () => {
     if (!this.dragEnabled()) { return; }
     this.setState({ dragged: null });
-  },
+  };
 
-  handlePaste() {
+  handlePaste = () => {
     if (!this.copyPasteEnabled() || !(this.state.copied)) { return; }
     let selected = this.state.selected;
     let cellKey = this.getColumn(this.state.selected.idx).key;
@@ -675,27 +673,27 @@ const ReactDataGrid = createReactClass({
     if (this.props.onGridRowsUpdated) {
       this.onGridRowsUpdated(cellKey, toRow, toRow, {[cellKey]: textToCopy}, AppConstants.UpdateActions.COPY_PASTE, fromRow);
     }
-  },
+  };
 
-  handleCancelCopy() {
+  handleCancelCopy = () => {
     this.setState({copied: null});
-  },
+  };
 
-  handleCopy(args: {value: string}) {
+  handleCopy = (args: {value: string}) => {
     if (!this.copyPasteEnabled()) { return; }
     let textToCopy = args.value;
     let selected = this.state.selected;
     let copied = {idx: selected.idx, rowIdx: selected.rowIdx};
     this.setState({textToCopy: textToCopy, copied: copied});
-  },
+  };
 
-  handleSort: function(columnKey: string, direction: SortType) {
+  handleSort = (columnKey: string, direction: SortType) => {
     this.setState({sortDirection: direction, sortColumn: columnKey}, function() {
       this.props.onGridSort(columnKey, direction);
     });
-  },
+  };
 
-  getSelectedRow(rows, key) {
+  getSelectedRow = (rows, key) => {
     let selectedRow = rows.filter(r => {
       if (r[this.props.rowKey] === key) {
         return true;
@@ -705,14 +703,14 @@ const ReactDataGrid = createReactClass({
     if (selectedRow.length > 0) {
       return selectedRow[0];
     }
-  },
+  };
 
-  useNewRowSelection() {
+  useNewRowSelection = () => {
     return this.props.rowSelection && this.props.rowSelection.selectBy;
-  },
+  };
 
   // return false if not a shift select so can be handled as normal row selection
-  handleShiftSelect(rowIdx) {
+  handleShiftSelect = (rowIdx) => {
     if (this.state.lastRowIdxUiSelected > -1 && this.isSingleKeyDown(KeyCodes.Shift)) {
       let {keys, indexes, isSelectedKey} = this.props.rowSelection.selectBy;
       let isPreviouslySelected = RowUtils.isRowSelected(keys, indexes, isSelectedKey, this.props.rowGetter(rowIdx), rowIdx);
@@ -755,9 +753,9 @@ const ReactDataGrid = createReactClass({
     }
 
     return false;
-  },
+  };
 
-  handleNewRowSelect(rowIdx, rowData) {
+  handleNewRowSelect = (rowIdx, rowData) => {
     if (this.selectAllCheckbox && this.selectAllCheckbox.checked === true) {
       this.selectAllCheckbox.checked = false;
     }
@@ -772,11 +770,11 @@ const ReactDataGrid = createReactClass({
     } else if (!isPreviouslySelected && typeof this.props.rowSelection.onRowsSelected === 'function') {
       this.props.rowSelection.onRowsSelected([{rowIdx, row: rowData}]);
     }
-  },
+  };
 
   // columnKey not used here as this function will select the whole row,
   // but needed to match the function signature in the CheckboxEditor
-  handleRowSelect(rowIdx: number, columnKey: string, rowData, e: Event) {
+  handleRowSelect = (rowIdx: number, columnKey: string, rowData, e: Event) => {
     e.stopPropagation();
 
     if (this.useNewRowSelection()) {
@@ -801,9 +799,9 @@ const ReactDataGrid = createReactClass({
         this.props.onRowSelect(selectedRows.filter(r => r.isSelected === true));
       }
     }
-  },
+  };
 
-  handleCheckboxChange: function(e: SyntheticEvent) {
+  handleCheckboxChange = (e: SyntheticEvent) => {
     let allRowsSelected;
     if (e.currentTarget instanceof HTMLInputElement && e.currentTarget.checked === true) {
       allRowsSelected = true;
@@ -849,9 +847,9 @@ const ReactDataGrid = createReactClass({
         this.props.onRowSelect(selectedRows.filter(r => r.isSelected === true));
       }
     }
-  },
+  };
 
-  getScrollOffSet() {
+  getScrollOffSet = () => {
     let scrollOffset = 0;
     if (this.grid) {
       let canvas = this.grid.querySelector('.react-grid-Canvas');
@@ -860,15 +858,15 @@ const ReactDataGrid = createReactClass({
       }
     }
     this.setState({scrollOffset: scrollOffset});
-  },
+  };
 
-  getRowOffsetHeight(): number {
+  getRowOffsetHeight = (): number => {
     let offsetHeight = 0;
     this.getHeaderRows().forEach((row) => offsetHeight += parseFloat(row.height, 10) );
     return offsetHeight;
-  },
+  };
 
-  getHeaderRows(): Array<{ref: Function; height: number;}> {
+  getHeaderRows = (): Array<{ref: Function; height: number;}> => {
     let rows = [{ ref: (node) => this.row = node, height: this.props.headerRowHeight || this.props.rowHeight, rowType: 'header' }];
     if (this.state.canFilter === true) {
       rows.push({
@@ -880,40 +878,41 @@ const ReactDataGrid = createReactClass({
       });
     }
     return rows;
-  },
+  };
 
-  getInitialSelectedRows: function() {
+  getInitialSelectedRows = () => {
     let selectedRows = [];
     for (let i = 0; i < this.props.rowsCount; i++) {
       selectedRows.push(false);
     }
     return selectedRows;
-  },
+  };
 
-  getRowSelectionProps() {
+  getRowSelectionProps = () => {
     if (this.props.rowSelection) {
       return this.props.rowSelection.selectBy;
     }
 
     return null;
-  },
+  };
 
-  getSelectedRows() {
+  getSelectedRows = () => {
     if (this.props.rowSelection) {
       return null;
     }
 
     return this.state.selectedRows.filter(r => r.isSelected === true);
-  },
+  };
 
-  getSelectedValue(): string {
+  getSelectedValue = (): string => {
     let rowIdx = this.state.selected.rowIdx;
     let idx = this.state.selected.idx;
     let cellKey = this.getColumn(idx).key;
     let row = this.props.rowGetter(rowIdx);
     return RowUtils.get(row, cellKey);
-  },
-  canExitGrid(e: SyntheticEvent): boolean {
+  };
+
+  canExitGrid = (e: SyntheticEvent): boolean => {
     // When the cellNavigationMode is 'none', you can exit the grid if you're at the start or end of the row
     // When the cellNavigationMode is 'changeRow', you can exit the grid if you're at the first or last cell of the grid
     // When the cellNavigationMode is 'loopOverRow', there is no logical exit point so you can't exit the grid
@@ -945,9 +944,9 @@ const ReactDataGrid = createReactClass({
       }
     }
     return false;
-  },
+  };
 
-  moveSelectedCell(e: SyntheticEvent, rowDelta: number, cellDelta: number) {
+  moveSelectedCell = (e: SyntheticEvent, rowDelta: number, cellDelta: number) => {
     // we need to prevent default as we control grid scroll
     // otherwise it moves every time you left/right which is janky
     e.preventDefault();
@@ -962,18 +961,18 @@ const ReactDataGrid = createReactClass({
     }
     this.scrollToColumn(idx);
     this.onSelect({ idx: idx, rowIdx: rowIdx });
-  },
+  };
 
-  getNbrColumns() {
+  getNbrColumns = () => {
     const {columns, enableRowSelect} = this.props;
     return enableRowSelect ? columns.length + 1 : columns.length;
-  },
+  };
 
-  getDataGridDOMNode() {
+  getDataGridDOMNode = () => {
     return this.grid;
-  },
+  };
 
-  calculateNextSelectionPosition(cellNavigationMode: string, cellDelta: number, rowDelta: number) {
+  calculateNextSelectionPosition = (cellNavigationMode: string, cellDelta: number, rowDelta: number) => {
     let _rowDelta = rowDelta;
     let idx = this.state.selected.idx + cellDelta;
     const nbrColumns = this.getNbrColumns();
@@ -998,25 +997,25 @@ const ReactDataGrid = createReactClass({
     }
     let rowIdx = this.state.selected.rowIdx + _rowDelta;
     return {idx, rowIdx};
-  },
+  };
 
-  isAtLastCellInRow(nbrColumns) {
+  isAtLastCellInRow = (nbrColumns) => {
     return this.state.selected.idx === nbrColumns - 1;
-  },
+  };
 
-  isAtLastRow() {
+  isAtLastRow = () => {
     return this.state.selected.rowIdx === this.props.rowsCount - 1;
-  },
+  };
 
-  isAtFirstCellInRow() {
+  isAtFirstCellInRow = () => {
     return this.state.selected.idx === 0;
-  },
+  };
 
-  isAtFirstRow() {
+  isAtFirstRow = () => {
     return this.state.selected.rowIdx === 0;
-  },
+  };
 
-  openCellEditor(rowIdx, idx) {
+  openCellEditor = (rowIdx, idx) => {
     let row = this.props.rowGetter(rowIdx);
     let col = this.getColumn(idx);
 
@@ -1032,9 +1031,9 @@ const ReactDataGrid = createReactClass({
     } else {
       this.setActive('Enter');
     }
-  },
+  };
 
-  scrollToColumn(colIdx) {
+  scrollToColumn = (colIdx) => {
     if (this.grid) {
       let canvas = this.grid.querySelector('.react-grid-Canvas');
       if (canvas) {
@@ -1067,14 +1066,14 @@ const ReactDataGrid = createReactClass({
         }
       }
     }
-  },
+  };
 
-  deselect() {
+  deselect = () => {
     const selected = {rowIdx: -1, idx: -1};
     this.setState({selected});
-  },
+  };
 
-  setActive(keyPressed: string) {
+  setActive = (keyPressed: string) => {
     let rowIdx = this.state.selected.rowIdx;
     let row = this.props.rowGetter(rowIdx);
 
@@ -1098,9 +1097,9 @@ const ReactDataGrid = createReactClass({
         this.handleCancelCopy();
       }
     }
-  },
+  };
 
-  setInactive() {
+  setInactive = () => {
     let rowIdx = this.state.selected.rowIdx;
     let row = this.props.rowGetter(rowIdx);
 
@@ -1111,13 +1110,13 @@ const ReactDataGrid = createReactClass({
       let selected = Object.assign({}, this.state.selected, {idx: idx, rowIdx: rowIdx, active: false});
       this.setState({selected: selected});
     }
-  },
+  };
 
-  isActive(): boolean {
+  isActive = (): boolean => {
     return this.state.selected.active === true;
-  },
+  };
 
-  setupGridColumns: function(props = this.props): Array<any> {
+  setupGridColumns = (props = this.props): Array<any> => {
     const { columns } = props;
     if (this._cachedColumns === columns) {
       return this._cachedComputedColumns;
@@ -1150,17 +1149,17 @@ const ReactDataGrid = createReactClass({
     this._cachedComputedColumns = cols;
 
     return this._cachedComputedColumns;
-  },
+  };
 
-  copyPasteEnabled: function(): boolean {
+  copyPasteEnabled = (): boolean => {
     return this.props.onCellCopyPaste !== null;
-  },
+  };
 
-  dragEnabled: function(): boolean {
+  dragEnabled = (): boolean => {
     return this.props.onGridRowsUpdated !== undefined || this.props.onCellsDragged !== undefined;
-  },
+  };
 
-  renderToolbar(): ReactElement {
+  renderToolbar = (): ReactElement => {
     let Toolbar = this.props.toolbar;
     let toolBarProps =  {columns: this.props.columns, onToggleFilter: this.onToggleFilter, numberOfRows: this.props.rowsCount};
     if (React.isValidElement(Toolbar)) {
@@ -1168,7 +1167,7 @@ const ReactDataGrid = createReactClass({
     } else if (isFunction(Toolbar)) {
       return <Toolbar {...toolBarProps}/>;
     }
-  },
+  };
 
   render() {
     let cellMetaData = {
@@ -1252,7 +1251,7 @@ const ReactDataGrid = createReactClass({
         </div>
       );
   }
-});
+}
 
 
 module.exports = ReactDataGrid;

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -1,8 +1,6 @@
 const React                 = require('react');
 import PropTypes from 'prop-types';
 const BaseGrid              = require('./Grid');
-const Row                   = require('./Row');
-const ExcelColumn           = require('./PropTypeShapes/ExcelColumn');
 const CheckboxEditor        = require('./editors/CheckboxEditor');
 const RowUtils = require('./RowUtils');
 const ColumnUtils = require('./ColumnUtils');
@@ -120,7 +118,10 @@ class ReactDataGrid extends React.Component {
     onAddSubRow: PropTypes.func,
     enableCellAutoFocus: PropTypes.bool,
     onBeforeEdit: PropTypes.func,
-    selectAllRenderer: PropTypes.object
+    selectAllRenderer: PropTypes.object,
+    minColumnWidth: PropTypes.number,
+    columnEquality: PropTypes.func,
+    onColumnResize: PropTypes.func
   };
 
   static defaultProps = {

--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -2,7 +2,6 @@ import OverflowCell from './OverflowCell';
 import rowComparer from './RowComparer';
 const React = require('react');
 import PropTypes from 'prop-types';
-const createReactClass = require('create-react-class');
 const joinClasses = require('classnames');
 const Cell = require('./Cell');
 const columnUtils = require('./ColumnUtils');
@@ -19,10 +18,10 @@ class CellExpander extends React.Component {
 // The list of the propTypes that we want to include in the Row div
 const knownDivPropertyKeys = ['height'];
 
-const Row = createReactClass({
-  displayName: 'Row',
+class Row extends React.Component {
+  static displayName = 'Row';
 
-  propTypes: {
+  static propTypes = {
     height: PropTypes.number.isRequired,
     columns: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
     row: PropTypes.any.isRequired,
@@ -40,45 +39,43 @@ const Row = createReactClass({
     colDisplayStart: PropTypes.number.isRequired,
     colDisplayEnd: PropTypes.number.isRequired,
     isScrolling: PropTypes.bool.isRequired
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      cellRenderer: Cell,
-      isSelected: false,
-      height: 35
-    };
-  },
+  static defaultProps = {
+    cellRenderer: Cell,
+    isSelected: false,
+    height: 35
+  };
 
   shouldComponentUpdate(nextProps) {
     return rowComparer(nextProps, this.props);
-  },
+  }
 
-  handleDragEnter() {
+  handleDragEnter = () => {
     let handleDragEnterRow = this.props.cellMetaData.handleDragEnterRow;
     if (handleDragEnterRow) {
       handleDragEnterRow(this.props.idx);
     }
-  },
+  };
 
-  getSelectedColumn() {
+  getSelectedColumn = () => {
     if (this.props.cellMetaData) {
       let selected = this.props.cellMetaData.selected;
       if (selected && selected.idx) {
         return columnUtils.getColumn(this.props.columns, selected.idx);
       }
     }
-  },
+  };
 
-  getCellRenderer(columnKey) {
+  getCellRenderer = (columnKey) => {
     let CellRenderer = this.props.cellRenderer;
     if (this.props.subRowDetails && this.props.subRowDetails.field === columnKey) {
       return CellExpander;
     }
     return CellRenderer;
-  },
+  };
 
-  getCell(column, i, selectedColumn) {
+  getCell = (column, i, selectedColumn) => {
     let CellRenderer = this.props.cellRenderer;
     const { colVisibleStart, colVisibleEnd, idx, cellMetaData } = this.props;
     const { key, formatter, locked } = column;
@@ -101,9 +98,9 @@ const Row = createReactClass({
     };
 
     return <CellRenderer {...baseCellProps} {...cellProps} />;
-  },
+  };
 
-  getCells() {
+  getCells = () => {
     let cells = [];
     let lockedCells = [];
     let selectedColumn = this.getSelectedColumn();
@@ -123,9 +120,9 @@ const Row = createReactClass({
     }
 
     return cells.concat(lockedCells);
-  },
+  };
 
-  getRowHeight() {
+  getRowHeight = () => {
     let rows = this.props.expandedRows || null;
     if (rows && this.props.idx) {
       let row = rows[this.props.idx] || null;
@@ -134,9 +131,9 @@ const Row = createReactClass({
       }
     }
     return this.props.height;
-  },
+  };
 
-  getCellValue(key) {
+  getCellValue = (key) => {
     let val;
     if (key === 'select-row') {
       return this.props.isSelected;
@@ -146,9 +143,9 @@ const Row = createReactClass({
       val = this.props.row[key];
     }
     return val;
-  },
+  };
 
-  isContextMenuDisplayed() {
+  isContextMenuDisplayed = () => {
     if (this.props.cellMetaData) {
       let selected = this.props.cellMetaData.selected;
       if (selected && selected.contextMenuDisplayed && selected.rowIdx === this.props.idx) {
@@ -156,30 +153,30 @@ const Row = createReactClass({
       }
     }
     return false;
-  },
+  };
 
-  getExpandableOptions(columnKey) {
+  getExpandableOptions = (columnKey) => {
     let subRowDetails = this.props.subRowDetails;
     if (subRowDetails) {
       return { canExpand: subRowDetails && subRowDetails.field === columnKey && ((subRowDetails.children && subRowDetails.children.length > 0) || subRowDetails.group === true), field: subRowDetails.field, expanded: subRowDetails && subRowDetails.expanded, children: subRowDetails && subRowDetails.children, treeDepth: subRowDetails ? subRowDetails.treeDepth : 0, subRowDetails: subRowDetails };
     }
     return {};
-  },
+  };
 
-  setScrollLeft(scrollLeft) {
+  setScrollLeft = (scrollLeft) => {
     this.props.columns.forEach((column) => {
       if (column.locked) {
         if (!this[column.key]) return;
         this[column.key].setScrollLeft(scrollLeft);
       }
     });
-  },
+  };
 
-  getKnownDivProps() {
+  getKnownDivProps = () => {
     return createObjectWithProperties(this.props, knownDivPropertyKeys);
-  },
+  };
 
-  renderCell(props) {
+  renderCell = (props) => {
     if (typeof this.props.cellRenderer === 'function') {
       this.props.cellRenderer.call(this, props);
     }
@@ -188,7 +185,7 @@ const Row = createReactClass({
     }
 
     return this.props.cellRenderer(props);
-  },
+  };
 
   render() {
     let className = joinClasses(
@@ -217,6 +214,6 @@ const Row = createReactClass({
       </div >
     );
   }
-});
+}
 
 module.exports = Row;

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -1,5 +1,4 @@
 const React                = require('react');
-const createReactClass = require('create-react-class');
 const Canvas               = require('./Canvas');
 const cellMetaDataShape    = require('./PropTypeShapes/CellMetaDataShape');
 import PropTypes from 'prop-types';
@@ -9,10 +8,10 @@ import {
   getNextScrollState
 } from './utils/viewportUtils';
 
-const Viewport = createReactClass({
-  displayName: 'Viewport',
+class Viewport extends React.Component {
+  static displayName = 'Viewport';
 
-  propTypes: {
+  static propTypes = {
     rowOffsetHeight: PropTypes.number.isRequired,
     totalWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     columnMetrics: PropTypes.object.isRequired,
@@ -46,9 +45,15 @@ const Viewport = createReactClass({
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
     rowGroupRenderer: PropTypes.func
-  },
+  };
 
-  onScroll(scroll: {scrollTop: number; scrollLeft: number}) {
+  static defaultProps = {
+    rowHeight: 30
+  };
+
+  state = getGridState(this.props);
+
+  onScroll = (scroll: {scrollTop: number; scrollLeft: number}) => {
     this.updateScroll(
       scroll.scrollTop, scroll.scrollLeft,
       this.state.height,
@@ -59,59 +64,56 @@ const Viewport = createReactClass({
     if (this.props.onScroll) {
       this.props.onScroll({scrollTop: scroll.scrollTop, scrollLeft: scroll.scrollLeft});
     }
-  },
+  };
 
-  getScroll(): {scrollLeft: number; scrollTop: number} {
+  getScroll = (): {scrollLeft: number; scrollTop: number} => {
     return this.canvas.getScroll();
-  },
+  };
 
-  setScrollLeft(scrollLeft: number) {
+  setScrollLeft = (scrollLeft: number) => {
     this.canvas.setScrollLeft(scrollLeft);
-  },
+  };
 
-  getDefaultProps(): { rowHeight: number } {
-    return {
-      rowHeight: 30
-    };
-  },
-
-  getInitialState() {
-    return getGridState(this.props);
-  },
-
-  getDOMNodeOffsetWidth() {
+  getDOMNodeOffsetWidth = () => {
     return this.viewport ? this.viewport.offsetWidth : 0;
-  },
+  };
 
-  clearScrollTimer() {
+  clearScrollTimer = () => {
     if (this.resetScrollStateTimeoutId) {
       clearTimeout(this.resetScrollStateTimeoutId);
     }
-  },
+  };
 
-  resetScrollStateAfterDelay() {
+  resetScrollStateAfterDelay = () => {
     this.clearScrollTimer();
     this.resetScrollStateTimeoutId = setTimeout(
       this.resetScrollStateAfterDelayCallback,
       500
     );
-  },
+  };
 
-  resetScrollStateAfterDelayCallback() {
+  resetScrollStateAfterDelayCallback = () => {
     this.resetScrollStateTimeoutId = null;
     this.setState({
       isScrolling: false
     });
-  },
+  };
 
-  updateScroll(scrollTop: number, scrollLeft: number, height: number, rowHeight: number, length: number, width) {
+  updateScroll = (
+    scrollTop: number,
+    scrollLeft: number,
+    height: number,
+    rowHeight: number,
+    length: number,
+    width,
+  ) => {
     this.resetScrollStateAfterDelay();
     const nextScrollState = getNextScrollState(this.props, this.getDOMNodeOffsetWidth, scrollTop, scrollLeft, height, rowHeight, length, width);
 
     this.setState(nextScrollState);
-  },
+  };
 
-  metricsUpdated() {
+  metricsUpdated = () => {
     let height = this.viewportHeight();
     let width = this.viewportWidth();
     if (height) {
@@ -124,17 +126,19 @@ const Viewport = createReactClass({
         width
       );
     }
-  },
+  };
 
-  viewportHeight(): number {
+  viewportHeight = (): number => {
     return this.viewport ? this.viewport.offsetHeight : 0;
-  },
+  };
 
-  viewportWidth(): number {
+  viewportWidth = (): number => {
     return this.viewport ? this.viewport.offsetWidth : 0;
-  },
+  };
 
-  componentWillReceiveProps(nextProps: { rowHeight: number; rowsCount: number, rowOffsetHeight: number }) {
+  componentWillReceiveProps(
+    nextProps: { rowHeight: number; rowsCount: number, rowOffsetHeight: number },
+  ) {
     if (this.props.rowHeight !== nextProps.rowHeight ||
       this.props.minHeight !== nextProps.minHeight) {
       const newState = getGridState(nextProps);
@@ -168,7 +172,7 @@ const Viewport = createReactClass({
         nextProps.rowsCount
       );
     }
-  },
+  }
 
   componentDidMount() {
     if (window.addEventListener) {
@@ -177,12 +181,12 @@ const Viewport = createReactClass({
       window.attachEvent('resize', this.metricsUpdated);
     }
     this.metricsUpdated();
-  },
+  }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.metricsUpdated);
     this.clearScrollTimer();
-  },
+  }
 
   render() {
     let style = {
@@ -234,6 +238,6 @@ const Viewport = createReactClass({
       </div>
     );
   }
-});
+}
 
 module.exports = Viewport;

--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -24,7 +24,8 @@ class EditorContainer extends React.Component {
       onCommit: PropTypes.func
     }).isRequired,
     column: PropTypes.object.isRequired,
-    height: PropTypes.number.isRequired
+    height: PropTypes.number.isRequired,
+    onGridKeyDown: PropTypes.func
   };
 
   state = {isInvalid: false};

--- a/packages/react-data-grid/src/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/editors/EditorContainer.js
@@ -1,6 +1,5 @@
 const React                   = require('react');
 import PropTypes from 'prop-types';
-const createReactClass = require('create-react-class');
 const joinClasses              = require('classnames');
 const SimpleTextEditor        = require('./SimpleTextEditor');
 const isFunction              = require('../utils/isFunction');
@@ -8,10 +7,10 @@ import { isKeyPrintable, isCtrlKeyHeldDown } from '../utils/keyboardUtils';
 
 require('../../../../themes/react-data-grid-core.css');
 
-const EditorContainer = createReactClass({
-  displayName: 'EditorContainer',
+class EditorContainer extends React.Component {
+  static displayName = 'EditorContainer';
 
-  propTypes: {
+  static propTypes = {
     rowIdx: PropTypes.number,
     rowData: PropTypes.object.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object, PropTypes.bool]).isRequired,
@@ -26,16 +25,13 @@ const EditorContainer = createReactClass({
     }).isRequired,
     column: PropTypes.object.isRequired,
     height: PropTypes.number.isRequired
-  },
+  };
 
-  changeCommitted: false,
-  changeCanceled: false,
+  state = {isInvalid: false};
+  changeCommitted = false;
+  changeCanceled = false;
 
-  getInitialState() {
-    return {isInvalid: false};
-  },
-
-  componentDidMount: function() {
+  componentDidMount() {
     let inputNode = this.getInputNode();
     if (inputNode !== undefined) {
       this.setTextInputFocus();
@@ -44,25 +40,25 @@ const EditorContainer = createReactClass({
         inputNode.style.height = this.props.height - 1 + 'px';
       }
     }
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     if (!this.changeCommitted && !this.changeCanceled) {
       this.commit({key: 'Enter'});
     }
-  },
+  }
 
-  isKeyExplicitlyHandled(key: string): boolean {
+  isKeyExplicitlyHandled = (key: string): boolean => {
     return isFunction(this['onPress' + key]);
-  },
+  };
 
-  checkAndCall(methodName: string, args: any) {
+  checkAndCall = (methodName: string, args: any) => {
     if (isFunction(this[methodName])) {
       this[methodName](args);
     }
-  },
+  };
 
-  onKeyDown: function(e: SyntheticKeyboardEvent) {
+  onKeyDown = (e: SyntheticKeyboardEvent) => {
     if (isCtrlKeyHeldDown(e)) {
       this.checkAndCall('onPressKeyWithCtrl', e);
     } else if (this.isKeyExplicitlyHandled(e.key)) {
@@ -79,9 +75,9 @@ const EditorContainer = createReactClass({
     if (isFunction(this.props.onGridKeyDown)) {
       this.props.onGridKeyDown(e);
     }
-  },
+  };
 
-  createEditor(): ReactElement {
+  createEditor = (): ReactElement => {
     let editorRef = (c) => this.editor = c;
     let editorProps = {
       ref: editorRef,
@@ -106,94 +102,94 @@ const EditorContainer = createReactClass({
     }
 
     return <SimpleTextEditor ref={editorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;
-  },
+  };
 
-  onPressEnter() {
+  onPressEnter = () => {
     this.commit({key: 'Enter'});
-  },
+  };
 
-  onPressTab() {
+  onPressTab = () => {
     this.commit({key: 'Tab'});
-  },
+  };
 
-  onPressEscape(e: SyntheticKeyboardEvent) {
+  onPressEscape = (e: SyntheticKeyboardEvent) => {
     if (!this.editorIsSelectOpen()) {
       this.commitCancel();
     } else {
       // prevent event from bubbling if editor has results to select
       e.stopPropagation();
     }
-  },
+  };
 
-  onPressArrowDown(e: SyntheticKeyboardEvent) {
+  onPressArrowDown = (e: SyntheticKeyboardEvent) => {
     if (this.editorHasResults()) {
       // dont want to propogate as that then moves us round the grid
       e.stopPropagation();
     } else {
       this.commit(e);
     }
-  },
+  };
 
-  onPressArrowUp(e: SyntheticKeyboardEvent) {
+  onPressArrowUp = (e: SyntheticKeyboardEvent) => {
     if (this.editorHasResults()) {
       // dont want to propogate as that then moves us round the grid
       e.stopPropagation();
     } else {
       this.commit(e);
     }
-  },
+  };
 
-  onPressArrowLeft(e: SyntheticKeyboardEvent) {
+  onPressArrowLeft = (e: SyntheticKeyboardEvent) => {
     // prevent event propogation. this disables left cell navigation
     if (!this.isCaretAtBeginningOfInput()) {
       e.stopPropagation();
     } else {
       this.commit(e);
     }
-  },
+  };
 
-  onPressArrowRight(e: SyntheticKeyboardEvent) {
+  onPressArrowRight = (e: SyntheticKeyboardEvent) => {
     // prevent event propogation. this disables right cell navigation
     if (!this.isCaretAtEndOfInput()) {
       e.stopPropagation();
     } else {
       this.commit(e);
     }
-  },
+  };
 
-  editorHasResults(): boolean {
+  editorHasResults = (): boolean => {
     if (isFunction(this.getEditor().hasResults)) {
       return this.getEditor().hasResults();
     }
 
     return false;
-  },
+  };
 
-  editorIsSelectOpen() {
+  editorIsSelectOpen = () => {
     if (isFunction(this.getEditor().isSelectOpen)) {
       return this.getEditor().isSelectOpen();
     }
 
     return false;
-  },
+  };
 
-  getRowMetaData(): any {
+  getRowMetaData = (): any => {
     // clone row data so editor cannot actually change this
     // convention based method to get corresponding Id or Name of any Name or Id property
     if (typeof this.props.column.getRowMetaData === 'function') {
       return this.props.column.getRowMetaData(this.props.rowData, this.props.column);
     }
-  },
+  };
 
-  getEditor(): Editor {
+  getEditor = (): Editor => {
     return this.editor;
-  },
+  };
 
-  getInputNode(): HTMLInputElement {
+  getInputNode = (): HTMLInputElement => {
     return this.getEditor().getInputNode();
-  },
+  };
 
-  getInitialValue(): string {
+  getInitialValue = (): string => {
     let selected = this.props.cellMetaData.selected;
     let keyCode = selected.initialKeyCode;
     if (keyCode === 'Delete' || keyCode === 'Backspace') {
@@ -204,15 +200,15 @@ const EditorContainer = createReactClass({
 
     let text = keyCode ? String.fromCharCode(keyCode) : this.props.value;
     return text;
-  },
+  };
 
-  getContainerClass() {
+  getContainerClass = () => {
     return joinClasses({
       'has-error': this.state.isInvalid === true
     });
-  },
+  };
 
-  commit(args: {key : string}) {
+  commit = (args: {key : string}) => {
     let opts = args || {};
     let updated = this.getEditor().getValue();
     if (this.isNewValueValid(updated)) {
@@ -220,14 +216,14 @@ const EditorContainer = createReactClass({
       let cellKey = this.props.column.key;
       this.props.cellMetaData.onCommit({cellKey: cellKey, rowIdx: this.props.rowIdx, updated: updated, key: opts.key});
     }
-  },
+  };
 
-  commitCancel() {
+  commitCancel = () => {
     this.changeCanceled = true;
     this.props.cellMetaData.onCommitCancel();
-  },
+  };
 
-  isNewValueValid(value: string): boolean {
+  isNewValueValid = (value: string): boolean => {
     if (isFunction(this.getEditor().validate)) {
       let isValid = this.getEditor().validate(value);
       this.setState({isInvalid: !isValid});
@@ -235,9 +231,9 @@ const EditorContainer = createReactClass({
     }
 
     return true;
-  },
+  };
 
-  setCaretAtEndOfInput() {
+  setCaretAtEndOfInput = () => {
     let input = this.getInputNode();
     // taken from http://stackoverflow.com/questions/511088/use-javascript-to-place-cursor-at-end-of-text-in-text-input-element
     let txtLength = input.value.length;
@@ -249,45 +245,45 @@ const EditorContainer = createReactClass({
       fieldRange.collapse();
       fieldRange.select();
     }
-  },
+  };
 
-  isCaretAtBeginningOfInput(): boolean {
+  isCaretAtBeginningOfInput = (): boolean => {
     let inputNode = this.getInputNode();
     return inputNode.selectionStart === inputNode.selectionEnd
       && inputNode.selectionStart === 0;
-  },
+  };
 
-  isCaretAtEndOfInput(): boolean {
+  isCaretAtEndOfInput = (): boolean => {
     let inputNode = this.getInputNode();
     return inputNode.selectionStart === inputNode.value.length;
-  },
+  };
 
-  isBodyClicked(e) {
+  isBodyClicked = (e) => {
     let relatedTarget = this.getRelatedTarget(e);
     return (relatedTarget === null);
-  },
+  };
 
-  isViewportClicked(e) {
+  isViewportClicked = (e) => {
     let relatedTarget = this.getRelatedTarget(e);
     return (relatedTarget.className.indexOf('react-grid-Viewport') > -1);
-  },
+  };
 
-  isClickInsideEditor(e) {
+  isClickInsideEditor = (e) => {
     let relatedTarget = this.getRelatedTarget(e);
     return (e.currentTarget.contains(relatedTarget) || (relatedTarget.className.indexOf('editing') > -1 || relatedTarget.className.indexOf('react-grid-Cell') > -1));
-  },
+  };
 
-  getRelatedTarget(e) {
+  getRelatedTarget = (e) => {
     return e.relatedTarget ||
             e.explicitOriginalTarget ||
             document.activeElement; // IE11
-  },
+  };
 
-  handleRightClick(e) {
+  handleRightClick = (e) => {
     e.stopPropagation();
-  },
+  };
 
-  handleBlur(e) {
+  handleBlur = (e) => {
     e.stopPropagation();
     if (this.isBodyClicked(e)) {
       this.commit(e);
@@ -299,9 +295,9 @@ const EditorContainer = createReactClass({
         this.commit(e);
       }
     }
-  },
+  };
 
-  setTextInputFocus() {
+  setTextInputFocus = () => {
     let selected = this.props.cellMetaData.selected;
     let keyCode = selected.initialKeyCode;
     let inputNode = this.getInputNode();
@@ -314,13 +310,13 @@ const EditorContainer = createReactClass({
         inputNode.select();
       }
     }
-  },
+  };
 
-  renderStatusIcon(): ?ReactElement {
+  renderStatusIcon = (): ?ReactElement => {
     if (this.state.isInvalid === true) {
       return <span className="glyphicon glyphicon-remove form-control-feedback"></span>;
     }
-  },
+  };
 
   render(): ?ReactElement {
     return (
@@ -330,6 +326,6 @@ const EditorContainer = createReactClass({
         </div>
       );
   }
-});
+}
 
 module.exports = EditorContainer;

--- a/webpack-dev-server.js
+++ b/webpack-dev-server.js
@@ -19,7 +19,6 @@ const specificConfig =  {
     react: 'React',
     'react/addons': 'React',
     'react-dom': 'ReactDOM',
-    'create-react-class': 'createReactClass',
     faker: 'faker',
     moment: 'moment'
   },


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
`createReactClass` module is used for components that could not be migrated to ES6 classes due to `mixins`. #1078 has removed `mixins` and the remaining components can be migrated now

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
