### PR TITLE
Fix tooltips in fixed columns being hidden behind other cells

### DIFF
--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -37,8 +37,8 @@
 }
 
 .react-grid-Cell:not(.editing):not(.rdg-child-cell) .react-grid-Cell__value {
-  position: relative;		
-  top: 50%;		
+  position: relative;
+  top: 50%;
   transform: translateY(-50%);
 }
 
@@ -142,6 +142,10 @@
 .cell-tooltip {
     position: relative;
     display: inline-block;
+}
+
+.cell-tooltip:hover {
+  z-index: 101;
 }
 
 .cell-tooltip .cell-tooltip-text {


### PR DESCRIPTION
## Description
Tooltips were being hidden behind cells when they are in a frozen column.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```