### PR TITLE
Fix for #868: SelectAll behavior broken with multiple grids

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -47,6 +47,8 @@ type ColumnMetricsType = {
   minColumnWidth: number;
 };
 
+let _lastId = 0;
+
 class ReactDataGrid extends React.Component {
   static displayName = 'ReactDataGrid';
 
@@ -169,6 +171,7 @@ class ReactDataGrid extends React.Component {
   }
 
   componentWillMount() {
+    this._id = ++_lastId;
     this._mounted = true;
   }
 
@@ -1142,7 +1145,7 @@ class ReactDataGrid extends React.Component {
     let unshiftedCols = {};
     if (this.props.rowActionsCell || (props.enableRowSelect && !this.props.rowSelection) || (props.rowSelection && props.rowSelection.showCheckbox !== false)) {
       const SelectAllComponent = this.props.selectAllRenderer || SelectAll;
-      const SelectAllRenderer = <SelectAllComponent onChange={this.handleCheckboxChange} inputRef={grid => this.selectAllCheckbox = grid} />;
+      const SelectAllRenderer = <SelectAllComponent onChange={this.handleCheckboxChange} inputRef={grid => this.selectAllCheckbox = grid} id={_lastId} />;
       let headerRenderer = props.enableRowSelect === 'single' ? null : SelectAllRenderer;
       let Formatter = this.props.rowActionsCell ? this.props.rowActionsCell : CheckboxEditor;
       let selectColumn = {

--- a/packages/react-data-grid/src/formatters/SelectAll.js
+++ b/packages/react-data-grid/src/formatters/SelectAll.js
@@ -8,11 +8,11 @@ const SelectAll = (props) => {
         className="react-grid-checkbox"
         type="checkbox"
         name="select-all-checkbox"
-        id="select-all-checkbox"
+        id={"select-all-checkbox" + props.id}
         ref={props.inputRef}
         onChange={props.onChange}
       />
-      <label htmlFor="select-all-checkbox" className="react-grid-checkbox-label"></label>
+      <label htmlFor={"select-all-checkbox" + props.id} className="react-grid-checkbox-label"></label>
     </div>
   );
 };


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

If two or more grids are present at once, clicking on the SelectAll checkbox always toggles rows for the grid that was rendered first. This is because the ID `select-all-checkbox` is not unique throughout the page.

<img src="http://g.recordit.co/iYBHr9Yqhb.gif" />

**What is the new behavior?**

Clicking on the SelectAll checkbox toggles rows for the grid it belongs to, not another grid.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This PR appends an instance count to the ID attribute, i.e. `select-all-checkbox3` for the 3rd instance of a ReactDataGrid. There may be other ways to achieve this, but this is guaranteed unique across instances.