### PR TITLE
Hold to display context issue fixed #1197

### DIFF
--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -45,6 +45,7 @@ class Canvas extends React.Component {
     rowScrollTimeout: PropTypes.number,
     scrollToRowIndex: PropTypes.number,
     contextMenu: PropTypes.element,
+    holdToDisplayContext: PropTypes.number,
     getSubRowDetails: PropTypes.func,
     rowSelection: PropTypes.oneOfType([
       PropTypes.shape({
@@ -358,7 +359,8 @@ class Canvas extends React.Component {
           rows={rows}
           contextMenu={this.props.contextMenu}
           rowIdx={this.props.cellMetaData.selected.rowIdx}
-          idx={this.props.cellMetaData.selected.idx} />
+          idx={this.props.cellMetaData.selected.idx} 
+          holdToDisplayContext={this.props.holdToDisplayContext} />
       </div>
     );
   }

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -55,6 +55,7 @@ class Grid extends React.Component {
     rowScrollTimeout: PropTypes.number,
     scrollToRowIndex: PropTypes.number,
     contextMenu: PropTypes.element,
+    holdToDisplayContext: PropTypes.number,
     getSubRowDetails: PropTypes.func,
     draggableHeaderCell: PropTypes.func,
     getValidFilterValues: PropTypes.func,
@@ -173,6 +174,7 @@ class Grid extends React.Component {
                   rowScrollTimeout={this.props.rowScrollTimeout}
                   scrollToRowIndex={this.props.scrollToRowIndex}
                   contextMenu={this.props.contextMenu}
+                  holdToDisplayContext={this.props.holdToDisplayContext}
                   rowSelection={this.props.rowSelection}
                   getSubRowDetails={this.props.getSubRowDetails}
                   rowGroupRenderer={this.props.rowGroupRenderer}

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -79,6 +79,7 @@ class ReactDataGrid extends React.Component {
     scrollToRowIndex: PropTypes.number,
     onClearFilters: PropTypes.func,
     contextMenu: PropTypes.element,
+    holdToDisplayContext: PropTypes.number,
     cellNavigationMode: PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
     onCellSelected: PropTypes.func,
     onCellDeSelected: PropTypes.func,
@@ -1261,6 +1262,7 @@ class ReactDataGrid extends React.Component {
             rowScrollTimeout={this.props.rowScrollTimeout}
             scrollToRowIndex={this.props.scrollToRowIndex}
             contextMenu={this.props.contextMenu}
+            holdToDisplayContext={this.props.holdToDisplayContext}
             overScan={this.props.overScan} />
           </div>
         </div>

--- a/packages/react-data-grid/src/RowsContainer.js
+++ b/packages/react-data-grid/src/RowsContainer.js
@@ -35,9 +35,10 @@ class RowsContainer extends React.Component {
     const newProps = getNewContextMenuProps(this.props);
     const contextMenu = React.cloneElement(this.props.contextMenu, newProps);
     // Initialise the context menu if it is available
+    console.log('Context props are: ', this.props);
     return (
       <div>
-        <ContextMenuTrigger id={newProps.id}>
+        <ContextMenuTrigger id={newProps.id} holdToDisplay={this.props.holdToDisplayContext || -1}>
           <SimpleRowsContainer {...this.props} />
         </ContextMenuTrigger>
         {contextMenu}
@@ -57,6 +58,7 @@ class RowsContainer extends React.Component {
 
 RowsContainer.propTypes = {
   contextMenu: PropTypes.element,
+  holdToDisplayContext: PropTypes.number,
   rowIdx: PropTypes.number,
   idx: PropTypes.number,
   window: PropTypes.object

--- a/packages/react-data-grid/src/RowsContainer.js
+++ b/packages/react-data-grid/src/RowsContainer.js
@@ -35,7 +35,6 @@ class RowsContainer extends React.Component {
     const newProps = getNewContextMenuProps(this.props);
     const contextMenu = React.cloneElement(this.props.contextMenu, newProps);
     // Initialise the context menu if it is available
-    console.log('Context props are: ', this.props);
     return (
       <div>
         <ContextMenuTrigger id={newProps.id} holdToDisplay={this.props.holdToDisplayContext || -1}>

--- a/packages/react-data-grid/src/RowsContainer.js
+++ b/packages/react-data-grid/src/RowsContainer.js
@@ -37,7 +37,7 @@ class RowsContainer extends React.Component {
     // Initialise the context menu if it is available
     return (
       <div>
-        <ContextMenuTrigger id={newProps.id} holdToDisplay={this.props.holdToDisplayContext || -1}>
+        <ContextMenuTrigger id={newProps.id} holdToDisplay={this.props.holdToDisplayContext || 1000}>
           <SimpleRowsContainer {...this.props} />
         </ContextMenuTrigger>
         {contextMenu}

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -43,6 +43,7 @@ class Viewport extends React.Component {
     rowScrollTimeout: PropTypes.number,
     scrollToRowIndex: PropTypes.number,
     contextMenu: PropTypes.element,
+    holdToDisplayContext: PropTypes.number,
     getSubRowDetails: PropTypes.func,
     rowGroupRenderer: PropTypes.func
   };
@@ -230,6 +231,7 @@ class Viewport extends React.Component {
           rowScrollTimeout={this.props.rowScrollTimeout}
           scrollToRowIndex={this.props.scrollToRowIndex}
           contextMenu={this.props.contextMenu}
+          holdToDisplayContext={this.props.holdToDisplayContext}
           rowSelection={this.props.rowSelection}
           getSubRowDetails={this.props.getSubRowDetails}
           rowGroupRenderer={this.props.rowGroupRenderer}


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

See issue #1197 for detail of this fix.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#1197 


**What is the new behavior?**
The user can now specify a holdToDisplayContext prop in ReactDataGrid which will take a millisecond count for how long a left click must be to bring up context menu. Default is 1000, set to -1 if you wish to disable this functionality.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
