### PR TITLE
Added cell drag side-to-side functionality for editing. 

### DIFF
--- a/docs/api/docs.json
+++ b/docs/api/docs.json
@@ -3689,6 +3689,28 @@
         "required": false,
         "description": ""
       },
+      "enableDragVertical": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Allows user to toggle drag down functionality",
+        "defaultValue": {
+          "value": true,
+          "computed": false
+        }
+      },
+      "enableDragHorizontal": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Allows user to toggle drag side-to-side functionality",
+        "defaultValue": {
+          "value": false,
+          "computed": false
+        }
+      },
       "onGridRowsUpdated": {
         "type": {
           "name": "func"

--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -796,22 +796,116 @@ describe('Grid', function() {
         });
       });
 
+      describe('dragging over a column with enableDragHorizontal=true', function() {
+        beforeEach(function() {
+          let wrapper = this.createComponent();
+          let columns = [
+            { key: 'id', name: 'ID', width: 100, events: { onClick: () => {}} },
+            { key: 'title', name: 'Title', editable: true, width: 100 },
+            { key: 'count', name: 'Count', editable: true, width: 100 },
+            { key: 'country', name: 'Country', editable: true, width: 100 },
+            { key: 'planet', name: 'planet', width: 100 }
+          ];
+          wrapper.setProps({ enableDragHorizontal: true, columns });
+          this.component = wrapper.instance();
+          this.component.setState({
+            selected: { idx: 2, rowIdx: 2 },
+            dragged: { idx: 2, rowIdx: 2, value: 'apple', overIdx: 2, overRowIdx: 2 }
+          });
+        });
+
+        it('should store the current rowIdx, and idx in grid state when dragged left', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 1, rowIdx: 2, value: 'apple' });
+          expect(this.component.state.dragged).toEqual({ idx: 2, rowIdx: 2, value: 'apple', overIdx: 1, overRowIdx: 2 });
+        });
+
+        it('should store the current rowIdx, and idx in grid state when dragged too far left', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 0, rowIdx: 2, value: 'apple' });
+          expect(this.component.state.dragged).toEqual({ idx: 2, rowIdx: 2, value: 'apple', overIdx: 1, overRowIdx: 2 });
+        });
+
+        it('should store the current rowIdx, and idx in grid state when dragged right', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 3, rowIdx: 2, value: 'apple' });
+          expect(this.component.state.dragged).toEqual({ idx: 2, rowIdx: 2, value: 'apple', overIdx: 3, overRowIdx: 2 });
+        });
+
+        it('should store the current rowIdx, and idx in grid state when dragged too far right', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 8, rowIdx: 2, value: 'apple' });
+          expect(this.component.state.dragged).toEqual({ idx: 2, rowIdx: 2, value: 'apple', overIdx: 3, overRowIdx: 2 });
+        });
+      });
+
+      describe('finishing drag with enableDragHorizontal=true', function() {
+        beforeEach(function() {
+          let wrapper = this.createComponent();
+          let columns = [
+            { key: 'id', name: 'ID', editable: true, width: 100, events: { onClick: () => {}} },
+            { key: 'title', name: 'Title', editable: true, width: 100 },
+            { key: 'count', name: 'Count', editable: true, width: 100 },
+            { key: 'country', name: 'Country', editable: true, width: 100 },
+            { key: 'planet', name: 'planet', editable: true, width: 100 }
+          ];
+          spyOn(this.testProps, 'onCellsDragged');
+          wrapper.setProps({ onCellsDragged: this.testProps.onCellsDragged, enableDragHorizontal: true, columns });
+          this.component = wrapper.instance();
+          this.component.setState({
+            selected: { idx: 2, rowIdx: 2 },
+            dragged: { idx: 2, rowIdx: 2, value: 'apple', overIdx: 2, overRowIdx: 2 }
+          });
+        });
+
+        it('should trigger onCellsDragged event and call it with correct params when dragged left', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 1, rowIdx: 2, value: 'apple' });
+          this.getBaseGrid().props.onViewportDragEnd();
+          expect(this.component.props.onCellsDragged).toHaveBeenCalled();
+          expect(this.component.props.onCellsDragged.calls.argsFor(0)[0]).toEqual({ cellKey: 'count', fromRow: 2, toRow: 2, fromCol: 1, toCol: 2, value: 'apple' });
+        });
+
+        it('should trigger onCellsDragged event and call it with correct params when dragged too far left', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: -1, rowIdx: 2, value: 'apple' });
+          this.getBaseGrid().props.onViewportDragEnd();
+          expect(this.component.props.onCellsDragged).toHaveBeenCalled();
+          expect(this.component.props.onCellsDragged.calls.argsFor(0)[0]).toEqual({ cellKey: 'count', fromRow: 2, toRow: 2, fromCol: 0, toCol: 2, value: 'apple' });
+        });
+
+        it('should trigger onCellsDragged event and call it with correct params when dragged right', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 3, rowIdx: 2, value: 'apple' });
+          this.getBaseGrid().props.onViewportDragEnd();
+          expect(this.component.props.onCellsDragged).toHaveBeenCalled();
+          expect(this.component.props.onCellsDragged.calls.argsFor(0)[0]).toEqual({ cellKey: 'count', fromRow: 2, toRow: 2, fromCol: 2, toCol: 3, value: 'apple' });
+        });
+
+        it('should trigger onCellsDragged event and call it with correct params when dragged too far right', function() {
+          this.getCellMetaData().handleDragEnterCell({ idx: 8, rowIdx: 2, value: 'apple' });
+          this.getBaseGrid().props.onViewportDragEnd();
+          expect(this.component.props.onCellsDragged).toHaveBeenCalled();
+          expect(this.component.props.onCellsDragged.calls.argsFor(0)[0]).toEqual({ cellKey: 'count', fromRow: 2, toRow: 2, fromCol: 2, toCol: 4, value: 'apple' });
+        });
+      });
+
       describe('finishing drag', function() {
         beforeEach(function() {
           let wrapper = this.createComponent();
+          let columns = [
+            { key: 'id', name: 'ID', editable: true, width: 100, events: { onClick: () => {}} },
+            { key: 'title', name: 'Title', editable: true, width: 100 },
+            { key: 'count', name: 'Count', editable: true, width: 100 },
+            { key: 'country', name: 'Country', editable: true, width: 100 },
+            { key: 'planet', name: 'planet', editable: true, width: 100 }
+          ];
           spyOn(this.testProps, 'onCellsDragged');
-          wrapper.setProps({ onCellsDragged: this.testProps.onCellsDragged });
+          wrapper.setProps({ onCellsDragged: this.testProps.onCellsDragged, columns });
           this.component = wrapper.instance();
           this.component.setState({
             selected: { idx: 1, rowIdx: 2 },
-            dragged: { idx: 1, rowIdx: 2, value: 'apple', overRowIdx: 6 }
+            dragged: { idx: 1, rowIdx: 2, value: 'apple', overRowIdx: 6, overIdx: 1 }
           });
           this.getBaseGrid().props.onViewportDragEnd();
         });
 
         it('should trigger onCellsDragged event and call it with correct params', function() {
           expect(this.component.props.onCellsDragged).toHaveBeenCalled();
-          expect(this.component.props.onCellsDragged.calls.argsFor(0)[0]).toEqual({ cellKey: 'title', fromRow: 2, toRow: 6, value: 'apple' });
+          expect(this.component.props.onCellsDragged.calls.argsFor(0)[0]).toEqual({ cellKey: 'title', fromRow: 2, toRow: 6, fromCol: 1, toCol: 1, value: 'apple' });
         });
       });
 

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -409,6 +409,7 @@ class Cell extends React.Component {
   isDraggedOverDownwards = (): boolean => {
     let dragged = this.props.cellMetaData.dragged;
     if (!this.isSelected() && this.isDraggedOver()) {
+      // Note that this is is a visual lower bound, and a numerical upper bound.
       let lowerBound = dragged.rowIdx > dragged.overRowIdx ?
         dragged.rowIdx : dragged.overRowIdx;
       return this.props.rowIdx === lowerBound;

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -165,6 +165,14 @@ class Cell extends React.Component {
     e.preventDefault();
   };
 
+  handleDragEnter = () => {
+    let handleDragEnterCell = this.props.cellMetaData.handleDragEnterCell;
+    let { idx, rowIdx, value } = this.props;
+    if (handleDragEnterCell) {
+      handleDragEnterCell({ idx: idx, rowIdx: rowIdx, value: value });
+    }
+  };
+
   getStyle = () => {
     let style = {
       position: 'absolute',
@@ -196,6 +204,19 @@ class Cell extends React.Component {
     }
   };
 
+  getDraggedClasses = () => {
+    if (!this.isDragged()) {
+      return {};
+    }
+    return {
+      'is-dragged-over-up': this.isDraggedOverUpwards(),
+      'is-dragged-over-down': this.isDraggedOverDownwards(),
+      'is-dragged-over-right': this.isDraggedOverRight(),
+      'is-dragged-over-left': this.isDraggedOverLeft(),
+      'was-dragged-over': this.wasDraggedOver()
+    };
+  }
+
   getCellClass = () => {
     let className = joinClasses(
       this.props.column.cellClass,
@@ -203,13 +224,10 @@ class Cell extends React.Component {
       this.props.className,
       this.props.column.locked ? 'react-grid-Cell--locked' : null
     );
-    let extraClasses = joinClasses({
+    let extraClasses = joinClasses(this.getDraggedClasses(), {
       'row-selected': this.props.isRowSelected,
       editing: this.isActive(),
-      copied: this.isCopied() || this.wasDraggedOver() || this.isDraggedOverUpwards() || this.isDraggedOverDownwards(),
-      'is-dragged-over-up': this.isDraggedOverUpwards(),
-      'is-dragged-over-down': this.isDraggedOverDownwards(),
-      'was-dragged-over': this.wasDraggedOver(),
+      copied: this.isCopied() || this.isDragged(),
       'cell-tooltip': this.props.tooltip ? true : false,
       'rdg-child-cell': this.props.expandableOptions && this.props.expandableOptions.subRowDetails && this.props.expandableOptions.treeDepth > 0,
       'last-column': this.props.column.isLastColumn
@@ -325,13 +343,20 @@ class Cell extends React.Component {
     );
   };
 
-  isDraggedOver = (): boolean => {
+  // Helper function to reduce unnecessary calls to dragged checks.
+  isDragged = (): boolean => {
     let dragged = this.props.cellMetaData.dragged;
     return (
-      dragged &&
-      dragged.overRowIdx === this.props.rowIdx
-      && dragged.idx === this.props.idx
+      dragged
+      && ((dragged.overRowIdx <= this.props.rowIdx && this.props.rowIdx <= dragged.rowIdx)
+        || (dragged.overRowIdx >= this.props.rowIdx && this.props.rowIdx >= dragged.rowIdx))
+      && ((dragged.overIdx <= this.props.idx && this.props.idx <= dragged.idx)
+        || (dragged.overIdx >= this.props.idx && this.props.idx >= dragged.idx))
     );
+  };
+
+  isDraggedOver = (): boolean => {
+    return this.isDragged() && !this.wasDraggedOver();
   };
 
   wasDraggedOver = (): boolean => {
@@ -340,7 +365,8 @@ class Cell extends React.Component {
       dragged
       && ((dragged.overRowIdx < this.props.rowIdx && this.props.rowIdx < dragged.rowIdx)
         || (dragged.overRowIdx > this.props.rowIdx && this.props.rowIdx > dragged.rowIdx))
-      && dragged.idx === this.props.idx
+      && ((dragged.overIdx < this.props.idx && this.props.idx < dragged.idx)
+        || (dragged.overIdx > this.props.idx && this.props.idx > dragged.idx))
     );
   };
 
@@ -371,13 +397,44 @@ class Cell extends React.Component {
 
   isDraggedOverUpwards = (): boolean => {
     let dragged = this.props.cellMetaData.dragged;
-    return !this.isSelected() && this.isDraggedOver() && this.props.rowIdx < dragged.rowIdx;
+    if (!this.isSelected() && this.isDraggedOver()) {
+      // Note that this is is a visual upper bound, and a numerical lower bound.
+      let upperBound = dragged.rowIdx < dragged.overRowIdx ?
+        dragged.rowIdx : dragged.overRowIdx;
+      return this.props.rowIdx === upperBound;
+    }
+    return false;
   };
 
   isDraggedOverDownwards = (): boolean => {
     let dragged = this.props.cellMetaData.dragged;
-    return !this.isSelected() && this.isDraggedOver() && this.props.rowIdx > dragged.rowIdx;
+    if (!this.isSelected() && this.isDraggedOver()) {
+      let lowerBound = dragged.rowIdx > dragged.overRowIdx ?
+        dragged.rowIdx : dragged.overRowIdx;
+      return this.props.rowIdx === lowerBound;
+    }
+    return false;
   };
+
+  isDraggedOverRight = (): boolean => {
+    let dragged = this.props.cellMetaData.dragged;
+    if (!this.isSelected() && this.isDraggedOver()) {
+      let rightBound = dragged.idx > dragged.overIdx ?
+        dragged.idx : dragged.overIdx;
+      return this.props.idx === rightBound;
+    }
+    return false;
+  }
+
+  isDraggedOverLeft = (): boolean => {
+    let dragged = this.props.cellMetaData.dragged;
+    if (!this.isSelected() && this.isDraggedOver()) {
+      let leftBound = dragged.idx < dragged.overIdx ?
+        dragged.idx : dragged.overIdx;
+      return this.props.idx === leftBound;
+    }
+    return false;
+  }
 
   isFocusedOnBody = () => {
     return document.activeElement == null || (document.activeElement.nodeName && typeof document.activeElement.nodeName === 'string' && document.activeElement.nodeName.toLowerCase() === 'body');
@@ -536,7 +593,7 @@ class Cell extends React.Component {
 
 
     return (
-      <div {...this.getKnownDivProps() } className={className} style={style} {...events} ref={(node) => { this.node = node; }}>
+      <div {...this.getKnownDivProps() } className={className} style={style} {...events} ref={(node) => { this.node = node; }} onDragEnter={this.handleDragEnter}>
         {cellActions}
         {cellContent}
         {dragHandle}

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -657,7 +657,8 @@ class ReactDataGrid extends React.Component {
       let fromCol = selected.idx    < dragged.overIdx    ? selected.idx    : dragged.overIdx;
       let toCol   = selected.idx    > dragged.overIdx    ? selected.idx    : dragged.overIdx;
       if (this.props.onCellsDragged) {
-        this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
+        const { value } = dragged;
+        this.props.onCellsDragged({cellKey, fromRow, toRow, fromCol, toCol, value});
       }
       if (this.props.onGridRowsUpdated) {
         // Value resolution just copies the `selected` cells value, applying it to the `updated` object.
@@ -699,7 +700,7 @@ class ReactDataGrid extends React.Component {
       while (cur !== draggedTo.idx) {
         cur += nextCol;
         let column = this.getColumn(cur);
-        if (!column.editable) {
+        if (!(column && column.editable)) {
           cur -= nextCol;
           break;
         }

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -72,6 +72,8 @@ class ReactDataGrid extends React.Component {
     sortColumn: PropTypes.string,
     sortDirection: PropTypes.oneOf(Object.keys(DEFINE_SORT)),
     onDragHandleDoubleClick: PropTypes.func,
+    enableDragVertical: PropTypes.bool,
+    enableDragHorizontal: PropTypes.bool,
     onGridRowsUpdated: PropTypes.func,
     onRowSelect: PropTypes.func,
     rowKey: PropTypes.string,
@@ -133,6 +135,8 @@ class ReactDataGrid extends React.Component {
     rowHeight: 35,
     headerFiltersHeight: 45,
     enableRowSelect: false,
+    enableDragVertical: true,
+    enableDragHorizontal: false,
     minHeight: 350,
     rowKey: 'id',
     rowScrollTimeout: 0,
@@ -635,6 +639,7 @@ class ReactDataGrid extends React.Component {
       && rowIdx < this.props.rowsCount;
   };
 
+  // FIXME: the `dragged` variable will have the row idx!
   handleDragStart = (dragged: DraggedType) => {
     if (!this.dragEnabled()) { return; }
     if (this.isCellWithinBounds(dragged)) {
@@ -650,11 +655,16 @@ class ReactDataGrid extends React.Component {
       let cellKey = column.key;
       let fromRow = selected.rowIdx < dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
       let toRow   = selected.rowIdx > dragged.overRowIdx ? selected.rowIdx : dragged.overRowIdx;
+      let fromCol = selected.idx    < dragged.overIdx    ? selected.idx    : dragged.overIdx;
+      let toCol   = selected.idx    > dragged.overIdx    ? selected.idx    : dragged.overIdx;
       if (this.props.onCellsDragged) {
         this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
       }
       if (this.props.onGridRowsUpdated) {
-        this.onGridRowsUpdated(cellKey, fromRow, toRow, {[cellKey]: dragged.value}, AppConstants.UpdateActions.CELL_DRAG);
+        //fromRow
+        let updated = {}
+        this.props.columns.slice(fromCol, toCol + 1).forEach(column => { updated[column.key] = dragged.value; })
+        this.onGridRowsUpdated(cellKey, fromRow, toRow, updated, AppConstants.UpdateActions.CELL_DRAG);
       }
     }
     this.setState({dragged: {complete: true}});
@@ -663,9 +673,44 @@ class ReactDataGrid extends React.Component {
   handleDragEnter = (row: any) => {
     if (!this.dragEnabled() || this.state.dragged == null) { return; }
     let dragged = this.state.dragged;
-    dragged.overRowIdx = row;
+    const { enableDragVertical } = this.props;
+    if (enableDragVertical) {
+      dragged.overRowIdx = row;
+    } else {
+      dragged.overRowIdx = this.state.selected.rowIdx;
+    }
     this.setState({dragged: dragged});
   };
+
+  handleDragEnterCell = (draggedTo: DraggedType) => {
+    if (!this.dragEnabled() || this.state.dragged == null) { return; }
+    let dragged = this.state.dragged;
+
+    const { enableDragVertical, enableDragHorizontal } = this.props;
+
+    if (enableDragVertical) {
+      dragged.overRowIdx = draggedTo.rowIdx;
+    } else {
+      dragged.overRowIdx = this.state.selected.rowIdx;
+    }
+    if (enableDragHorizontal) {
+      // This way the drag will stop at uneditable columns.
+      let nextCol = dragged.idx < draggedTo.idx ? 1 : -1;
+      let cur = this.state.selected.idx;
+      while (cur !== draggedTo.idx) {
+        cur += nextCol;
+        let column = this.getColumn(cur);
+        if (!column.editable) {
+          cur -= nextCol;
+          break;
+        }
+      }
+      dragged.overIdx = cur;
+    } else {
+      dragged.overIdx = this.state.selected.idx;
+    }
+    this.setState({dragged: dragged});
+  }
 
   handleTerminateDrag = () => {
     if (!this.dragEnabled()) { return; }
@@ -1197,6 +1242,7 @@ class ReactDataGrid extends React.Component {
       onCommitCancel: this.setInactive,
       copied: this.state.copied,
       handleDragEnterRow: this.handleDragEnter,
+      handleDragEnterCell: this.handleDragEnterCell,
       handleTerminateDrag: this.handleTerminateDrag,
       enableCellSelect: this.props.enableCellSelect,
       onColumnEvent: this.onColumnEvent,

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -661,8 +661,8 @@ class ReactDataGrid extends React.Component {
       }
       if (this.props.onGridRowsUpdated) {
         // Value resolution just copies the `selected` cells value, applying it to the `updated` object.
-        let updated = {}
-        this.props.columns.slice(fromCol, toCol + 1).forEach(column => { updated[column.key] = dragged.value; })
+        let updated = {};
+        this.props.columns.slice(fromCol, toCol + 1).forEach(col => { updated[col.key] = dragged.value; });
         this.onGridRowsUpdated(cellKey, fromRow, toRow, updated, AppConstants.UpdateActions.CELL_DRAG);
       }
     }

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -639,7 +639,6 @@ class ReactDataGrid extends React.Component {
       && rowIdx < this.props.rowsCount;
   };
 
-  // FIXME: the `dragged` variable will have the row idx!
   handleDragStart = (dragged: DraggedType) => {
     if (!this.dragEnabled()) { return; }
     if (this.isCellWithinBounds(dragged)) {
@@ -661,7 +660,7 @@ class ReactDataGrid extends React.Component {
         this.props.onCellsDragged({cellKey: cellKey, fromRow: fromRow, toRow: toRow, value: dragged.value});
       }
       if (this.props.onGridRowsUpdated) {
-        //fromRow
+        // Value resolution just copies the `selected` cells value, applying it to the `updated` object.
         let updated = {}
         this.props.columns.slice(fromCol, toCol + 1).forEach(column => { updated[column.key] = dragged.value; })
         this.onGridRowsUpdated(cellKey, fromRow, toRow, updated, AppConstants.UpdateActions.CELL_DRAG);

--- a/packages/react-data-grid/src/__tests__/Canvas.spec.js
+++ b/packages/react-data-grid/src/__tests__/Canvas.spec.js
@@ -20,6 +20,7 @@ let testProps = {
     onCommitCancel: () => {},
     copied: {},
     handleDragEnterRow: () => {},
+    handleDragEnterCell: () => {},
     handleTerminateDrag: () => {},
     onAddSubRow: () => {}
   }

--- a/packages/react-data-grid/src/__tests__/Cell.spec.js
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.js
@@ -21,6 +21,7 @@ let testCellMetaData = {
   onCommitCancel: function() {},
   copied: null,
   handleDragEnterRow: function() {},
+  handleDragEnterCell: function() {},
   handleTerminateDrag: function() {},
   onColumnEvent: function() {}
 };
@@ -599,6 +600,7 @@ describe('Cell Tests', () => {
         onCommitCancel: jasmine.createSpy(),
         copied: null,
         handleDragEnterRow: jasmine.createSpy(),
+        handleDragEnterCell: jasmine.createSpy(),
         handleTerminateDrag: jasmine.createSpy(),
         onColumnEvent: jasmine.createSpy()
       },
@@ -629,6 +631,7 @@ describe('Cell Tests', () => {
         onCommitCancel: jasmine.createSpy(),
         copied: null,
         handleDragEnterRow: jasmine.createSpy(),
+        handleDragEnterCell: jasmine.createSpy(),
         handleTerminateDrag: jasmine.createSpy(),
         onColumnEvent: jasmine.createSpy()
       },
@@ -724,6 +727,7 @@ describe('Cell Tests', () => {
           onCommitCancel: jasmine.createSpy(),
           copied: null,
           handleDragEnterRow: jasmine.createSpy(),
+          handleDragEnterCell: jasmine.createSpy(),
           handleTerminateDrag: jasmine.createSpy(),
           onColumnEvent: jasmine.createSpy()
         },
@@ -754,6 +758,7 @@ describe('Cell Tests', () => {
             onCommitCancel: jasmine.createSpy(),
             copied: null,
             handleDragEnterRow: jasmine.createSpy(),
+            handleDragEnterCell: jasmine.createSpy(),
             handleTerminateDrag: jasmine.createSpy(),
             onColumnEvent: jasmine.createSpy(),
             getCellActions: sinon.stub().returns([action])

--- a/packages/react-data-grid/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid/src/__tests__/Grid.spec.js
@@ -192,6 +192,7 @@ describe('Rendering Grid component', () => {
         onCommitCancel: jasmine.createSpy(),
         copied: null,
         handleDragEnterRow: jasmine.createSpy(),
+        handleDragEnterCell: jasmine.createSpy(),
         handleTerminateDrag: jasmine.createSpy(),
         onColumnEvent: jasmine.createSpy()
       },

--- a/packages/react-data-grid/src/__tests__/Header.spec.js
+++ b/packages/react-data-grid/src/__tests__/Header.spec.js
@@ -139,6 +139,7 @@ describe('Header Unit Tests', () => {
         onCellDoubleClick: () => {},
         onCellClick: () => { },
         handleDragEnterRow: () => {},
+        handleDragEnterCell: () => {},
         handleTerminateDrag: () => {},
         selected: { rowIdx: 0, id: 1 }
       }

--- a/packages/react-data-grid/src/__tests__/Row.spec.js
+++ b/packages/react-data-grid/src/__tests__/Row.spec.js
@@ -69,6 +69,7 @@ describe('Row', () => {
         onCommitCancel: jasmine.createSpy(),
         copied: null,
         handleDragEnterRow: jasmine.createSpy(),
+        handleDragEnterCell: jasmine.createSpy(),
         handleTerminateDrag: jasmine.createSpy(),
         onColumnEvent: jasmine.createSpy()
       },

--- a/packages/react-data-grid/src/__tests__/Viewport.spec.js
+++ b/packages/react-data-grid/src/__tests__/Viewport.spec.js
@@ -32,6 +32,7 @@ let viewportProps = {
     onCommitCancel: () => { },
     copied: {},
     handleDragEnterRow: () => { },
+    handleDragEnterCell: () => { },
     handleTerminateDrag: () => { }
   },
   rowKey: 'Id'
@@ -66,6 +67,7 @@ let viewportPropsNoColumns = {  // when creating anew plan copying from an exist
     onCommitCancel: () => { },
     copied: {},
     handleDragEnterRow: () => { },
+    handleDragEnterCell: () => { },
     handleTerminateDrag: () => { }
   },
   rowKey: 'Id'

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -65,15 +65,19 @@
 }
 
 .react-grid-Cell.is-dragged-over-down {
-  border-right: 1px dashed black;
-  border-left: 1px dashed black;
   border-bottom: 1px dashed black;
 }
 
 .react-grid-Cell.is-dragged-over-up {
-  border-right: 1px dashed black;
-  border-left: 1px dashed black;
   border-top: 1px dashed black;
+}
+
+.react-grid-Cell.is-dragged-over-right {
+  border-right: 1px dashed black;
+}
+
+.react-grid-Cell.is-dragged-over-left {
+  border-left: 1px dashed black;
 }
 
 .react-grid-Cell.is-dragged-over-up .drag-handle {
@@ -94,9 +98,9 @@
   width: 34px;
   height: 34px;
 }
+
 .react-grid-Cell.was-dragged-over {
-  border-right: 1px dashed black;
-  border-left: 1px dashed black;
+
 }
 
 .react-grid-Cell:hover:focus .drag-handle {


### PR DESCRIPTION
## Description
Added code to support toggle-able drag side to side functionality. This functionality is accessed by setting the optional ReactDataGrid prop `<enableDragHorizontal={true}`. A toggle to control drag down functionality was also added. 

```js
// These are the defaultProp values, which allow for current grid functionality.
ReactDataGrid.props += { enableDragHorizontal: false, enableDragVertical: true };
```

Added tests in [Grid.spec.js](https://github.com/colindjk/react-data-grid/blob/master/packages/react-data-grid-addons/src/__tests__/Grid.spec.js) in the package `react-data-grid-addons`. 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Use is only able to drag up and down when `enableCellSelect=true`. 


**What is the new behavior?**
Adds the toggles `enableDragVertical` and `enableDragHorizontal` which allow the user to control how they can drag values across the grid. The `enableDragHorizontal` toggle accesses new functionality which allows the user to copy values across the grid horizontally. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
The `handleDragEnterRow` is essentially deprecated with this update, but still contains it's old functionality for the sake of avoiding a breaking change. In the future, the `handleDragEnterRow` should be replaced with `handleDragEnterCell`. It also should be noted that `handleDragEnterRow` _currently_ is called every time `handleDragEnterCell` is called (meaning even if the row hasn't been left, the function gets called) meaning it might need to have been renamed anyway.  
