### PR TITLE
Fix Allow Other Backends for DraggableContainer (#920)

### DIFF
--- a/packages/react-data-grid-addons/src/draggable-header/DraggableContainer.js
+++ b/packages/react-data-grid-addons/src/draggable-header/DraggableContainer.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import html5DragDropContext from '../shared/html5DragDropContext';
 import DraggableHeaderCell from './DraggableHeaderCell';
+import { DragDropContextProvider } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 
-class DraggableContainer extends React.Component {
+export default class DraggableContainer extends React.Component {
   renderGrid() {
     return React.Children.map(this.props.children, child => {
       return React.cloneElement(child, {
@@ -14,7 +15,16 @@ class DraggableContainer extends React.Component {
 
   render() {
     let grid = this.renderGrid();
-    return (
+    // Test if a react-dnd context already exists
+    // higher up the component tree. If not, insert
+    // a react-dnd DragDropContextProvider to serve as context
+    const addContextIfNeeded = component =>
+      this.context.dragDropManager
+        ? component
+        : <DragDropContextProvider backend={HTML5Backend}>
+          {component}
+        </DragDropContextProvider>;
+    return addContextIfNeeded(
       <div>
         {React.cloneElement(grid, this.props)}
       </div>
@@ -26,4 +36,6 @@ DraggableContainer.propTypes = {
   children: PropTypes.element
 };
 
-export default html5DragDropContext(DraggableContainer);
+DraggableContainer.contextTypes = {
+  dragDropManager: PropTypes.object
+};

--- a/packages/react-data-grid-addons/src/draggable-header/__tests__/DraggableContainer.spec.js
+++ b/packages/react-data-grid-addons/src/draggable-header/__tests__/DraggableContainer.spec.js
@@ -1,12 +1,26 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import TestBackend from 'react-dnd-test-backend';
+import { DragDropContextProvider } from 'react-dnd';
 
 import DraggableContainer from '../DraggableContainer';
 import ReactDataGrid from 'react-data-grid';
 
 describe('<DraggableContainer />', () => {
-  it('should render grid wrapper to be used as Drag and Drop context with grid as a child component inside', () => {
-    const wrapper = shallow(<DraggableContainer />);
-    expect(wrapper.find(ReactDataGrid));
+  it('should render grid directly if a react-dnd context is already set in the react context', () => {
+    const wrapper = shallow(<DragDropContextProvider backend={TestBackend}>
+      <DraggableContainer>
+        <ReactDataGrid />
+      </DraggableContainer>
+    </DragDropContextProvider>);
+    const container = wrapper.find(DraggableContainer);
+    expect(container.length).toEqual(1);
+    const grid = container.find(ReactDataGrid);
+    expect(grid.length).toEqual(1);
+  });
+  it('should wrap grid in a DragDropContextProvider to assign a react-dnd context to the react context if none is already set', () => {
+    const wrapper = shallow(<DraggableContainer><ReactDataGrid /></DraggableContainer>);
+    const context = wrapper.find(DragDropContextProvider);
+    expect(context.length).toEqual(1);
   });
 });


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Presently, DraggableContainer always creates a React-dnd context when used, regardless of whether such a context has already been created by another component higher in the component tree. Indeed, the DraggableContainer class is wrapped in a React-dnd DragDropContext(HTML5Backend)(DraggableContainer) HOC before being exported. If another component in the same app also uses React-dnd, or if two ReactDataGrids are used in the same app, an error will occur at HTML5Backend initialization time ('Cannot have two HTML5 backends at the same time') causing the app the fail.

**What is the new behavior?**
The fix tests whether a React-dnd context is already there when rendering the DraggableContainer (to do that it checks if the 'dragDropManager' react context property). If not, it inserts a DragDropContextProvider. This way, existing code should not break, because of the DragDropContextProvider which replaces the previous DragDropContext(HTML5Backend). And code which mixes react-data-grid with another React-dnd-enabled component should work provided they both live under the umbrella of a DragDropContextProvider defined as a common ancestor of these components.



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
