### PR TITLE
Change text of FilterableHeaderCell placeholder into props for non-English-Speakers

### DIFF
--- a/docs/markdowns/FilterableHeaderCell.md
+++ b/docs/markdowns/FilterableHeaderCell.md
@@ -15,3 +15,7 @@ type: `shaperequire('../../../PropTypeShapes/ExcelColumn')`
 
 type: `func`
 
+
+### `searchPlaceholderText`
+
+type: `string`

--- a/docs/markdowns/HeaderRow.md
+++ b/docs/markdowns/HeaderRow.md
@@ -90,3 +90,7 @@ type: `shape[object Object]`
 
 type: `union(number|string)`
 
+
+### `searchPlaceholderText`
+
+type: `string`

--- a/docs/markdowns/ReactDataGrid.md
+++ b/docs/markdowns/ReactDataGrid.md
@@ -224,3 +224,7 @@ defaultValue: `-1`
 
 type: `element`
 
+
+### `searchPlaceholderText`
+
+type: `string`

--- a/packages/react-data-grid/src/Header.js
+++ b/packages/react-data-grid/src/Header.js
@@ -118,6 +118,7 @@ class Header extends React.Component {
         draggableHeaderCell={this.props.draggableHeaderCell}
         filterable={row.filterable}
         onFilterChange={row.onFilterChange}
+        searchPlaceholderText={row.searchPlaceholderText}
         onHeaderDrop={this.props.onHeaderDrop}
         sortColumn={this.props.sortColumn}
         sortDirection={this.props.sortDirection}

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -43,7 +43,8 @@ class HeaderRow extends React.Component {
     onScroll: PropTypes.func,
     rowType: PropTypes.string,
     draggableHeaderCell: PropTypes.func,
-    onHeaderDrop: PropTypes.func
+    onHeaderDrop: PropTypes.func,
+    searchPlaceholderText: PropTypes.string
   };
 
   componentWillMount() {

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -114,6 +114,7 @@ class ReactDataGrid extends React.Component {
     onCheckCellIsEditable: PropTypes.func,
     /* called before cell is set active, returns a boolean to determine whether cell is editable */
     overScan: PropTypes.object,
+    searchPlaceholderText: PropTypes.string,
     onDeleteSubRow: PropTypes.func,
     onAddSubRow: PropTypes.func,
     enableCellAutoFocus: PropTypes.bool,
@@ -878,6 +879,7 @@ class ReactDataGrid extends React.Component {
         ref: (node) => this.filterRow = node,
         filterable: true,
         onFilterChange: this.props.onAddFilter,
+        searchPlaceholderText: this.props.searchPlaceholderText,
         height: this.props.headerFiltersHeight,
         rowType: 'filter'
       });

--- a/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
@@ -5,7 +5,12 @@ import PropTypes from 'prop-types';
 class FilterableHeaderCell extends React.Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    column: PropTypes.shape(ExcelColumn)
+    column: PropTypes.shape(ExcelColumn),
+    searchPlaceholderText: PropTypes.string
+  };
+
+  static defaultProps = {
+    searchPlaceholderText: 'Search'
   };
 
   state: {filterTerm: string} = {filterTerm: ''};
@@ -22,7 +27,7 @@ class FilterableHeaderCell extends React.Component {
     }
 
     let inputKey = 'header-filter-' + this.props.column.key;
-    return (<input key={inputKey} type="text" className="form-control input-sm" placeholder="Search" value={this.state.filterTerm} onChange={this.handleChange}/>);
+    return (<input key={inputKey} type="text" className="form-control input-sm" placeholder={this.props.searchPlaceholderText} value={this.state.filterTerm} onChange={this.handleChange}/>);
   };
 
   render(): ?ReactElement {


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
User can not change text of FilterableHeaderCell placeholder.


**What is the new behavior?**
User can change text of FilterableHeaderCell placeholder via "searchPlaceholderText" props.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
