### PR TITLE
Rectangular selection range support (on top of 'next')

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example30-selection-range-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example30-selection-range-events.js
@@ -74,9 +74,11 @@ class Example extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onCellRangeSelectionStarted={this.onStart}
-          onCellRangeSelectionUpdated={this.onUpdate}
-          onCellRangeSelectionCompleted={this.onComplete}
+          cellRangeSelection={{
+            onStart: this.onStart,
+            onUpdate: this.onUpdate,
+            onComplete: this.onComplete
+          }}
         />
       </div>
     );
@@ -85,11 +87,11 @@ class Example extends React.Component {
 
 const exampleDescription = (
   <div>
-    <h4>onCellRangeSelectionStarted</h4>
+    <h4>cellRangeSelection.onStart</h4>
     <p>Called on mousedown on a cell. Receives <code>selectedRange</code> (containing <code>topLeft</code> and <code>topRight</code>) as an argument.</p>
-    <h4>onCellRangeSelectionUpdated</h4>
+    <h4>cellRangeSelection.onUpdate</h4>
     <p>Called on mouseover on a cell when dragging with the mouse, or when pressing shift+arrowkey. Receives <code>selectedRange</code> (containing <code>topLeft</code> and <code>topRight</code>) as an argument.</p>
-    <h4>onCellRangeSelectionCompleted</h4>
+    <h4>cellRangeSelection.onComplete</h4>
     <p>Called on mouseup (anywhere) when dragging with the mouse, or when pressing shift+arrowkey.</p>
     <p>Note: altering the selected range with shift+arrowkey will fire both an Updated and Completed event with each keystroke.</p>
     <h4>Example</h4>

--- a/packages/react-data-grid-examples/src/scripts/example30-selection-range-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example30-selection-range-events.js
@@ -1,0 +1,106 @@
+const ReactDataGrid = require('react-data-grid');
+const exampleWrapper = require('../components/exampleWrapper');
+const React = require('react');
+
+class Example extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this._columns = [
+      {
+        key: 'id',
+        name: 'ID'
+      },
+      {
+        key: 'title',
+        name: 'Title'
+      },
+      {
+        key: 'count',
+        name: 'Count'
+      }
+    ];
+
+    this.state = { rows: this.createRows(1000) };
+  }
+
+  createRows = () => {
+    let rows = [];
+    for (let i = 1; i < 1000; i++) {
+      rows.push({
+        id: i,
+        title: 'Title ' + i,
+        count: i * 1000,
+        isSelected: false
+      });
+    }
+
+    return rows;
+  };
+
+  rowGetter = (i) => {
+    return this.state.rows[i];
+  };
+
+  onStart = (selectedRange) => {
+    this.textarea.value += 'START: ' +
+      `(${selectedRange.topLeft.idx}, ${selectedRange.topLeft.rowIdx}) -> ` +
+      `(${selectedRange.bottomRight.idx}, ${selectedRange.bottomRight.rowIdx})\n`;
+    this.textarea.scrollTop = this.textarea.scrollHeight;
+  };
+
+  onUpdate = (selectedRange) => {
+    this.textarea.value += 'UPDATE: ' +
+      `(${selectedRange.topLeft.idx}, ${selectedRange.topLeft.rowIdx}) -> ` +
+      `(${selectedRange.bottomRight.idx}, ${selectedRange.bottomRight.rowIdx})\n`;
+    this.textarea.scrollTop = this.textarea.scrollHeight;
+  };
+
+  onComplete = () => {
+    this.textarea.value += 'END\n';
+    this.textarea.scrollTop = this.textarea.scrollHeight;
+  };
+
+  render() {
+    return  (
+      <div>
+        <textarea
+          ref={(element) => this.textarea = element}
+          style={{width: '100%', marginBottom: '1em', padding: '0.5em', border: '1px solid black' }}
+          rows={5}
+        />
+        <ReactDataGrid
+          rowKey="id"
+          columns={this._columns}
+          rowGetter={this.rowGetter}
+          rowsCount={this.state.rows.length}
+          minHeight={500}
+          onCellRangeSelectionStarted={this.onStart}
+          onCellRangeSelectionUpdated={this.onUpdate}
+          onCellRangeSelectionCompleted={this.onComplete}
+        />
+      </div>
+    );
+  }
+}
+
+const exampleDescription = (
+  <div>
+    <h4>onCellRangeSelectionStarted</h4>
+    <p>Called on mousedown on a cell. Receives <code>selectedRange</code> (containing <code>topLeft</code> and <code>topRight</code>) as an argument.</p>
+    <h4>onCellRangeSelectionUpdated</h4>
+    <p>Called on mouseover on a cell when dragging with the mouse, or when pressing shift+arrowkey. Receives <code>selectedRange</code> (containing <code>topLeft</code> and <code>topRight</code>) as an argument.</p>
+    <h4>onCellRangeSelectionCompleted</h4>
+    <p>Called on mouseup (anywhere) when dragging with the mouse, or when pressing shift+arrowkey.</p>
+    <p>Note: altering the selected range with shift+arrowkey will fire both an Updated and Completed event with each keystroke.</p>
+    <h4>Example</h4>
+    <p>The example below uses these events to record a log of selection range activity (via both cursor and keyboard) into the textarea.</p>
+  </div>
+);
+
+module.exports = exampleWrapper({
+  WrappedComponent: Example,
+  exampleName: 'Selection Range Events',
+  exampleDescription,
+  examplePath: './scripts/example30-selection-range-events.js'
+  // TODO: add examplePlaygroundLink (once selection ranges are supported in the published version of RDG, so available in JSFiddle)
+});

