### PR TITLE
Fix cell click

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/data/MockStateObject.js
+++ b/packages/react-data-grid-addons/src/__tests__/data/MockStateObject.js
@@ -41,6 +41,7 @@ module.exports = function(stateValues, events) {
     sortColumn: null,
     dragged: null,
     scrollOffset: 0,
-    lastRowIdxUiSelected: -1
+    lastRowIdxUiSelected: -1,
+    isTabFocus: false
   }, stateValues);
 };

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -100,7 +100,8 @@ class Cell extends React.Component {
       || this.props.className !== nextProps.className
       || this.props.expandableOptions !== nextProps.expandableOptions
       || this.hasChangedDependentValues(nextProps)
-      || this.props.column.locked !== nextProps.column.locked;
+      || this.props.column.locked !== nextProps.column.locked
+      || this.props.cellMetaData.isTabFocus !== nextProps.cellMetaData.isTabFocus;
     return shouldUpdate;
   }
 
@@ -113,7 +114,8 @@ class Cell extends React.Component {
 
   onCellFocus = () => {
     let meta = this.props.cellMetaData;
-    if (meta != null && meta.onCellFocus && typeof (meta.onCellFocus) === 'function') {
+    console.log(meta.isTabFocus);
+    if (meta.isTabFocus && meta != null && meta.onCellFocus && typeof (meta.onCellFocus) === 'function') {
       meta.onCellFocus({ rowIdx: this.props.rowIdx, idx: this.props.idx });
     }
   };

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -114,7 +114,6 @@ class Cell extends React.Component {
 
   onCellFocus = () => {
     let meta = this.props.cellMetaData;
-    console.log(meta.isTabFocus);
     if (meta.isTabFocus && meta != null && meta.onCellFocus && typeof (meta.onCellFocus) === 'function') {
       meta.onCellFocus({ rowIdx: this.props.rowIdx, idx: this.props.idx });
     }

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -150,7 +150,7 @@ class ReactDataGrid extends React.Component {
   constructor(props, context) {
     super(props, context);
     let columnMetrics = this.createColumnMetrics();
-    let initialState = {columnMetrics, selectedRows: [], copied: null, expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, dragged: null, scrollOffset: 0, lastRowIdxUiSelected: -1};
+    let initialState = {columnMetrics, selectedRows: [], copied: null, expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, dragged: null, scrollOffset: 0, lastRowIdxUiSelected: -1, isTabFocus: false};
     if (props.enableCellSelect) {
       initialState.selected = {rowIdx: 0, idx: 0};
     } else {
@@ -361,6 +361,7 @@ class ReactDataGrid extends React.Component {
       this.props.onRowClick(cell.rowIdx, this.props.rowGetter(cell.rowIdx), this.getColumn(cell.idx));
     }
 
+    this.setState({ isTabFocus: false });
     if (e) {
       e.stopPropagation();
     }
@@ -435,6 +436,8 @@ class ReactDataGrid extends React.Component {
     if (this.props.rowsCount === 0) {
       return;
     }
+
+    this.setState({isTabFocus: true});
     // Scenario 0b: When we're editing a cell
     const idx = this.state.selected.idx;
     const rowIdx = this.state.selected.rowIdx;
@@ -1202,6 +1205,7 @@ class ReactDataGrid extends React.Component {
       onAddSubRow: this.props.onAddSubRow,
       isScrollingVerticallyWithKeyboard: this.isKeyDown(KeyCodes.DownArrow) || this.isKeyDown(KeyCodes.UpArrow),
       isScrollingHorizontallyWithKeyboard: this.isKeyDown(KeyCodes.LeftArrow) || this.isKeyDown(KeyCodes.RightArrow) || this.isKeyDown(KeyCodes.Tab),
+      isTabFocus: this.state.isTabFocus,
       enableCellAutoFocus: this.props.enableCellAutoFocus
     };
 

--- a/packages/react-data-grid/src/__tests__/Cell.spec.js
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.js
@@ -22,7 +22,8 @@ let testCellMetaData = {
   copied: null,
   handleDragEnterRow: function() {},
   handleTerminateDrag: function() {},
-  onColumnEvent: function() {}
+  onColumnEvent: function() {},
+  isTabFocus: true
 };
 
 let testProps = {


### PR DESCRIPTION
## Description
Fix cell click. It was broke by the onFocus event 

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Click event in the cell will not be triggered



**What is the new behavior?**
Click event in the cell will trigger


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
