### PR TITLE
Fix including the "from row" as an updated row during cell drag

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -536,15 +536,19 @@ class ReactDataGrid extends React.Component {
   };
 
   onGridRowsUpdated = (cellKey, fromRow, toRow, updated, action, originRow) => {
-    let rowIds = [];
+    const fromRowData = this.props.rowGetter(action === AppConstants.UpdateActions.COPY_PASTE ? originRow : fromRow);
+    const fromRowId = fromRowData[this.props.rowKey];
+    const toRowId = this.props.rowGetter(toRow)[this.props.rowKey];
 
-    for (let i = fromRow; i <= toRow; i++) {
-      rowIds.push(this.props.rowGetter(i)[this.props.rowKey]);
+    let rowIds = [];
+    if (fromRow === toRow) {
+      rowIds.push(toRowId);
+    } else {
+      for (let i = fromRow + 1; i <= toRow; i++) {
+        rowIds.push(this.props.rowGetter(i)[this.props.rowKey]);
+      }
     }
 
-    let fromRowData = this.props.rowGetter(action === 'COPY_PASTE' ? originRow : fromRow);
-    let fromRowId = fromRowData[this.props.rowKey];
-    let toRowId = this.props.rowGetter(toRow)[this.props.rowKey];
     this.props.onGridRowsUpdated({cellKey, fromRow, toRow, fromRowId, toRowId, rowIds, updated, action, fromRowData});
   };
 

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -535,40 +535,32 @@ class ReactDataGrid extends React.Component {
     }
   };
 
