### PR TITLE
Grouping toolbar UI fixes

### DIFF
--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 export default class GroupedColumnButton extends Component {
   render() {
     return (
-      <div className="grouped-col-btn btn btn-primary btn-sm">
+      <div className="grouped-col-btn btn btn-sm">
         <span className="grouped-col-btn__name">{this.props.name}</span>
         <span className="grouped-col-btn__remove glyphicon glyphicon-trash"
               onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)} />

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
@@ -1,23 +1,14 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
-
 export default class GroupedColumnButton extends Component {
   render() {
-    let style = {
-      width: '80px',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap'
-    };
     return (
-      <button  className="btn grouped-col-btn btn-sm"><span style={style}>{this.props.name}</span>
-        <span
-          className="glyphicon glyphicon-trash"
-          style={{float: 'right', paddingLeft: '5px'}}
-          onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)}>
-        </span>
-      </button>
+      <div className="grouped-col-btn btn btn-primary btn-sm">
+        <span className="grouped-col-btn__name">{this.props.name}</span>
+        <span className="grouped-col-btn__remove glyphicon glyphicon-trash"
+              onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)} />
+      </div>
     );
   }
 }

--- a/themes/react-data-grid-toolbar.css
+++ b/themes/react-data-grid-toolbar.css
@@ -23,15 +23,22 @@
   touch-action: manipulation;
   cursor: pointer;
   -webkit-user-select: none;
-}
-.react-grid-Toolbar .btn:not(.grouped-col-btn) {
   color: inherit;
-  background: #fff;
+  background: white;
   border: 1px solid #e7eaec;
 }
-.react-grid-Toolbar .btn:not(.grouped-col-btn):hover {
+.react-grid-Toolbar .btn:hover {
   color: inherit;
   border: 1px solid #d2d2d2;
+}
+.react-grid-Toolbar .grouped-col-btn {
+  background-color: #428bca;
+  color: white;
+  border-color: #2b669a;
+}
+.react-grid-Toolbar .grouped-col-btn:hover {
+  color: white;
+  border-color: #2b669a;
 }
 .react-grid-Toolbar .grouped-col-btn + .grouped-col-btn {
   margin-left: 5px;

--- a/themes/react-data-grid-toolbar.css
+++ b/themes/react-data-grid-toolbar.css
@@ -23,20 +23,21 @@
   touch-action: manipulation;
   cursor: pointer;
   -webkit-user-select: none;
+}
+.react-grid-Toolbar .btn:not(.grouped-col-btn) {
   color: inherit;
-  background: white;
+  background: #fff;
   border: 1px solid #e7eaec;
 }
-.react-grid-Toolbar .btn:hover {
+.react-grid-Toolbar .btn:not(.grouped-col-btn):hover {
   color: inherit;
   border: 1px solid #d2d2d2;
 }
-.react-grid-Toolbar .grouped-col-btn {
-  background-color: #428bca;
-  color: white;
+.react-grid-Toolbar .grouped-col-btn + .grouped-col-btn {
+  margin-left: 5px;
 }
-.react-grid-Toolbar .grouped-col-btn:hover {
-  color: white;
+.react-grid-Toolbar .grouped-col-btn__remove {
+  margin-left: 5px;
 }
 .react-grid-Toolbar .tools {
   display: inline-block;


### PR DESCRIPTION
## Description
This PR introduces 2 fixes for [row grouping](http://adazzle.github.io/react-data-grid/#/examples/grouping) toolbar:
1. Fix styling in Firefox
1. Fix behavior of 'remove' (i.e. clear grouping) button - in IE and Firefox clicking it trigerred no action (probably because browsers were confused about click event of span inside button)

Additionally, inline styles in GroupedColumnButton component were replaced with CSS classes so it's easier to override:
`grouped-col-btn` - individual button itself (no change from current className)
`grouped-col-btn__name` - <span> containing group name (new)
`grouped-col-btn__remove` - remove icon (new)

**Please check if the PR fulfills these requirements**
- [ ] ~~The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md~~ No guidelines found for commit messages; let me know if should change
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~ No tests update needed
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ No docs update needed


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

| Browser | Button appearance | Click on 'trashcan' icon |
| --- | --- | --- |
| Chrome | OK | Works |
| IE | OK | Doesn't work |
| Firefox | Bad | Doesn't work |

See comparison of rendering: ![img](https://i.imgur.com/Yv312ZA.gif)

**What is the new behavior?**

| Browser | Button appearance | Click on 'trashcan' icon |
| --- | --- | --- |
| Chrome | OK | Works |
| IE | OK | Works |
| Firefox | OK | Works |

See comparison of rendering: ![img](https://i.imgur.com/vOKSQAJ.gif)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Current implementation intends to limit label on the button (column name) to 80px and clip longer text using ellipsis. However, it actually doesn't work. I removed this part of styles and left such setting to the discretion of developer using react-data-grid (just target `.react-grid-Toolbar .grouped-col-btn__name` selector in your CSS).