### PR TITLE
Fix drag fill in IE and FF

### DIFF
--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -44,12 +44,20 @@ class Row extends React.Component {
   }
 
   handleDragEnter = (e) => {
-    e.dataTransfer.dropEffect = 'move';
+    // Prevent default to allow drop
+    e.preventDefault();
     const { idx, cellMetaData: { onDragEnter } } = this.props;
     onDragEnter({ overRowIdx: idx });
   };
 
-  handleDrop= (e) => {
+  handleDragOver = (e) => {
+    e.dataTransfer.dropEffect = 'move';
+    e.preventDefault();
+  };
+
+  handleDrop = (e) => {
+    // The default in Firefox is to treat data in dataTransfer as a URL and perform navigation on it, even if the data type used is 'text'
+    // To bypass this, we need to capture and prevent the drop event.
     e.preventDefault();
   };
 
@@ -159,12 +167,13 @@ class Row extends React.Component {
     let cells = this.getCells();
     return (
       <div
-        {...this.getKnownDivProps() }
+        {...this.getKnownDivProps()}
         className={className}
         style={style}
         onDragEnter={this.handleDragEnter}
+        onDragOver={this.handleDragOver}
         onDrop={this.handleDrop}
-       >
+      >
         {
           React.isValidElement(this.props.row) ?
             this.props.row : cells

--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -358,7 +358,7 @@ class InteractionMasks extends React.Component {
     }
   };
 
-  dragEnabled = () => {
+  isDragEnabled = () => {
     const { onGridRowsUpdated, onCellsDragged } = this.props;
     return this.isSelectedCellEditable() && (isFunction(onGridRowsUpdated) || isFunction(onCellsDragged));
   };
@@ -368,8 +368,15 @@ class InteractionMasks extends React.Component {
     // To prevent dragging down/up when reordering rows. (TODO: is this required)
     const isViewportDragging = e && e.target && e.target.className;
     if (idx > -1 && isViewportDragging) {
-      e.dataTransfer.effectAllowed = 'copy';
-      e.dataTransfer.setData('text/plain', JSON.stringify({ idx, rowIdx }));
+      e.dataTransfer.effectAllowed = 'move';
+      // Setting data is required to make an element draggable in FF
+      const transferData = JSON.stringify({ idx, rowIdx });
+      try {
+        e.dataTransfer.setData('text/plain', transferData);
+      } catch (ex) {
+        // IE only supports 'text' and 'URL' for the 'type' argument
+        e.dataTransfer.setData('text', transferData);
+      }
       this.setState({
         draggedPosition: { idx, rowIdx }
       });
@@ -461,7 +468,7 @@ class InteractionMasks extends React.Component {
             isGroupedRow={rowData && rowData.__metaData ? rowData.__metaData.isGroup : false}
             scrollLeft={this.props.scrollLeft}
           >
-            {this.dragEnabled() && (
+            {this.isDragEnabled() && (
               <DragHandle
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -43,7 +43,9 @@
   border-bottom: 0px;
   z-index: 8;
   cursor: crosshair;
+  cursor: -moz-grab;
   cursor: -webkit-grab;
+  cursor: grab;
 }
 
 .react-grid-Cell:not(.editing) .react-grid-Cell__value {
@@ -143,7 +145,9 @@
   border: 1px solid #66afe9;
   z-index: 8;
   cursor: crosshair;
+  cursor: -moz-grab;
   cursor: -webkit-grab;
+  cursor: grab;
 }
 
 .react-grid-Row.row-selected .react-grid-Cell{

--- a/themes/react-data-grid-row.css
+++ b/themes/react-data-grid-row.css
@@ -13,9 +13,9 @@
 
 .react-grid-Row:hover .rdg-drag-row-handle {
   cursor: move; /* fallback if grab cursor is unsupported */
-  cursor: grab;
   cursor: -moz-grab;
   cursor: -webkit-grab;
+  cursor: grab;
   width: 12px;
   height: 30px;
   margin-left: 0px;


### PR DESCRIPTION
- [x] Fix [drag exception](http://mereskin.github.io/dnd/) in Internet explorer 
> Internet Explorer only supports 'text' and 'URL' for the 'type' argument. If you try setting type to anything else, IE will throw an exception.
- [ ] Fix performance regression in firefox.  When the grid is scrolled to the middle then the drag fill operation is extremely slow. This is caused by [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1443146) bug.
> The problem comes from the fact that the item's container is shifted right with a CSS transformation (translateX). The ghost is positioned like there was no translation. 