-  onGridRowsUpdated = (cellKey, fromRow, toRow, updated, action, originRow) => {
-    const fromRowData = this.props.rowGetter(action === AppConstants.UpdateActions.COPY_PASTE ? originRow : fromRow);
-    const fromRowId = fromRowData[this.props.rowKey];
-    const toRowId = this.props.rowGetter(toRow)[this.props.rowKey];
+  onGridRowsUpdated = (cellKey, fromRowIdx, toRowIdx, updated, action, originRowIdx) => {
+    const { rowGetter, rowKey } = this.props;
+    const fromRowData = rowGetter(action === AppConstants.UpdateActions.COPY_PASTE ? originRowIdx : fromRowIdx);
+    const fromRowId = fromRowData[rowKey];
+    const toRowId = rowGetter(toRowIdx)[rowKey];
 
     let rowIds = [];
-    if (fromRow === toRow) {
-      rowIds.push(toRowId);
-    } else {
-      for (let i = fromRow + 1; i <= toRow; i++) {
-        rowIds.push(this.props.rowGetter(i)[this.props.rowKey]);
-      }
+    for (let i = fromRowIdx + 1; i < toRowIdx; i++) {
+      rowIds.push(rowGetter(i)[this.props.rowKey]);
     }
+    rowIds.push(toRowId);
 
-    this.props.onGridRowsUpdated({cellKey, fromRow, toRow, fromRowId, toRowId, rowIds, updated, action, fromRowData});
+    this.props.onGridRowsUpdated({cellKey, fromRowIdx, toRowIdx, fromRowId, toRowId, rowIds, updated, action, fromRowData});
   };
 
   onCellCommit = (commit: RowUpdateEvent) => {
-    let selected = Object.assign({}, this.state.selected);
-    selected.active = false;
-    let expandedRows = this.state.expandedRows;
-    // if(commit.changed && commit.changed.expandedHeight){
-    //   expandedRows = this.expandRow(commit.rowIdx, commit.changed.expandedHeight);
-    // }
-    this.setState({selected: selected, expandedRows: expandedRows});
+    const selected = { ...this.state.selected, active: false };
+    this.setState({ selected });
 
     if (this.props.onRowUpdated) {
       this.props.onRowUpdated(commit);
     }
 
-    let targetRow = commit.rowIdx;
-
     if (this.props.onGridRowsUpdated) {
-      this.onGridRowsUpdated(commit.cellKey, targetRow, targetRow, commit.updated, AppConstants.UpdateActions.CELL_UPDATE);
+      const targetRowIdx = commit.rowIdx;
+      this.onGridRowsUpdated(commit.cellKey, targetRowIdx, targetRowIdx, commit.updated, AppConstants.UpdateActions.CELL_UPDATE);
     }
   };
 
@@ -606,7 +598,7 @@ class ReactDataGrid extends React.Component {
     }
 
     if (this.props.onGridRowsUpdated) {
-      let cellKey = this.getColumn(e.idx).key;
+      const cellKey = this.getColumn(e.idx).key;
       this.onGridRowsUpdated(cellKey, e.rowIdx, this.props.rowsCount - 1, {[cellKey]: e.rowData[cellKey]}, AppConstants.UpdateActions.COLUMN_FILL);
     }
   };
@@ -639,17 +631,19 @@ class ReactDataGrid extends React.Component {
 
   handleDragEnd = () => {
     if (!this.dragEnabled()) { return; }
+
     const { selected, dragged } = this.state;
-    const column = this.getColumn(this.state.selected.idx);
+    const column = this.getColumn(selected.idx);
     if (selected && dragged && column) {
-      let cellKey = column.key;
-      let fromRow = selected.rowIdx < dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
-      let toRow   = selected.rowIdx > dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
+      const cellKey = column.key;
+      const fromRowIdx = selected.rowIdx < dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
+      const toRowIdx   = selected.rowIdx > dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
       if (this.props.onCellsDragged) {
-        this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
+        this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRowIdx, toRow: toRowIdx, value: dragged.value});
       }
+
       if (this.props.onGridRowsUpdated) {
-        this.onGridRowsUpdated(cellKey, fromRow, toRow, {[cellKey]: dragged.value}, AppConstants.UpdateActions.CELL_DRAG);
+        this.onGridRowsUpdated(cellKey, fromRowIdx, toRowIdx, {[cellKey]: dragged.value}, AppConstants.UpdateActions.CELL_DRAG);
       }
     }
     this.setState({dragged: {complete: true}});
@@ -669,18 +663,18 @@ class ReactDataGrid extends React.Component {
 
   handlePaste = () => {
     if (!this.copyPasteEnabled() || !(this.state.copied)) { return; }
-    let selected = this.state.selected;
-    let cellKey = this.getColumn(this.state.selected.idx).key;
-    let textToCopy = this.state.textToCopy;
-    let fromRow = this.state.copied.rowIdx;
-    let toRow = selected.rowIdx;
+
+    const { selected, textToCopy, copied } = this.state;
+    const cellKey = this.getColumn(selected.idx).key;
+    const fromRowIdx = copied.rowIdx;
+    const toRowIdx = selected.rowIdx;
 
     if (this.props.onCellCopyPaste) {
-      this.props.onCellCopyPaste({cellKey: cellKey, rowIdx: toRow, value: textToCopy, fromRow: fromRow, toRow: toRow});
+      this.props.onCellCopyPaste({cellKey: cellKey, rowIdx: toRowIdx, value: textToCopy, fromRow: fromRowIdx, toRow: toRowIdx});
     }
 
     if (this.props.onGridRowsUpdated) {
-      this.onGridRowsUpdated(cellKey, toRow, toRow, {[cellKey]: textToCopy}, AppConstants.UpdateActions.COPY_PASTE, fromRow);
+      this.onGridRowsUpdated(cellKey, toRowIdx, toRowIdx, {[cellKey]: textToCopy}, AppConstants.UpdateActions.COPY_PASTE, fromRowIdx);
     }
   };
 

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -551,7 +551,7 @@ class ReactDataGrid extends React.Component {
   };
 
   onCellCommit = (commit: RowUpdateEvent) => {
-    const selected = { ...this.state.selected, active: false };
+    const selected = Object.assign({}, this.state.selected, { active: false });
     this.setState({ selected });
 
     if (this.props.onRowUpdated) {

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -3,14 +3,20 @@ import ReactDOM from 'react-dom';
 import ReactDataGrid from '../ReactDataGrid';
 import { shallow } from 'enzyme';
 import * as helpers from '../helpers/test/GridPropHelpers';
+import { UpdateActions } from '../AppConstants';
+
+const ROW_KEY = 'id';
 
 function shallowRenderGrid({
   enableCellAutoFocus = undefined,
   cellNavigationMode = undefined,
   numRows = helpers.rowsCount(),
-  onCellSelected, onCellDeSelected
+  onCellSelected,
+  onCellDeSelected,
+  onGridRowsUpdated
 }) {
   const enzymeWrapper = shallow(<ReactDataGrid
+    rowKey={ROW_KEY}
     columns={helpers.columns}
     rowGetter={helpers.rowGetter}
     rowsCount={numRows}
@@ -19,6 +25,7 @@ function shallowRenderGrid({
     cellNavigationMode={cellNavigationMode}
     onCellSelected={onCellSelected}
     onCellDeSelected={onCellDeSelected}
+    onGridRowsUpdated={onGridRowsUpdated}
   />);
   return {
     enzymeWrapper
@@ -42,7 +49,12 @@ describe('configure enableCellAutoFocus property', () => {
 });
 
 function shallowRenderGridWithSelectionHandlers() {
-  const props = { cellNavigationMode: 'none', onCellSelected: jasmine.createSpy(), onCellDeSelected: jasmine.createSpy() };
+  const props = {
+    cellNavigationMode: 'none',
+    onCellSelected: jasmine.createSpy(),
+    onCellDeSelected: jasmine.createSpy(),
+    onGridRowsUpdated: jasmine.createSpy()
+  };
   const { enzymeWrapper } = shallowRenderGrid(props);
   return enzymeWrapper.instance();
 }
@@ -599,465 +611,36 @@ describe('using keyboard to navigate through the grid by pressing Tab or Shift+T
   });
 });
 
-//
-//   var testProps = {
-//     enableCellSelect: true,
-//     columns:columns,
-//     rowGetter:rowGetter,
-//     rowsCount: _rows.length,
-//     width:300,
-//     onRowUpdated : function(update){},
-//     onCellCopyPaste : function(){},
-//     onCellsDragged : function(){},
-//     onGridSort : function(){}
-//   }
-//
-//   beforeEach(() => {
-//     var rowsCount = 1000;
-//     component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-//   });
-//
-//   it('should create a new instance of Grid', () => {
-//     expect(component).toBeDefined();
-//   });
-//
-//   it('should render a BaseGrid stub', () => {
-//     var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//     expect(baseGrid).toBeDefined();
-//   });
-//
-//
-//   it('should render a Toolbar if passed in as props to grid', () => {
-//     var Toolbar = StubComponent('Toolbar');
-//     component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
-//     var toolbarInstance = TestUtils.findRenderedComponentWithType(component, Toolbar);
-//     expect(toolbarInstance).toBeDefined();
-//   });
-//
-//   it('onToggleFilter trigger of Toolbar should set filter state of grid and render a filterable header row', () => {
-//     //arrange
-//     var Toolbar = StubComponent('Toolbar');
-//     component = TestUtils.renderIntoDocument(<Grid {...testProps} toolbar={<Toolbar/>} />);
-//     var toolbarInstance = TestUtils.findRenderedComponentWithType(component, Toolbar);
-//     //act
-//     toolbarInstance.props.onToggleFilter();
-//     //assert
-//     var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//     expect(component.state.canFilter).toBe(true);
-//     expect(baseGrid.props.headerRows.length).toEqual(2);
-//     var filterableHeaderRow = baseGrid.props.headerRows[1];
-//     expect(filterableHeaderRow.ref).toEqual("filterRow");
-//   });
-//
-//
-//   it("should be initialized with correct state", () => {
-//     expect(component.state).toEqual({
-//       selectedRows : [],
-//       selected : {rowIdx : 0,  idx : 0},
-//       copied : null,
-//       canFilter : false,
-//       expandedRows : [],
-//       columnFilters : {},
-//       sortDirection : null,
-//       sortColumn : null,
-//       dragged : null
-//     });
-//   });
-//
-//   describe("When cell selection disabled", () => {
-//
-//     it("grid should be initialized with selected state of {rowIdx : -1, idx : -1}", () => {
-//       component = TestUtils.renderIntoDocument(<Grid
-//         enableCellSelect={false}
-//         columns={columns}
-//         rowGetter={rowGetter}
-//         rowsCount={_rows.length}
-//         width={300}/>);
-//       expect(component.state.selected).toEqual({
-//         rowIdx : -1,
-//         idx : -1
-//       });
-//     });
-//
-//   });
-//
-//   describe("When row selection enabled", () => {
-//
-//     beforeEach(() => {
-//       component = TestUtils.renderIntoDocument(<Grid {...testProps} enableRowSelect={true} />);
-//     });
-//
-//     afterEach(() => {
-//       component.setState({selectedRows : []});
-//     });
-//
-//     it("should render an additional Select Row column", () => {
-//
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var selectRowCol = baseGrid.props.columns[0];
-//       expect(baseGrid.props.columns.length).toEqual(columns.length + 1);
-//       expect(selectRowCol.key).toEqual('select-row');
-//       expect(TestUtils.isElementOfType(selectRowCol.formatter, CheckboxEditorStub)).toBe(true);
-//     });
-//
-//     it("clicking header checkbox should toggle select all rows", () => {
-//       //arrange
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var selectRowCol = baseGrid.props.columns[0];
-//       var headerCheckbox = selectRowCol.headerRenderer;
-//       var checkbox = document.createElement('input');
-//       checkbox.type = "checkbox";
-//       checkbox.value = "value";
-//       checkbox.checked = true;
-//       var fakeEvent = {currentTarget : checkbox};
-//       //act
-//       headerCheckbox.props.onChange(fakeEvent);
-//       //assert
-//       var selectedRows = component.state.selectedRows;
-//       expect(selectedRows.length).toEqual(_rows.length);
-//       selectedRows.forEach(function(selected){
-//         expect(selected).toBe(true);
-//       });
-//       //trigger unselect
-//       checkbox.checked = false;
-//       headerCheckbox.props.onChange(fakeEvent);
-//       component.state.selectedRows.forEach(function(selected){
-//         expect(selected).toBe(false);
-//       });
-//     });
-//
-//     it("should be able to select an individual row when selected = false", () => {
-//       component.setState({selectedRows : [false, false, false, false]});
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var selectRowCol = baseGrid.props.columns[0];
-//       selectRowCol.onRowSelect(3);
-//       expect(component.state.selectedRows[3]).toBe(true);
-//     });
-//
-//     it("should be able to select an individual row when selected = null", () => {
-//       component.setState({selectedRows : [null, null, null, null]});
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var selectRowCol = baseGrid.props.columns[0];
-//       selectRowCol.onRowSelect(2);
-//       expect(component.state.selectedRows[2]).toBe(true);
-//     });
-//
-//     it("should be able to unselect an individual row ", () => {
-//       component.setState({selectedRows : [null, true, true, true]});
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var selectRowCol = baseGrid.props.columns[0];
-//
-//       selectRowCol.onRowSelect(3);
-//       expect(component.state.selectedRows[3]).toBe(false);
-//     });
-//   });
-//
-//
-//   describe("User Interaction",() => {
-//
-//     afterEach(() => {
-//       component.setState({selected  : {idx : 0, rowIdx : 0}});
-//     });
-//
-//     function SimulateGridKeyDown(component, key, ctrlKey){
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var fakeEvent = {key : key, keyCode :key, ctrlKey: ctrlKey, preventDefault : function(){}, stopPropagation : function(){}};
-//       baseGrid.props.onViewportKeydown(fakeEvent);
-//     }
-//
-//     it("hitting TAB should decrement selected cell index by 1", () => {
-//       SimulateGridKeyDown(component, 'Tab');
-//       expect(component.state.selected).toEqual({
-//         idx : 1,
-//         rowIdx : 0
-//       });
-//     });
-//
-//     describe("When selected cell is in top corner of grid", () => {
-//
-//       beforeEach(() => {
-//         component.setState({selected  : {idx : 0, rowIdx : 0}});
-//       });
-//
-//       it("on ArrowUp keyboard event should not change selected index", () => {
-//         SimulateGridKeyDown(component, 'ArrowUp');
-//         expect(component.state.selected).toEqual({
-//           idx : 0,
-//           rowIdx : 0
-//         });
-//       });
-//
-//       it("on ArrowLeft keyboard event should not change selected index", () => {
-//         SimulateGridKeyDown(component, 'ArrowLeft');
-//         expect(component.state.selected).toEqual({
-//           idx : 0,
-//           rowIdx : 0
-//         });
-//       });
-//
-//     });
-//
-//     describe("When selected cell has adjacent cells on all sides", () => {
-//
-//
-//       beforeEach(() => {
-//         component.setState({selected  : {idx : 1, rowIdx : 1}});
-//       });
-//
-//       it("on ArrowRight keyboard event should increment selected cell index by 1", () => {
-//         SimulateGridKeyDown(component, 'ArrowRight');
-//         expect(component.state.selected).toEqual({
-//           idx : 2,
-//           rowIdx : 1
-//         });
-//       });
-//
-//       it("on ArrowDown keyboard event should increment selected row index by 1", () => {
-//         SimulateGridKeyDown(component, 'ArrowDown');
-//         expect(component.state.selected).toEqual({
-//           idx : 1,
-//           rowIdx : 2
-//         });
-//       });
-//
-//       it("on ArrowLeft keyboard event should decrement selected row index by 1", () => {
-//         SimulateGridKeyDown(component, 'ArrowLeft');
-//         expect(component.state.selected).toEqual({
-//           idx : 0,
-//           rowIdx : 1
-//         });
-//       });
-//
-//       it("on ArrowUp keyboard event should decrement selected row index by 1", () => {
-//         SimulateGridKeyDown(component, 'ArrowUp');
-//         expect(component.state.selected).toEqual({
-//           idx : 1,
-//           rowIdx : 0
-//         });
-//       });
-//     });
-//
-//     describe("When column is editable", () => {
-//
-//       beforeEach(() => {
-//         columns[1].editable = true;
-//       });
-//
-//
-//
+describe('onGridRowsUpdated', () => {
+  const CELL_KEY = 'column1';
 
-//
-//       it("copy a cell value should store the value in grid state", () => {
-//         //arrange
-//         var selectedCellIndex = 1, selectedRowIndex = 1;
-//         component.setState({selected  : {idx : selectedCellIndex, rowIdx : selectedRowIndex}});
-//         var keyCode_c = '99';
-//         var expectedCellValue = _rows[selectedRowIndex].title;
-//         //act
-//         SimulateGridKeyDown(component, keyCode_c, true);
-//         //assert
-//         expect(component.state.textToCopy).toEqual(expectedCellValue);
-//         expect(component.state.copied).toEqual({idx : selectedCellIndex, rowIdx : selectedRowIndex});
-//       });
-//
-//       it("paste a cell value should call onCellCopyPaste of component with correct params", () => {
-//         //arrange
-//         spyOn(testProps, 'onCellCopyPaste');
-//         component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-//         component.setState({
-//           textToCopy : 'banana',
-//           selected   : {idx : 1, rowIdx : 5},
-//           copied     : {idx : 1, rowIdx : 1}
-//         });
-//         var keyCode_v = '118';
-//         SimulateGridKeyDown(component, keyCode_v, true);
-//         expect(testProps.onCellCopyPaste).toHaveBeenCalled();
-//         expect(testProps.onCellCopyPaste.calls.mostRecent().args[0]).toEqual({cellKey: "title", rowIdx: 5, value: "banana", fromRow: 1, toRow: 5})
-//       });
-//
-//       it("cell commit cancel should set grid state inactive", () =>{
-//         component.setState({selected : {idx : 1, rowIdx:1, active : true}})
-//         var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//         var meta = baseGrid.props.cellMetaData;
-//         meta.onCommitCancel();
-//         expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
-//       });
-//
-//       it("pressing escape should set grid state inactive", () =>{
-//         component.setState({selected : {idx : 1, rowIdx:1, active : true}})
-//         SimulateGridKeyDown(component, 'Escape');
-//         expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : false });
-//       });
-//
-//       it("pressing enter should set grid state active", () =>{
-//         component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-//         SimulateGridKeyDown(component, 'Enter');
-//         expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Enter' });
-//       });
-//
-//       it("pressing delete should set grid state active", () =>{
-//         component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-//         SimulateGridKeyDown(component, 'Delete');
-//         expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Delete' });
-//       });
-//
-//       it("pressing backspace should set grid state active", () =>{
-//         component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-//         SimulateGridKeyDown(component, 'Backspace');
-//         expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 'Backspace' });
-//       });
-//
-//       it("typing a char should set grid state active and store the typed value", () =>{
-//         component.setState({selected : {idx : 1, rowIdx:1, active : false}})
-//         var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//         var fakeEvent = {keyCode : 66, key :"Unidentified", preventDefault : function(){}, stopPropagation : function(){}};
-//         baseGrid.props.onViewportKeydown(fakeEvent);
-//         expect(component.state.selected).toEqual({idx : 1, rowIdx : 1, active : true, initialKeyCode : 66 });
-//       });
-//
-//     });
-//
-//     describe("When column is not editable", () => {
-//       beforeEach(() => {
-//         columns[1].editable = false;
-//       });
-//
-//       it("double click on grid should not activate current selected cell", () => {
-//         component.setState({selected : {idx : 1, rowIdx : 1}});
-//         columns[1].editable = false;
-//         var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//         baseGrid.props.onViewportDoubleClick();
-//         expect(component.state.selected).toEqual({
-//           idx : 1,
-//           rowIdx : 1
-//         })
-//       });
-//     });
-//
+  const getRow = (rowKey) => { return { ROW_KEY: rowKey }; };
+  const testOnGridRowsUpdated = (rowKeys, expectedUpdatedRowIds, action =  UpdateActions.CELL_UPDATE) => {
+    const updatedRows = rowKeys.map(rowKey => getRow(rowKey));
+    const updatedRowData = { CELL_KEY: 'update' };
+    const fromRow =  updatedRows[0];
+    const toRow =  updatedRows[updatedRows.length - 1];
 
-//
-//   describe("Cell Meta Data", () => {
-//
-//     function getCellMetaData(component){
-//
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//
-//       return baseGrid.props.cellMetaData;
-//     }
-//
-//     it('creates a cellMetaData object and passes to baseGrid as props', () => {
-//       var meta = getCellMetaData(component)
-//       expect(meta).toEqual(jasmine.objectContaining({
-//         selected : {rowIdx : 0, idx : 0},
-//         dragged  : null,
-//         copied   : null
-//       }));
-//       expect(typeof meta.onCellClick === 'function').toBe(true);
-//       expect(typeof meta.onCommit === 'function').toBe(true);
-//       expect(typeof meta.onCommitCancel === 'function').toBe(true);
-//       expect(typeof meta.handleDragEnterRow === 'function').toBe(true);
-//       expect(typeof meta.handleTerminateDrag === 'function').toBe(true);
-//     });
-//
-//     it("Changing Grid state should update cellMetaData", () => {
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var newState = {selected  : {idx : 2, rowIdx : 2}, dragged : {idx : 2, rowIdx : 2}}
-//       component.setState(newState);
-//       var meta = baseGrid.props.cellMetaData;
-//       expect(meta).toEqual(jasmine.objectContaining(newState));
-//     });
-//
-//     it("cell commit should trigger onRowUpdated with correct params", () => {
-//       spyOn(testProps, 'onRowUpdated');
-//       component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-//       var meta = getCellMetaData(component);
-//       var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
-//       meta.onCommit(fakeCellUpdate);
-//       expect(testProps.onRowUpdated.calls.count()).toEqual(1);
-//       expect(testProps.onRowUpdated.argsForCall[0][0]).toEqual({
-//         cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"
-//       })
-//     });
-//
-//     it("cell commit should deactivate selected cell", () => {
-//       component.setState({selected : {idx : 3, rowIdx : 3, active : true}});
-//       var meta = getCellMetaData(component);
-//       var fakeCellUpdate = {cellKey: "title", rowIdx: 0, updated: {title : 'some new title'}, key: "Enter"}
-//       meta.onCommit(fakeCellUpdate);
-//       expect(component.state.selected).toEqual({
-//           idx : 3,
-//           rowIdx : 3,
-//           active : false
-//         });
-//     });
-//
-//     it("cell commit after TAB should select next cell", () => {
-//       component.setState({selected : {idx : 1, rowIdx : 1, active : true}});
-//       var meta = getCellMetaData(component);
-//       var fakeCellUpdate = {cellKey: "title", rowIdx: 1, updated: {title : 'some new title'}, keyCode: "Tab"}
-//       meta.onCommit(fakeCellUpdate);
-//       expect(component.state.selected).toEqual({
-//         idx : 2,
-//         rowIdx : 1,
-//         active : false
-//       });
-//     });
-//
-//
-//     it("Cell click should set selected state of grid", () =>{
-//       var meta = getCellMetaData(component);
-//       meta.onCellClick({idx : 2, rowIdx : 2 });
-//       expect(component.state.selected).toEqual({idx : 2, rowIdx : 2 });
-//     });
-//
-//
-//   })
-//
-//
-//   describe("When column is sortable", () => {
-//
-//     var sortableColIdx =1;
-//     beforeEach(() => {
-//       columns[sortableColIdx].sortable = true;
-//       component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-//     })
-//
-//     afterEach(() => {
-//       columns[sortableColIdx].sortable = false;
-//     })
-//
-//     it("should provide column with a sortableHeaderRenderer", () => {
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var sortableColumn = baseGrid.props.columns[sortableColIdx];
-//       expect(TestUtils.isElementOfType(sortableColumn.headerRenderer, SortableHeaderCellStub)).toBe(true);
-//     });
-//
-//     it("should pass sort direction as props to headerRenderer when column is sortColumn", () => {
-//       component.setState({sortDirection : 'ASC', sortColumn : columns[1].key});
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var sortableHeaderRenderer = baseGrid.props.columns[sortableColIdx].headerRenderer;
-//       expect(sortableHeaderRenderer.props.sortDirection).toEqual('ASC');
-//     });
-//
-//     it("should call onGridSort when headerRender click", () => {
-//       //arrange
-//       spyOn(testProps, 'onGridSort');
-//       component = TestUtils.renderIntoDocument(<Grid {...testProps}/>);
-//       component.setState({sortDirection : 'ASC', sortColumn : columns[1].key});
-//       var baseGrid = TestUtils.findRenderedComponentWithType(component, BaseGridStub);
-//       var sortableHeaderRenderer = baseGrid.props.columns[sortableColIdx].headerRenderer;
-//       //act
-//       sortableHeaderRenderer.props.onSort('title', 'DESC');
-//       //assert
-//       expect(testProps.onGridSort).toHaveBeenCalled();
-//       expect(testProps.onGridSort.calls.mostRecent().args[0]).toEqual('title');
-//       expect(testProps.onGridSort.calls.mostRecent().args[1]).toEqual('DESC');
-//     });
-//
-//
-//   });
-//
-//
-//
-//
-// });
+    const grid = shallowRenderGridWithSelectionHandlers();
+    grid.onGridRowsUpdated(CELL_KEY, fromRow, toRows, updatedRowData, action, fromRow);
+    expect(grid.props.onGridRowsUpdated).toHaveBeenCalledWith({
+      cellKey: CELL_KEY,
+      fromRow,
+      toRow,
+      fromRowId: fromRow[ROW_KEY],
+      toRowId: toRow[ROW_KEY],
+      rowIds: expectedUpdatedRowIds,
+      updated: updatedRowData,
+      action,
+      fromRowData: fromRow
+    });
+  };
+
+  it('should update target row if one row is updated', () => {
+    testOnGridRowsUpdated([1], [1]);
+  });
+
+  it('should not update "from row" if multiple rows are updated', () => {
+    testOnGridRowsUpdated([1, 2, 3], [2, 3], UpdateActions.CELL_DRAG);
+  });
+});

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -622,7 +622,7 @@ describe('onGridRowsUpdated', () => {
     const toRow =  updatedRows[updatedRows.length - 1];
 
     const grid = shallowRenderGridWithSelectionHandlers();
-    grid.onGridRowsUpdated(CELL_KEY, fromRow, toRows, updatedRowData, action, fromRow);
+    grid.onGridRowsUpdated(CELL_KEY, fromRow, toRow, updatedRowData, action, fromRow);
     expect(grid.props.onGridRowsUpdated).toHaveBeenCalledWith({
       cellKey: CELL_KEY,
       fromRow,

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -614,25 +614,26 @@ describe('using keyboard to navigate through the grid by pressing Tab or Shift+T
 describe('onGridRowsUpdated', () => {
   const CELL_KEY = 'column1';
 
-  const getRow = (rowKey) => { return { ROW_KEY: rowKey }; };
+  const getRow = (rowKey, index) => { return { ROW_KEY: rowKey, index }; };
   const testOnGridRowsUpdated = (rowKeys, expectedUpdatedRowIds, action =  UpdateActions.CELL_UPDATE) => {
-    const updatedRows = rowKeys.map(rowKey => getRow(rowKey));
+    const updatedRows = rowKeys.map((rowKey, index) => getRow(rowKey, index));
     const updatedRowData = { CELL_KEY: 'update' };
-    const fromRow =  updatedRows[0];
-    const toRow =  updatedRows[updatedRows.length - 1];
+    const fromRowData = updatedRows[0];
+    const fromRowIdx = fromRowData.index;
+    const toRowIdx = updatedRows[updatedRows.length - 1].index;
 
     const grid = shallowRenderGridWithSelectionHandlers();
-    grid.onGridRowsUpdated(CELL_KEY, fromRow, toRow, updatedRowData, action, fromRow);
+    grid.onGridRowsUpdated(CELL_KEY, fromRowIdx, toRowIdx, updatedRowData, action, fromRowIdx);
     expect(grid.props.onGridRowsUpdated).toHaveBeenCalledWith({
       cellKey: CELL_KEY,
-      fromRow,
-      toRow,
+      fromRow: fromRowIdx,
+      toRow: toRowIdx,
       fromRowId: fromRow[ROW_KEY],
       toRowId: toRow[ROW_KEY],
       rowIds: expectedUpdatedRowIds,
       updated: updatedRowData,
       action,
-      fromRowData: fromRow
+      fromRowData
     });
   };
 


### PR DESCRIPTION
## Description
When updating multiple rows, which happens during cell dragging, we shouldn't include the "from row" in the updated `rowIds`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
We include the "from row" in the updated `rowIds` object.

**What is the new behavior?**
We exclude the "from row" from the updated `rowIds` object.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
