### PR TITLE
DefaultRowGroupRenderer should be a class to be referenced

### DIFF
--- a/packages/react-data-grid/src/RowGroup.js
+++ b/packages/react-data-grid/src/RowGroup.js
@@ -70,35 +70,55 @@ RowGroup.propTypes = {
   renderer: PropTypes.func
 };
 
-const  DefaultRowGroupRenderer = (props) => {
-  let treeDepth = props.treeDepth || 0;
-  let marginLeft = treeDepth * 20;
+class DefaultRowGroupRenderer extends Component {
 
-  let style = {
-    height: '50px',
-    border: '1px solid #dddddd',
-    paddingTop: '15px',
-    paddingLeft: '5px'
-  };
+  constructor(props) {
+    super(props);
 
-  let onKeyDown = (e) => {
+    this.onKeyDown = this.onKeyDown.bind(this);
+  }
+
+  onKeyDown(e) {
     if (e.key === 'ArrowLeft') {
-      props.onRowExpandToggle(false);
+      this.props.onRowExpandToggle(false);
     }
     if (e.key === 'ArrowRight') {
-      props.onRowExpandToggle(true);
+      this.props.onRowExpandToggle(true);
     }
     if (e.key === 'Enter') {
-      props.onRowExpandToggle(!props.isExpanded);
+      this.props.onRowExpandToggle(!this.props.isExpanded);
     }
-  };
-  return (
-    <div style={style} onKeyDown={onKeyDown} tabIndex={0}>
-      <span className="row-expand-icon" style={{float: 'left', marginLeft: marginLeft, cursor: 'pointer'}} onClick={props.onRowExpandClick} >{props.isExpanded ? String.fromCharCode('9660') : String.fromCharCode('9658')}</span>
-      <strong>{props.columnGroupName}: {props.name}</strong>
-    </div>
-  );
-};
+  }
+
+  render() {
+    let treeDepth = this.props.treeDepth || 0;
+    let marginLeft = treeDepth * 20;
+
+    let style = {
+      height: '50px',
+      border: '1px solid #dddddd',
+      paddingTop: '15px',
+      paddingLeft: '5px'
+    };
+
+    return (
+      <div style={style} onKeyDown={this.onKeyDown} tabIndex={0}>
+        <span
+          className="row-expand-icon"
+          style={{ float: 'left', marginLeft: marginLeft, cursor: 'pointer' }}
+          onClick={this.props.onRowExpandClick}
+        >
+          {this.props.isExpanded
+            ? String.fromCharCode('9660')
+            : String.fromCharCode('9658')}
+        </span>
+        <strong>
+          {this.props.columnGroupName}: {this.props.name}
+        </strong>
+      </div>
+    );
+  }
+}
 
 DefaultRowGroupRenderer.propTypes = {
   onRowExpandClick: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Generates a warning `Update: Warning: Stateless function components cannot be given refs`.


**What is the new behavior?**
We use a Class for this component so we can use `refs`.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
