### PR TITLE
Rectangular selection range support

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/data/MockStateObject.js
+++ b/packages/react-data-grid-addons/src/__tests__/data/MockStateObject.js
@@ -33,6 +33,24 @@ module.exports = function(stateValues, events) {
       rowIdx: 0,
       idx: 0
     },
+    selectedRange: {
+      topLeft: {
+        rowIdx: 0,
+        idx: 0
+      },
+      bottomRight: {
+        rowIdx: 0,
+        idx: 0
+      },
+      startCell: {
+        rowIdx: 0,
+        idx: 0
+      },
+      cursorCell: {
+        rowIdx: 0,
+        idx: 0
+      }
+    },
     copied: null,
     canFilter: false,
     expandedRows: [],

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -45,7 +45,6 @@ class Grid extends React.Component {
     onViewportKeyup: PropTypes.func,
     onViewportDragStart: PropTypes.func.isRequired,
     onViewportDragEnd: PropTypes.func.isRequired,
-    onViewportClick: PropTypes.func.isRequired,
     onViewportDoubleClick: PropTypes.func.isRequired,
     onColumnResize: PropTypes.func,
     onSort: PropTypes.func,
@@ -149,10 +148,10 @@ class Grid extends React.Component {
               tabIndex={this.props.tabIndex}
               onKeyDown={this.props.onViewportKeydown}
               onKeyUp={this.props.onViewportKeyup}
-              onClick={this.props.onViewportClick}
               onDoubleClick={this.props.onViewportDoubleClick}
               onDragStart={this.props.onViewportDragStart}
-              onDragEnd={this.props.onViewportDragEnd}>
+              onDragEnd={this.props.onViewportDragEnd}
+            >
                 <Viewport
                   ref={(node) => { this.viewport = node; } }
                   rowKey={this.props.rowKey}

--- a/packages/react-data-grid/src/PropTypeShapes/CellMetaDataShape.js
+++ b/packages/react-data-grid/src/PropTypeShapes/CellMetaDataShape.js
@@ -2,9 +2,12 @@ import PropTypes from 'prop-types';
 
 module.exports = {
   selected: PropTypes.object.isRequired,
+  selectedRange: PropTypes.object.isRequired,
   copied: PropTypes.object,
   dragged: PropTypes.object,
   onCellClick: PropTypes.func.isRequired,
+  onCellMouseDown: PropTypes.func.isRequired,
+  onCellMouseEnter: PropTypes.func.isRequired,
   onCellDoubleClick: PropTypes.func.isRequired,
   onCommit: PropTypes.func.isRequired,
   onCommitCancel: PropTypes.func.isRequired,

--- a/packages/react-data-grid/src/RowComparer.js
+++ b/packages/react-data-grid/src/RowComparer.js
@@ -8,6 +8,11 @@ function doesRowContainSelectedCell(props) {
   return false;
 }
 
+function isWithinSelectedRange(props) {
+  const selectedRange = props.cellMetaData.selectedRange;
+  return selectedRange && selectedRange.topLeft.rowIdx <= props.idx && props.idx <= selectedRange.bottomRight.rowIdx;
+}
+
 function willRowBeDraggedOver(props) {
   let dragged = props.cellMetaData.dragged;
   return dragged != null && (dragged.rowIdx >= 0 || dragged.complete === true);
@@ -22,6 +27,8 @@ export const shouldRowUpdate = (nextProps, currentProps) => {
   return !(ColumnMetrics.sameColumns(currentProps.columns, nextProps.columns, ColumnMetrics.sameColumn)) ||
     doesRowContainSelectedCell(currentProps) ||
     doesRowContainSelectedCell(nextProps) ||
+    isWithinSelectedRange(currentProps) ||
+    isWithinSelectedRange(nextProps) ||
     willRowBeDraggedOver(nextProps) ||
     nextProps.row !== currentProps.row ||
     currentProps.colDisplayStart !== nextProps.colDisplayStart ||

--- a/packages/react-data-grid/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid/src/__tests__/Grid.spec.js
@@ -85,7 +85,7 @@ describe('Base Grid Tests', () => {
     expect(testProps.onViewportDoubleClick).toHaveBeenCalled();
   });
 
-  it('dragstart in viewport should call props.onViewportDoubleClick', () => {
+  it('dragstart in viewport should call props.onViewportDragStart', () => {
     let viewportContainerNode;
     spyOn(testProps, 'onViewportDragStart');
     testElement = TestUtils.renderIntoDocument(<Grid {...testProps}/>);

--- a/packages/react-data-grid/src/utils/keyboardUtils.js
+++ b/packages/react-data-grid/src/utils/keyboardUtils.js
@@ -14,7 +14,12 @@ function isCtrlKeyHeldDown(e) {
   return (e.ctrlKey === true || e.metaKey === true) && e.key !== 'Control';
 }
 
+function isShiftKeyHeldDown(e) {
+  return e.shiftKey === true && e.key !== 'Shift';
+}
+
 export {
   isKeyPrintable,
-  isCtrlKeyHeldDown
+  isCtrlKeyHeldDown,
+  isShiftKeyHeldDown
 };

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -11,11 +11,65 @@
   outline-offset: -2px;
 }
 
+.react-grid-Cell.selected::before {
+  content: "";
+  background-color: #66afe930;
+  position: absolute;
+  height: 100%;
+  left: 0;
+  right: 0;
+}
+.react-grid-Cell.selected-top {
+  box-shadow: inset 0 1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-bottom {
+  box-shadow: inset 0 -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-left {
+  box-shadow: inset 1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-right {
+  box-shadow: inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-bottom {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset 0 -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-left {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset 1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-right {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-bottom-left {
+  box-shadow: inset 0 -1px 0 0 #66afe9, inset 1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-bottom-right {
+  box-shadow: inset 0 -1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-left-right {
+  box-shadow: inset 1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-left-right {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset 1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-bottom-left-right {
+  box-shadow: inset 0 -1px 0 0 #66afe9, inset 1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-bottom-left {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset 0 -1px 0 0 #66afe9, inset 1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-bottom-right {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset 0 -1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+.react-grid-Cell.selected-top-bottom-left-right {
+  box-shadow: inset 0 1px 0 0 #66afe9, inset 0 -1px 0 0 #66afe9, inset 1px 0 0 #66afe9, inset -1px 0 0 #66afe9;
+}
+
 .react-grid-Cell--locked:focus {
   z-index: 100;
 }
 
-.react-grid-Cell:focus .drag-handle {
+.react-grid-Cell.selected-top-bottom-left-right .drag-handle {
   position: absolute;
   bottom: -5px;
   right: -4px;
@@ -60,7 +114,7 @@
   box-shadow: none;
 }
 
-.react-grid-Cell:hover:focus .drag-handle .glyphicon-arrow-down {
+.react-grid-Cell.selected-top-bottom-left-right:hover .drag-handle .glyphicon-arrow-down {
   display: 'block'
 }
 
@@ -99,7 +153,7 @@
   border-left: 1px dashed black;
 }
 
-.react-grid-Cell:hover:focus .drag-handle {
+.react-grid-Cell.selected-top-bottom-left-right:hover .drag-handle {
   position: absolute;
   bottom: -8px;
   right: -7px;

--- a/themes/react-data-grid-core.css
+++ b/themes/react-data-grid-core.css
@@ -15,6 +15,12 @@
 .react-grid-Grid {
   background-color: #ffffff;
   border: 1px solid #dddddd;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .react-grid-Canvas {


### PR DESCRIPTION
## Description
As per my feature request and rough outline in #1133, this PR allows users to select rectangular ranges with both the mouse and keyboard (and to subscribe to events about such ranges, so that their application can react appropriately).

**Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

I don't (yet) understand what the approach to documentation is on this project. If someone could let me know what they'd expect to see, how docs are generated, etc, I'll by happy to add a commit to this PR.

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Clicking & dragging selects the text in the cells / shift+arrows just moves the selected cell.


**What is the new behaviour?**
Clicking & dragging selects a rectangular range, with the selected/"cursor" cell following the mouse. The range is displayed with a thin border; the selected cell retains a (slightly thicker) border. When the range is greater than 1x1, the selected cells also have a semi-transparent overlay. Text in the grid is no longer selectable except when editing content (in modern browsers; this behaviour won't be supported by IE9 or lower).

The selected range can also be manipulated by holding shift and using the arrow keys. (An existing range is updated by keeping the same start point and moving the "cursor" cell)

Clicking in the window but not on a cell clears the selection.

New callbacks (onCellRangeSelectionStarted, onCellRangeSelectionUpdated, and onCellRangeSelectionCompleted) are called (if they're present) when starting a drag, moving whilst dragging, and ending a drag. Modifying the range via the keyboard calls only the latter two callbacks.

There were a few questions I asked in #1133. I've taken the below approaches:
- Text selection is prevented in browsers other than IE9 and below. For now, I'm just assuming that's okay, and that this project doesn't support IE9 or lower; I can't see anything official on what's supported, but shout if that's not true.
- onViewportDoubleClick remains. I don't understand how it's ever actually invoked by a user (given if you click a cell, it stops the event from propagating), but leaving it in doesn't seem like a problem for this PR.
- I've removed onViewportClick, but I believe the behaviour is preserved: if you click in the viewport but outside a cell, when you mouseup the window's event handler will see that but also see there's no selection drag in process, and so call deselect. As with onViewportDoubleClick, I don't actually understand how you trigger this as a user, but I've tried to preserve behaviour regardless.
- I haven't done anything about onCellDeSelect not being called in some situations when a cell is, in fact, deselected. I do think that's probably a bug, but I thought it was best left for a different PR.
- Clicking outside the grid calls deselect() now. Previously the cell just lost focus (so it looked deselected, because the CSS relied on :focus, but the selected state remained). Now the actual selected state is changed. I'm not sure this is an externally observable difference, though, because of the point above about onCellDeSelect not being fired when you might expect it to.
- This feature is always on - i.e. I haven't provided any setting to disable it. I considered providing one, or tying it to enableCellSelect, but as far as I can tell enableCellSelect doesn't actually prevent cell selection, but merely stops there being a cell selected by default when the grid is first rendered.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
Okay, so there are a few small differences noted above, but I don't believe they're "breaking." The part I'm most concerned by is preventing text selection, but I strongly suspect that's not behaviour that anyone would be relying on.

**Other information**

The first commit in this PR is essentially unrelated to this feature - it's tidying up and isolating various tests. It's a prerequisite of the next commit, though: without doing that tidy up, some state was leaking between tests (such that something at some point triggered a render of Canvas, which had fewer rows than specified, so ultimately generated an exception that killed the test runner).