### PR TITLE
Fixed feature link 404's in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,20 @@ Features
 --------
 
 - Lightning fast virtual rendering
-- [Can render hundreds of thousands of rows with no lag](http://adazzle.github.io/react-data-grid/examples.html#/one-million-rows)
+- [Can render hundreds of thousands of rows with no lag](http://adazzle.github.io/react-data-grid/#/examples/one-million-rows)
 - Keyboard navigation
-- [Fully editable grid](http://adazzle.github.io/react-data-grid/examples.html#/editable)
-- [Rich cell editors like autocomplete, checkbox and dropdown editors, complete with keyboard navigation](http://adazzle.github.io/react-data-grid/examples.html#/built-in-editors)
+- [Fully editable grid](http://adazzle.github.io/react-data-grid/#/examples/editable)
+- [Rich cell editors like autocomplete, checkbox and dropdown editors, complete with keyboard navigation](http://adazzle.github.io/react-data-grid/#/examples/built-in-editors)
 - Custom cell Editors - Easily create your own
-- [Custom cell Formatters](http://adazzle.github.io/react-data-grid/examples.html#/custom-formatters)
-- [Frozen columns](http://adazzle.github.io/react-data-grid/examples.html#/fixed-cols)
-- [Resizable columns](http://adazzle.github.io/react-data-grid/examples.html#/resizable-cols)
-- [Sorting](http://adazzle.github.io/react-data-grid/examples.html#/sortable-cols) 
-- [Filtering](http://adazzle.github.io/react-data-grid/examples.html#/filterable-sortable-grid) 
-- [Context Menu](http://adazzle.github.io/react-data-grid/examples.html#/context-menu)
+- [Custom cell Formatters](http://adazzle.github.io/react-data-grid/#/examples/custom-formatters)
+- [Frozen columns](http://adazzle.github.io/react-data-grid/#/examples/fixed-cols)
+- [Resizable columns](http://adazzle.github.io/react-data-grid/#/examples/resizable-cols)
+- [Sorting](http://adazzle.github.io/react-data-grid/#/examples/sortable-cols) 
+- [Filtering](http://adazzle.github.io/react-data-grid/#/examples/filterable-sortable-grid) 
+- [Context Menu](http://adazzle.github.io/react-data-grid/#/examples/context-menu)
 - Copy and Paste values into other cells
-- [Multiple cell updates using cell dragdown](http://adazzle.github.io/react-data-grid/examples.html#/cell-drag-down)
-- [Association of events of individual columns](http://adazzle.github.io/react-data-grid/examples.html#/column-events)
+- [Multiple cell updates using cell dragdown](http://adazzle.github.io/react-data-grid/#/examples/cell-drag-down)
+- [Association of events of individual columns](http://adazzle.github.io/react-data-grid/#/examples/column-events)
 
 
 Check out the `examples` directory to see how simple previously complex UI


### PR DESCRIPTION
## Description
This PR fixes broken links in the the features list in the README.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~ N/A
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The links to documentation website example under the features list produce 404 errors when followed.


**What is the new behavior?**
The links load the corresponding examples as expected


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
