### PR TITLE
Allow to change default filter's placeholder

### DIFF
--- a/docs/markdowns/FilterableHeaderCell.md
+++ b/docs/markdowns/FilterableHeaderCell.md
@@ -15,3 +15,7 @@ type: `shaperequire('../../../PropTypeShapes/ExcelColumn')`
 
 type: `func`
 
+
+### `filterPlaceholderText`
+
+type: `string`

--- a/docs/markdowns/Grid.md
+++ b/docs/markdowns/Grid.md
@@ -51,6 +51,11 @@ type: `func`
 type: `func`
 
 
+### `filterPlaceholderText`
+
+typ: `string`
+
+
 ### `headerRows`
 
 type: `union(array|func)`

--- a/docs/markdowns/Header.md
+++ b/docs/markdowns/Header.md
@@ -21,6 +21,11 @@ type: `func`
 type: `func`
 
 
+### `filterPlaceholderText`
+
+typ: `string`
+
+
 ### `headerRows` (required)
 
 type: `array`

--- a/docs/markdowns/HeaderRow.md
+++ b/docs/markdowns/HeaderRow.md
@@ -51,6 +51,11 @@ type: `func`
 type: `func`
 
 
+### `filterPlaceholderText`
+
+type: `string`
+
+
 ### `onScroll`
 
 type: `func`

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
@@ -12,7 +12,7 @@ class AutoCompleteFilter extends React.Component {
     this.getOptions = this.getOptions.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.filterValues = this.filterValues.bind(this);
-    this.state = {options: this.getOptions(), rawValue: '', placeholder: 'Search'};
+    this.state = {options: this.getOptions(), rawValue: '', placeholder: props.filterPlaceholderText};
   }
 
   componentWillReceiveProps(newProps) {
@@ -82,7 +82,12 @@ AutoCompleteFilter.propTypes = {
   onChange: PropTypes.func.isRequired,
   column: PropTypes.shape(ExcelColumn),
   getValidFilterValues: PropTypes.func,
-  multiSelection: PropTypes.bool
+  multiSelection: PropTypes.bool,
+  filterPlaceholderText: PropTypes.string
+};
+
+AutoCompleteFilter.defaultProps = {
+  filterPlaceholderText: 'Search'
 };
 
 export default AutoCompleteFilter;

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -58,6 +58,7 @@ class Grid extends React.Component {
     getSubRowDetails: PropTypes.func,
     draggableHeaderCell: PropTypes.func,
     getValidFilterValues: PropTypes.func,
+    filterPlaceholderText: PropTypes.string,
     rowGroupRenderer: PropTypes.func,
     overScan: PropTypes.object
   };
@@ -142,6 +143,7 @@ class Grid extends React.Component {
           onScroll={this.onHeaderScroll}
           getValidFilterValues={this.props.getValidFilterValues}
           cellMetaData={this.props.cellMetaData}
+          filterPlaceholderText={this.props.filterPlaceholderText}
           />
           {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
             <div

--- a/packages/react-data-grid/src/Header.js
+++ b/packages/react-data-grid/src/Header.js
@@ -32,6 +32,7 @@ class Header extends React.Component {
     onHeaderDrop: PropTypes.func,
     draggableHeaderCell: PropTypes.func,
     getValidFilterValues: PropTypes.func,
+    filterPlaceholderText: PropTypes.string,
     cellMetaData: PropTypes.shape(cellMetaDataShape)
   };
 
@@ -124,6 +125,7 @@ class Header extends React.Component {
         onSort={this.props.onSort}
         onScroll={this.props.onScroll}
         getValidFilterValues={this.props.getValidFilterValues}
+        filterPlaceholderText={this.props.filterPlaceholderText}
         />);
     });
     return headerRows;

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -39,6 +39,7 @@ class HeaderRow extends React.Component {
     headerCellRenderer: PropTypes.func,
     filterable: PropTypes.bool,
     onFilterChange: PropTypes.func,
+    filterPlaceholderText: PropTypes.string,
     resizing: PropTypes.object,
     onScroll: PropTypes.func,
     rowType: PropTypes.string,

--- a/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
+++ b/packages/react-data-grid/src/cells/headerCells/FilterableHeaderCell.js
@@ -5,7 +5,12 @@ import PropTypes from 'prop-types';
 class FilterableHeaderCell extends React.Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    column: PropTypes.shape(ExcelColumn)
+    column: PropTypes.shape(ExcelColumn),
+    filterPlaceholderText: PropTypes.string
+  };
+
+  static defaultProps = {
+    filterPlaceholderText: 'Search'
   };
 
   state: {filterTerm: string} = {filterTerm: ''};
@@ -22,7 +27,7 @@ class FilterableHeaderCell extends React.Component {
     }
 
     let inputKey = 'header-filter-' + this.props.column.key;
-    return (<input key={inputKey} type="text" className="form-control input-sm" placeholder="Search" value={this.state.filterTerm} onChange={this.handleChange}/>);
+    return (<input key={inputKey} type="text" className="form-control input-sm" placeholder={this.props.filterPlaceholderText} value={this.state.filterTerm} onChange={this.handleChange}/>);
   };
 
   render(): ?ReactElement {


### PR DESCRIPTION
## Description
Allow us to change the "Search" placeholder of default filter and AutocompleteFilter. This is useful for i18n for instance.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Placeholder of default filter and AutocompleteFilter is "Search".


**What is the new behavior?**
Placeholder of default filter and AutocompleteFilter is still "Search" if `filterPlaceholder` props is not given to the grid, and takes this props' value otherwise.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
