### PR TITLE
Updated CharCode for Right Triangle to render it little larger.

### DIFF
--- a/packages/react-data-grid/src/AppConstants.js
+++ b/packages/react-data-grid/src/AppConstants.js
@@ -12,7 +12,7 @@ const constants = {
   },
   CellExpand: {
     DOWN_TRIANGLE: String.fromCharCode('9660'),
-    RIGHT_TRIANGLE: String.fromCharCode('9654')
+    RIGHT_TRIANGLE: String.fromCharCode('9658')
   }
 };
 


### PR DESCRIPTION
## Description
In a TreView, the Right Triangle to expand the Cell is tiny when compared to the Down Triangle displayed after expanding the cell. It is little tedious to point the mouse and click on this tiny Right Triangle. Updated the CharCode to render the Right Triangle to match the size of Down Triangle 

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Other... Please describe: Cosmetic change
```

**What is the current behavior?** (You can also link to an open issue here)
In a TreView, the Right Triangle to expand the Cell is tiny when compared to the Down Triangle displayed after expanding the cell. It is little tedious to point the mouse and click on this tiny Right Triangle. 


**What is the new behavior?**
The Right Triangle is rendered little larger and matches the size of the Down Triangle


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
