### PR TITLE
Correct link to Formatters in readme

### DIFF
--- a/packages/react-data-grid-addons/README.md
+++ b/packages/react-data-grid-addons/README.md
@@ -36,7 +36,7 @@ This package exports:
 name                   | source                                     |
 -----------------------|--------------------------------------------|
 Editors                | [Editors](./src/editors)                   |
-Formatters             | [Formatters](./src/Formatters)             |
+Formatters             | [Formatters](./src/formatters)             |
 Toolbar                | [Toolbar](./src/toolbars/Toolbar.js)       |
 ToolsPanel             | [ToolsPanelCell](./src/toolbars)           |
 Data                   | [Data](./src/data)                         |


### PR DESCRIPTION
A tiny change to the readme to correct the link to the formatters directory.