### PR TITLE
Fix for Select All not getting checked if all rows are selected manully

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -140,6 +140,7 @@ class ReactDataGrid extends React.Component {
 
     this.state = initialState;
     this.eventBus = new EventBus();
+    this._selectedRowsCount = 0;
   }
 
   componentDidMount() {
@@ -468,9 +469,16 @@ class ReactDataGrid extends React.Component {
     this.setState({lastRowIdxUiSelected: isPreviouslySelected ? -1 : rowIdx, selected: {rowIdx: rowIdx, idx: 0}});
 
     if (isPreviouslySelected && typeof this.props.rowSelection.onRowsDeselected === 'function') {
+      this._selectedRowsCount -= 1;
       this.props.rowSelection.onRowsDeselected([{rowIdx, row: rowData}]);
     } else if (!isPreviouslySelected && typeof this.props.rowSelection.onRowsSelected === 'function') {
+      this._selectedRowsCount += 1;
       this.props.rowSelection.onRowsSelected([{rowIdx, row: rowData}]);
+    }
+    if (this.selectAllCheckbox && this.selectAllCheckbox.checked === false) {
+      if (this._selectedRowsCount === this.props.rowsCount) {
+        this.selectAllCheckbox.checked = true;
+      }
     }
   };
 
@@ -507,8 +515,10 @@ class ReactDataGrid extends React.Component {
     let allRowsSelected;
     if (e.currentTarget instanceof HTMLInputElement && e.currentTarget.checked === true) {
       allRowsSelected = true;
+      this._selectedRowsCount = this.props.rowsCount;
     } else {
       allRowsSelected = false;
+      this._selectedRowsCount = 0;
     }
     if (this.useNewRowSelection()) {
       let {keys, indexes, isSelectedKey} = this.props.rowSelection.selectBy;


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
If "Row Selection" is enabled and user manually selects all rows checkboxes then "Select All" checkbox doesn't get checked automatically


**What is the new behavior?**
If user select all rows manually "Select All" will be checked.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
No test cases were found for select all in "Row Selection" We should add it