### PR TITLE
Allow the DraggableHeader to use the same DropSource as GroupedColumnsPanel

### DIFF
--- a/packages/react-data-grid-addons/src/draggable-header/DraggableHeaderCell.js
+++ b/packages/react-data-grid-addons/src/draggable-header/DraggableHeaderCell.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DragSource, DropTarget } from 'react-dnd';
-import { HeaderCell } from 'react-data-grid';
+import { _constants, HeaderCell } from 'react-data-grid';
+const { DragItemTypes } = _constants;
 
 class DraggableHeaderCell extends React.Component {
   render() {
@@ -87,10 +88,10 @@ DraggableHeaderCell.propTypes = {
   canDrop: PropTypes.bool
 };
 
-DraggableHeaderCell = DropTarget('Column', target, targetCollect)(
+DraggableHeaderCell = DropTarget(DragItemTypes.Column, target, targetCollect)(
   DraggableHeaderCell
 );
-DraggableHeaderCell = DragSource('Column', headerCellSource, collect)(
+DraggableHeaderCell = DragSource(DragItemTypes.Column, headerCellSource, collect)(
   DraggableHeaderCell
 );
 


### PR DESCRIPTION
## Description
A data grid with a draggable header and a grouped columns panel in the toolbar cannot receive drop events for both, only one or the other.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
 
As reported in #1106, you are not able to create a component that supports drag-n-drop for both the DraggableHeader component and the GroupedColumnsPanel component. They have slightly different drop types, `"column"` vs `"Column"`.

**What is the new behavior?**
Changed the hard-coded `"Column"` type to the constant `DragItemTypes.Column` type which is the same type that the grouping panel uses.

Here is a gist with the "grouping" demo modified to allow column reordering https://gist.github.com/MrLeebo/b0df98cffacd3a3e52c8258d09a6a187

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

Potentially breaking, though I think it is low risk. If a user has supplemented the "Draggable Header" demo with their own custom DropSource, they will need to change the type from `"Column"` to the constant `DragItemTypes.Column`.

**Other information**:

This may be a bit of a rant, if you'll indulge me. Even with this change, I personally found it incredibly difficult to get these two features to work together. The gist I posted has a lot of weird hacks and "gotchas" that I had to overcome.

https://gist.github.com/MrLeebo/b0df98cffacd3a3e52c8258d09a6a187

1) Changing the `columns` prop does not appear to trigger a re-render of the grid, so after you re-order, the columns stay in their original order until something else refreshes it.
2) The old demo would set the `this.state.columns` to an empty array and then immediately set it to the new array, but this solution breaks the grouping feature.
3) I modified the dragged column by giving it a `draggedOn: new Date()` property to force the equality check. That causes the UI to refresh.
4) The drop event causes both event handlers to fire. I'm not very familiar with drag and drop, so I don't know if there's a better way to distinguish which event handler was intended to fire.