--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -72,6 +72,9 @@ class Canvas extends React.Component {
     onDragHandleDoubleClick: PropTypes.func.isRequired,
     onCellSelected: PropTypes.func,
     onCellDeSelected: PropTypes.func,
+    onCellRangeSelectionStarted: PropTypes.func,
+    onCellRangeSelectionUpdated: PropTypes.func,
+    onCellRangeSelectionCompleted: PropTypes.func,
     onCommit: PropTypes.func.isRequired
   };
 
@@ -380,6 +383,9 @@ class Canvas extends React.Component {
             onBeforeFocus={this.onFocusInteractionMask}
             onCellSelected={this.props.onCellSelected}
             onCellDeSelected={this.props.onCellDeSelected}
+            onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
+            onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
+            onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
             scrollLeft={this._scroll.scrollLeft}
           />
           <RowsContainer

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -73,6 +73,20 @@ class Cell extends React.Component {
     }
   };
 
+  onCellMouseDown = () => {
+    const { idx, rowIdx, cellMetaData } = this.props;
+    if (isFunction(cellMetaData.onCellMouseDown)) {
+      cellMetaData.onCellMouseDown({ idx, rowIdx });
+    }
+  };
+
+  onCellMouseEnter = () => {
+    const { idx, rowIdx, cellMetaData } = this.props;
+    if (isFunction(cellMetaData.onCellMouseEnter)) {
+      cellMetaData.onCellMouseEnter({ idx, rowIdx });
+    }
+  };
+
   onCellContextMenu = () => {
     const { idx, rowIdx, cellMetaData } = this.props;
     if (isFunction(cellMetaData.onCellContextMenu)) {
@@ -226,6 +240,8 @@ class Cell extends React.Component {
     let onColumnEvent = this.props.cellMetaData ? this.props.cellMetaData.onColumnEvent : undefined;
     let gridEvents = {
       onClick: this.onCellClick,
+      onMouseDown: this.onCellMouseDown,
+      onMouseEnter: this.onCellMouseEnter,
       onDoubleClick: this.onCellDoubleClick,
       onContextMenu: this.onCellContextMenu,
       onDragOver: this.onDragOver

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -64,6 +64,9 @@ class Grid extends React.Component {
     onDragHandleDoubleClick: PropTypes.func.isRequired,
     onCellSelected: PropTypes.func,
     onCellDeSelected: PropTypes.func,
+    onCellRangeSelectionStarted: PropTypes.func,
+    onCellRangeSelectionUpdated: PropTypes.func,
+    onCellRangeSelectionCompleted: PropTypes.func,
     onCommit: PropTypes.func.isRequired
   };
 
@@ -196,6 +199,9 @@ class Grid extends React.Component {
                   onDragHandleDoubleClick={this.props.onDragHandleDoubleClick}
                   onCellSelected={this.props.onCellSelected}
                   onCellDeSelected={this.props.onCellDeSelected}
+                  onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
+                  onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
+                  onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
                   onCommit={this.props.onCommit}
                 />
             </div>

--- a/packages/react-data-grid/src/PropTypeShapes/CellMetaDataShape.js
+++ b/packages/react-data-grid/src/PropTypeShapes/CellMetaDataShape.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 module.exports = {
   rowKey: PropTypes.string.isRequired,
   onCellClick: PropTypes.func.isRequired,
+  onCellMouseDown: PropTypes.func.isRequired,
+  onCellMouseEnter: PropTypes.func.isRequired,
   onCellContextMenu: PropTypes.func.isRequired,
   onCellDoubleClick: PropTypes.func.isRequired,
   onDragEnter: PropTypes.func.isRequired,

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -55,6 +55,9 @@ class ReactDataGrid extends React.Component {
     cellNavigationMode: PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
     onCellSelected: PropTypes.func,
     onCellDeSelected: PropTypes.func,
+    onCellRangeSelectionStarted: PropTypes.func,
+    onCellRangeSelectionUpdated: PropTypes.func,
+    onCellRangeSelectionCompleted: PropTypes.func,
     onCellExpand: PropTypes.func,
     enableDragAndDrop: PropTypes.bool,
     onRowExpandToggle: PropTypes.func,
@@ -137,12 +140,14 @@ class ReactDataGrid extends React.Component {
   componentDidMount() {
     this._mounted = true;
     window.addEventListener('resize', this.metricsUpdated);
+    window.addEventListener('mouseup', this.onWindowMouseUp);
     this.metricsUpdated();
   }
 
   componentWillUnmount() {
     this._mounted = false;
     window.removeEventListener('resize', this.metricsUpdated);
+    window.removeEventListener('mouseup', this.onWindowMouseUp);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -157,6 +162,18 @@ class ReactDataGrid extends React.Component {
 
   selectCell = ({ idx, rowIdx }, openEditor) => {
     this.eventBus.dispatch(EventTypes.SELECT_CELL, { rowIdx, idx }, openEditor);
+  };
+
+  selectStart = (cellPosition) => {
+    this.eventBus.dispatch(EventTypes.SELECT_START, cellPosition);
+  };
+
+  selectUpdate = (cellPosition) => {
+    this.eventBus.dispatch(EventTypes.SELECT_UPDATE, cellPosition);
+  };
+
+  selectEnd = () => {
+    this.eventBus.dispatch(EventTypes.SELECT_END);
   };
 
   handleDragEnter = ({ overRowIdx }) => {
@@ -273,6 +290,18 @@ class ReactDataGrid extends React.Component {
     if (isFunction(onRowClick)) {
       onRowClick(rowIdx, rowGetter(rowIdx), this.getColumn(idx));
     }
+  };
+
+  onCellMouseDown = (cellPosition) => {
+    this.selectStart(cellPosition);
+  };
+
+  onCellMouseEnter = (cellPosition) => {
+    this.selectUpdate(cellPosition);
+  };
+
+  onWindowMouseUp = () => {
+    this.selectEnd();
   };
 
   onCellContextMenu = ({ rowIdx, idx }) => {
@@ -613,6 +642,8 @@ class ReactDataGrid extends React.Component {
     const cellMetaData = {
       rowKey: this.props.rowKey,
       onCellClick: this.onCellClick,
+      onCellMouseDown: this.onCellMouseDown,
+      onCellMouseEnter: this.onCellMouseEnter,
       onCellContextMenu: this.onCellContextMenu,
       onCellDoubleClick: this.onCellDoubleClick,
       onColumnEvent: this.onColumnEvent,
@@ -678,6 +709,9 @@ class ReactDataGrid extends React.Component {
             onDragHandleDoubleClick={this.onDragHandleDoubleClick}
             onCellSelected={this.props.onCellSelected}
             onCellDeSelected={this.props.onCellDeSelected}
+            onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
+            onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
+            onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
             onCommit={this.onCommit}
           />
         </div>

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -55,9 +55,11 @@ class ReactDataGrid extends React.Component {
     cellNavigationMode: PropTypes.oneOf(['none', 'loopOverRow', 'changeRow']),
     onCellSelected: PropTypes.func,
     onCellDeSelected: PropTypes.func,
-    onCellRangeSelectionStarted: PropTypes.func,
-    onCellRangeSelectionUpdated: PropTypes.func,
-    onCellRangeSelectionCompleted: PropTypes.func,
+    cellRangeSelection: PropTypes.shape({
+      onStart: PropTypes.func,
+      onUpdate: PropTypes.func,
+      onComplete: PropTypes.func
+    }),
     onCellExpand: PropTypes.func,
     enableDragAndDrop: PropTypes.bool,
     onRowExpandToggle: PropTypes.func,
@@ -709,9 +711,9 @@ class ReactDataGrid extends React.Component {
             onDragHandleDoubleClick={this.onDragHandleDoubleClick}
             onCellSelected={this.props.onCellSelected}
             onCellDeSelected={this.props.onCellDeSelected}
-            onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
-            onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
-            onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
+            onCellRangeSelectionStarted={this.props.cellRangeSelection && this.props.cellRangeSelection.onStart}
+            onCellRangeSelectionUpdated={this.props.cellRangeSelection && this.props.cellRangeSelection.onUpdate}
+            onCellRangeSelectionCompleted={this.props.cellRangeSelection && this.props.cellRangeSelection.onComplete}
             onCommit={this.onCommit}
           />
         </div>

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -55,6 +55,9 @@ class Viewport extends React.Component {
     onDragHandleDoubleClick: PropTypes.func.isRequired,
     onCellSelected: PropTypes.func,
     onCellDeSelected: PropTypes.func,
+    onCellRangeSelectionStarted: PropTypes.func,
+    onCellRangeSelectionUpdated: PropTypes.func,
+    onCellRangeSelectionCompleted: PropTypes.func,
     onCommit: PropTypes.func.isRequired
   };
 
@@ -258,6 +261,9 @@ class Viewport extends React.Component {
           onDragHandleDoubleClick={this.props.onDragHandleDoubleClick}
           onCellSelected={this.props.onCellSelected}
           onCellDeSelected={this.props.onCellDeSelected}
+          onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
+          onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
+          onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
           onCommit={this.props.onCommit}
         />
       </div>

--- a/packages/react-data-grid/src/constants/EventTypes.js
+++ b/packages/react-data-grid/src/constants/EventTypes.js
@@ -1,3 +1,6 @@
 export const SELECT_CELL = 'SELECT_CELL';
+export const SELECT_START = 'SELECT_START';
+export const SELECT_UPDATE = 'SELECT_UPDATE';
+export const SELECT_END = 'SELECT_END';
 export const DRAG_ENTER = 'DRAG_ENTER';
 export const SCROLL_TO_COLUMN = 'SCROLL_TO_COLUMN';

--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -558,31 +558,52 @@ class InteractionMasks extends React.Component {
     this.closeEditor();
   };
 
+  getSingleCellSelectView = (rowData) => {
+    const { rowHeight, columns } = this.props;
+    const { selectedPosition } = this.state;
+
+    return (
+      !this.state.isEditorEnabled && this.isGridSelected() && (
+        <SelectionMask
+          selectedPosition={selectedPosition}
+          rowHeight={rowHeight}
+          columns={columns}
+          isGroupedRow={rowData && rowData.__metaData ? rowData.__metaData.isGroup : false}
+        >
+          {this.dragEnabled() && (
+            <DragHandle
+              onDragStart={this.handleDragStart}
+              onDragEnd={this.handleDragEnd}
+              onDoubleClick={this.onDragHandleDoubleClick}
+            />
+          )}
+        </SelectionMask>
+      )
+    );
+  };
+
+  getCellRangeSelectView = () => {
+    const { rowHeight, columns } = this.props;
+    return [
+      <SelectionRangeMask
+        key="range-mask"
+        selectedRange={this.state.selectedRange}
+        columns={columns}
+        rowHeight={rowHeight}
+      />,
+      <SelectionMask
+        key="selection-mask"
+        selectedPosition={this.state.selectedRange.startCell}
+        columns={columns}
+        rowHeight={rowHeight}
+      />
+    ];
+  };
+
   render() {
     const { rowHeight, rowGetter, columns, contextMenu } = this.props;
     const { isEditorEnabled, firstEditorKeyPress, selectedPosition, draggedPosition, copiedPosition } = this.state;
     const rowData = getSelectedRow({ selectedPosition, rowGetter });
-
-    const singleCellSelectViewProps = {
-      visible: !this.state.isEditorEnabled && this.isGridSelected(),
-      selectedPosition: this.state.selectedPosition,
-      rowHeight: this.props.rowHeight,
-      columns: this.props.columns,
-      rowData: rowData,
-      dragEnabled: this.dragEnabled(),
-      dragHandleEventHandlers: {
-        onDragStart: this.handleDragStart,
-        onDragEnd: this.handleDragEnd,
-        onDoubleClick: this.onDragHandleDoubleClick
-      }
-    };
-    const cellRangeSelectViewProps = {
-      selectedRange: this.state.selectedRange,
-      selectedPosition: this.state.selectedRange.startCell,
-      columns: this.props.columns,
-      rowHeight: this.props.rowHeight
-    };
-
     return (
       <div
         ref={node => {
@@ -607,8 +628,8 @@ class InteractionMasks extends React.Component {
           />
         )}
         {selectedRangeIsSingleCell(this.state.selectedRange) ?
-          <SingleCellSelectView {...singleCellSelectViewProps} /> :
-          <CellRangeSelectView {...cellRangeSelectViewProps} />
+          this.getSingleCellSelectView(rowData) :
+          this.getCellRangeSelectView()
         }
         {isEditorEnabled && <EditorContainer
           firstEditorKeyPress={firstEditorKeyPress}
@@ -625,58 +646,5 @@ class InteractionMasks extends React.Component {
     );
   }
 }
-
-export const SingleCellSelectView = (props) => {
-  return (
-    props.visible && (
-      <SelectionMask
-        selectedPosition={props.selectedPosition}
-        rowHeight={props.rowHeight}
-        columns={props.columns}
-        isGroupedRow={props.rowData && props.rowData.__metaData ? props.rowData.__metaData.isGroup : false}
-      >
-        {props.dragEnabled && (
-          <DragHandle {...props.dragHandleEventHandlers} />
-        )}
-      </SelectionMask>
-    )
-  );
-};
-SingleCellSelectView.propTypes = {
-  visible: PropTypes.bool.isRequired,
-  selectedPosition: PropTypes.object.isRequired,
-  rowHeight: PropTypes.number.isRequired,
-  columns: PropTypes.array.isRequired,
-  rowData: PropTypes.object.isRequired,
-  dragEnabled: PropTypes.bool.isRequired,
-  dragHandleEventHandlers: PropTypes.shape({
-    onDragStart: PropTypes.func.isRequired,
-    onDragEnd: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func.isRequired
-  }).isRequired
-};
-
-export const CellRangeSelectView = (props) => {
-  return [
-    <SelectionRangeMask
-      key="range-mask"
-      selectedRange={props.selectedRange}
-      columns={props.columns}
-      rowHeight={props.rowHeight}
-    />,
-    <SelectionMask
-      key="selection-mask"
-      selectedPosition={props.selectedPosition}
-      columns={props.columns}
-      rowHeight={props.rowHeight}
-    />
-  ];
-};
-CellRangeSelectView.propTypes = {
-  selectedRange: PropTypes.object.isRequired,
-  selectedPosition: PropTypes.object.isRequired,
-  columns: PropTypes.array.isRequired,
-  rowHeight: PropTypes.number.isRequired
-};
 
 export default InteractionMasks;

--- a/packages/react-data-grid/src/masks/SelectionRangeMask.js
+++ b/packages/react-data-grid/src/masks/SelectionRangeMask.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { getSelectedRangeDimensions } from '../utils/SelectedCellUtils';
+import CellMask from './CellMask';
+
+function SelectionRangeMask({ selectedRange, columns, rowHeight, children}) {
+  const dimensions = getSelectedRangeDimensions({ selectedRange, columns, rowHeight });
+  return (
+    <CellMask
+      {...dimensions}
+      className="rdg-selected-range"
+    >
+      {children}
+    </CellMask>
+  );
+}
+
+SelectionRangeMask.propTypes = {
+  selectedRange: PropTypes.shape({
+    topLeft: PropTypes.shape({ idx: PropTypes.number.isRequired, rowIdx: PropTypes.number.isRequired }).isRequired,
+    bottomRight: PropTypes.shape({ idx: PropTypes.number.isRequired, rowIdx: PropTypes.number.isRequired }).isRequired,
+    startCell: PropTypes.shape({ idx: PropTypes.number.isRequired, rowIdx: PropTypes.number.isRequired }).isRequired,
+    cursorCell: PropTypes.shape({ idx: PropTypes.number.isRequired, rowIdx: PropTypes.number.isRequired }).isRequired
+  }).isRequired,
+  columns: PropTypes.array.isRequired,
+  rowHeight: PropTypes.number.isRequired
+};
+
+export default SelectionRangeMask;

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.js
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-import InteractionMasks, { SingleCellSelectView, CellRangeSelectView } from '../InteractionMasks';
+import InteractionMasks from '../InteractionMasks';
 import SelectionMask from '../SelectionMask';
+import SelectionRangeMask from '../SelectionRangeMask';
 import CopyMask from '../CopyMask';
 import DragMask from '../DragMask';
 import DragHandle from '../DragHandle';
@@ -66,39 +67,33 @@ describe('<InteractionMasks/>', () => {
   describe('Rendered masks', () => {
     describe('When a single cell is selected', () => {
       describe('within grid bounds', () => {
-        it('should render a SingleCellSelectView component with visible true', () => {
+        it('should render a SelectionMask component', () => {
           const { wrapper } = setup({}, { selectedPosition: { idx: 0, rowIdx: 0 } });
-          expect(wrapper.find(SingleCellSelectView).length).toBe(1);
-          expect(wrapper.find(SingleCellSelectView).props().visible).toBeTruthy();
+          expect(wrapper.find(SelectionMask).length).toBe(1);
         });
       });
 
       describe('outside grid bounds', () => {
-        it('should not render a SingleCellSelectView component with visible false', () => {
+        it('should not render a SelectionMask component', () => {
           const { wrapper } = setup();
-          expect(wrapper.find(SingleCellSelectView).length).toBe(1);
-          expect(wrapper.find(SingleCellSelectView).props().visible).toBeFalsy();
+          expect(wrapper.find(SelectionMask).length).toBe(0);
         });
       });
     });
 
     describe('When a cell range is selected', () => {
-      it('should render a CellRangeSelectView component, passing relevant props', () => {
-        const range = {
-          startCell: { idx: 0, rowIdx: 0 },
-          topLeft: { idx: 0, rowIdx: 0 },
-          bottomRight: { idx: 1, rowIdx: 1 }
-        };
+      it('should render a SelectionRangeMask component', () => {
         const { wrapper } = setup({}, {
           selectedPosition: { idx: 0, rowIdx: 0 },
-          selectedRange: range
+          selectedRange: {
+            topLeft: { idx: 0, rowIdx: 0 },
+            bottomRight: { idx: 1, rowIdx: 1 }
+          }
         });
-        expect(wrapper.find(CellRangeSelectView).length).toBe(1);
-        expect(wrapper.find(CellRangeSelectView).props().selectedPosition).toEqual({ idx: 0, rowIdx: 0 });
-        expect(wrapper.find(CellRangeSelectView).props().selectedRange).toEqual(range);
+        expect(wrapper.find(SelectionRangeMask).length).toBe(1);
       });
 
-      it('should render a CellRangeSelectView component on the range\'s start cell', () => {
+      it('should render a SelectionMask component on the range\'s start cell', () => {
         const { wrapper } = setup({}, {
           selectedPosition: { idx: 0, rowIdx: 0 },
           selectedRange: {
@@ -107,8 +102,8 @@ describe('<InteractionMasks/>', () => {
             startCell: { idx: 0, rowIdx: 0 }
           }
         });
-        expect(wrapper.find(CellRangeSelectView).length).toBe(1);
-        expect(wrapper.find(CellRangeSelectView).props().selectedPosition).toEqual({ idx: 0, rowIdx: 0 });
+        expect(wrapper.find(SelectionMask).length).toBe(1);
+        expect(wrapper.find(SelectionMask).props().selectedPosition).toEqual({ idx: 0, rowIdx: 0 });
       });
     });
   });
@@ -740,12 +735,10 @@ describe('<InteractionMasks/>', () => {
     it('should render the DragMask component on cell drag', () => {
       const { wrapper } = setupDrag();
       const setData = jasmine.createSpy();
-      const dragHandlers = wrapper.find(SingleCellSelectView).props().dragHandleEventHandlers;
-      dragHandlers.onDragStart({
+      wrapper.find(DragHandle).simulate('dragstart', {
         target: { className: 'test' },
         dataTransfer: { setData }
       });
-      wrapper.update();
 
       expect(wrapper.find(DragMask).length).toBe(1);
       expect(setData).toHaveBeenCalled();
@@ -754,14 +747,12 @@ describe('<InteractionMasks/>', () => {
     it('should update the dragged over cells on drag end', () => {
       const { wrapper, props } = setupDrag();
       const setData = jasmine.createSpy();
-      const dragHandlers = wrapper.find(SingleCellSelectView).props().dragHandleEventHandlers;
-      dragHandlers.onDragStart({
+      wrapper.find(DragHandle).simulate('dragstart', {
         target: { className: 'test' },
         dataTransfer: { setData }
       });
       props.eventBus.dispatch(EventTypes.DRAG_ENTER, { overRowIdx: 6 });
-      dragHandlers.onDragEnd();
-      wrapper.update();
+      wrapper.find(DragHandle).simulate('dragEnd');
 
       expect(props.onGridRowsUpdated).toHaveBeenCalledWith('Column1', 2, 6, { Column1: '3' }, AppConstants.UpdateActions.CELL_DRAG);
     });
@@ -774,50 +765,6 @@ describe('<InteractionMasks/>', () => {
 
       expect(wrapper.find(sel('context-menu')).props())
         .toEqual(jasmine.objectContaining({ idx: 1, rowIdx: 2 }));
-    });
-  });
-});
-
-describe('SingleCellSelectView', () => {
-  const setup = (overrideProps, render = shallow) => {
-    const props = {
-      visible: true,
-      selectedPosition: { idx: 0, rowIdx: 0 },
-      rowHeight: 10,
-      columns: [],
-      rowData: { __meta: { isGroup: false } },
-      dragEnabled: true,
-      ...overrideProps
-    };
-    const wrapper = render(<SingleCellSelectView {...props} />, { disableLifecycleMethods: false });
-    return { wrapper, props };
-  };
-
-  describe('with visible true', () => {
-    it('displays a SelectionMask', () => {
-      const { wrapper } = setup({ visible: true });
-      expect(wrapper.find(SelectionMask).length).toBe(1);
-    });
-  });
-
-  describe('with visible false', () => {
-    it('displays a SelectionMask', () => {
-      const { wrapper } = setup({ visible: false });
-      expect(wrapper.find(SelectionMask).length).toBe(0);
-    });
-  });
-
-  describe('with drag enabled', () => {
-    it('displays the DragHandle', () => {
-      const { wrapper } = setup({ dragEnabled: true });
-      expect(wrapper.find(DragHandle).length).toBe(1);
-    });
-  });
-
-  describe('with drag disabled', () => {
-    it('does not display the DragHandle', () => {
-      const { wrapper } = setup({ dragEnabled: false });
-      expect(wrapper.find(DragHandle).length).toBe(0);
     });
   });
 });

--- a/packages/react-data-grid/src/masks/__tests__/SelectionRangeMask.spec.js
+++ b/packages/react-data-grid/src/masks/__tests__/SelectionRangeMask.spec.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import CellMask from '../CellMask';
+import SelectionRangeMask from '../SelectionRangeMask';
+
+describe('SelectionRangeMask', () => {
+  const setup = (propsOverride = {}) => {
+    const props = {
+      selectedRange: {
+        topLeft: { idx: 0, rowIdx: 3 },
+        bottomRight: { idx: 1, rowIdx: 4 },
+        startCell: { idx: 0, rowIdx: 3 },
+        cursorCell: { idx: 1, rowIdx: 4 }
+      },
+      columns: [
+        { width: 50, left: 5 },
+        { width: 40, left: 55 }
+      ],
+      rowHeight: 30,
+      isGroupedRow: false,
+      scrollLeft: 0,
+      ...propsOverride
+    };
+
+    const wrapper = shallow(<SelectionRangeMask {...props} />);
+    return wrapper.find(CellMask);
+  };
+
+  it('should render the CellMask component with correct position for the selected cells (topLeft->bottomRight)', () => {
+    const mask = setup();
+
+    expect(mask.props()).toEqual(
+      jasmine.objectContaining({
+        height: 60, // = rowHeight * 2
+        width: 90, // = columns[0].width + columns[1].width
+        left: 5, // = left of leftmost column
+        top: 90, // = rowHeight * rowIdx of topmost column
+        zIndex: 1
+      })
+    );
+  });
+});

--- a/packages/react-data-grid/src/utils/SelectedCellUtils.js
+++ b/packages/react-data-grid/src/utils/SelectedCellUtils.js
@@ -22,6 +22,32 @@ export const getSelectedDimensions = ({ selectedPosition, columns, rowHeight }) 
   return { width: 0, left: 0, top: 0, height: rowHeight, zIndex: 1 };
 };
 
+const getColumnRangeProperties = (from, to, columns) => {
+  let totalWidth = 0;
+  let anyColLocked = false;
+  for (let i = from; i <= to; i++) {
+    const column = columnUtils.getColumn(columns, i);
+    totalWidth += column.width;
+    anyColLocked = anyColLocked || column.locked;
+  }
+  return { totalWidth, anyColLocked, left: columnUtils.getColumn(columns, from).left };
+};
+
+export const getSelectedRangeDimensions = ({ selectedRange, columns, rowHeight }) => {
+  const { topLeft, bottomRight } = selectedRange;
+
+  if (topLeft.idx < 0) {
+    return { width: 0, left: 0, top: 0, height: rowHeight, zIndex: 1 };
+  }
+
+  const { totalWidth, anyColLocked, left } = getColumnRangeProperties(topLeft.idx, bottomRight.idx, columns);
+  const top = getRowTop(topLeft.rowIdx, rowHeight);
+  const height = (bottomRight.rowIdx - topLeft.rowIdx + 1) * rowHeight;
+  const zIndex = anyColLocked ? 2 : 1;
+
+  return { width: totalWidth, left, top, height, zIndex };
+};
+
 export const getSelectedColumn = ({ selectedPosition, columns }) => {
   const { idx } = selectedPosition;
   return columnUtils.getColumn(columns, idx);
@@ -101,4 +127,9 @@ export function canExitGrid(e, { cellNavigationMode, columns, rowsCount, selecte
   }
 
   return false;
+}
+
+export function selectedRangeIsSingleCell(selectedRange) {
+  return selectedRange.topLeft.idx === selectedRange.bottomRight.idx &&
+    selectedRange.topLeft.rowIdx === selectedRange.bottomRight.rowIdx;
 }

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -10,6 +10,11 @@
   border: 2px solid #66afe9;
 }
 
+.rdg-selected-range {
+  border: 1px solid #66afe9;
+  background-color: #66afe930;
+}
+
 .moving-element {
   will-change: transform;
 }

--- a/themes/react-data-grid-core.css
+++ b/themes/react-data-grid-core.css
@@ -15,6 +15,12 @@
 .react-grid-Grid {
   background-color: #ffffff;
   border: 1px solid #dddddd;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .react-grid-Canvas {


### PR DESCRIPTION
## Description
Now that #1123 is complete, I've taken another run at resolving my feature request in #1133 - this PR obsoletes #1158.

This PR adds the ability to select (rectangular) ranges of cells, rather than just a single cell at a time. Both cursor (click and drag) and keyboard (shift + arrow keys) are supported.

I've also added a new example to demonstrate responding to range selection events from a parent component of a ReactDataGrid.

**Please check if the PR fulfills these requirements**
```
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```

I have added a new example page, but I'm not sure if that's sufficient - do I need to update some documentation (e.g. the markdowns in react-data-grid-examples/src/docs)? If so, how are they generated?

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Clicking & dragging selects the text in the cells / shift+arrows just moves the selected cell.


**What is the new behavior?**
(The below text is similar to, but different from, the text of my old PR.)

Clicking & dragging selects a rectangular range, with the selected/"cursor" cell following the mouse. The range is displayed with a thin border; the selected cell retains a (slightly thicker) border. When the range is greater than 1x1, the selected cells also have a semi-transparent overlay. Text in the grid is no longer selectable except when editing content (in modern browsers; this behaviour won't be supported by IE9 or lower).

The selected range can also be manipulated by holding shift and using the arrow keys. (An existing range is updated by keeping the same start point and moving the "cursor" cell.)

New callbacks (onCellRangeSelectionStarted, onCellRangeSelectionUpdated, and onCellRangeSelectionCompleted) are called (if they're present) when starting a drag, moving whilst dragging, and ending a drag. Modifying the range via the keyboard calls only the latter two callbacks.

There were a few questions I asked in #1133. I've taken the below approaches:

- Text selection is prevented in browsers other than IE9 and below. For now, I'm just assuming that's okay, and that this project doesn't support IE9 or lower; I can't see anything official on what's supported, but shout if that's not true.
- onViewportDoubleClick doesn't exist (except for outdated docs and specs) on next; it did on master.
- onViewportClick has also been removed on next.
- Deselecting in general seems to behave slightly differently on next, so I think my original comments on onCellDeSelect aren't relevant anymore.
- This feature is always on - i.e. I haven't provided any setting to disable it. (I haven't looked into the behaviour of enableCellSelect on next.)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
As before, I think the closest thing to a breaking change is that text isn't selectable any more.

**Other information**:

My previous PR had a first commit that refactored some tests (because without that refactoring, I couldn't get them to run reliably). I haven't needed them this time around, but I did rebase them, so I can easily put up another PR to add them to next if anyone's interested.