### PR TITLE
[Small Feature]Header should had it own class

### DIFF
--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -109,7 +109,7 @@ class HeaderCell extends React.Component {
       'react-grid-HeaderCell--resizing': this.state.resizing,
       'react-grid-HeaderCell--locked': this.props.column.locked
     });
-    className = joinClasses(className, this.props.className, this.props.column.cellClass);
+    className = joinClasses(className, this.props.className, this.props.column.headerClass);
     let cell = this.getCell();
     return (
       <div className={className} style={this.getStyle()}>


### PR DESCRIPTION
Header should had it own class, headerClass
Body had it own class, cellClass
This allow more customization for header

## Description
A few sentences describing the overall goals of the pull request's commits.
A very simple change to split the css between header and body 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Header cell sharing css with body css thorugh cellClass


**What is the new behavior?**
Header contain it own css class


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: