### PR TITLE
Update import module path.

### DIFF
--- a/packages/react-data-grid-addons/index.js
+++ b/packages/react-data-grid-addons/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./src');
+module.exports = require('./dist/react-data-grid-addons');


### PR DESCRIPTION
## Description
The module doesn't have './src' directory and it can brake project which will use it. Better way is fix require path on './dist/react-data-grid-addons'.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Broken import path

**What is the new behavior?**

Working default import

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
