### PR TITLE
Updated Editors to import DateRangeEditor

### DIFF
--- a/packages/react-data-grid-addons/src/editors/index.js
+++ b/packages/react-data-grid-addons/src/editors/index.js
@@ -4,6 +4,7 @@ const Editors = {
   AutoComplete: require('./AutoCompleteEditor'),
   DropDownEditor: require('./DropDownEditor'),
   ContainerEditorWrapper: require('./ContainerEditorWrapper'),
+  DateRangeEditor: require('./DateRangeEditor'),
   SimpleTextEditor,
   CheckboxEditor
 };


### PR DESCRIPTION
- Have you already searched for similar issues? Please help us out and double-check first!
Yes, i could not find an issue using DateRangeEditor.

- Also, please don't be that person who deletes this template. It's here for a reason.

- Thanks!

---

### Which version of React JS are you using?

✅ Officially supported ✅
- [ ] v15.4.x

⚠️ Not officially supported, expect warnings ⚠️
- [ ] v15.5.x
- [ ] v15.6.x

☣️ Not officially supported, expect warnings and errors ☣️
- [X] v16.x.x

---

### Which browser are you using?

✅ Officially supported ✅
- [ ] IE 9 / IE 10 / IE 11
- [ ] Edge
- [X] Chrome

⚠️ Not officially supported, but "should work" ⚠️
- [X] Firefox
- [ ] Safari

---

### I'm submitting a ...

- [X] 🐛 Bug Report
- [ ] 💡 Feature Request

> 👋 Need general support? Not sure about how to use React itself, or how to get started with the Grid?
> Please do not submit support request here. Instead see

> https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md

---

### Issue Details

```
Please include:
- What the current behavior is
- What the desired behvaior is
- (If Bug) Steps to reproduce the issue
- (If Feature) The motivation / use case for the feature

We especially love screenshots / videos of problems, and remember
The Best Issue Is A Pull Request™
```

Hi, i had planned to use DateRangeEditor from react-data-grid-addons, but i can not find it imported anywhere in your source, so i can not import it myself.
The DateRangeEditor file has a module.export, but editor.js ( https://github.com/adazzle/react-data-grid/blob/master/packages/react-data-grid-addons/src/editors/index.js ) does not import it.