### PR TITLE
EditorContainer Y position fix when scrolling the page in cell editing status

### DIFF
--- a/packages/common/editors/EditorContainer.js
+++ b/packages/common/editors/EditorContainer.js
@@ -68,7 +68,7 @@ class EditorContainer extends React.Component {
   calculateTransform = () => {
     const { column, left, scrollLeft, top, scrollTop } = this.props;
     const editorLeft = isFrozen(column) ? left : left - scrollLeft;
-    const editorTop = top - scrollTop - window.scrollY;
+    const editorTop = top - scrollTop - window.pageYOffset;
     return `translate(${editorLeft}px, ${editorTop}px)`;
   }
 

--- a/packages/common/editors/EditorContainer.js
+++ b/packages/common/editors/EditorContainer.js
@@ -42,6 +42,8 @@ class EditorContainer extends React.Component {
         inputNode.style.height = this.props.height - 1 + 'px';
       }
     }
+
+    window.addEventListener('scroll', this.setContainerTransform);
   }
 
   componentDidUpdate(prevProps) {
@@ -54,6 +56,20 @@ class EditorContainer extends React.Component {
     if (!this.changeCommitted && !this.changeCanceled) {
       this.commit({key: 'Enter'});
     }
+    window.removeEventListener('scroll', this.setContainerTransform);
+  }
+
+  setContainerTransform = (): void => {
+    if (this.containerRef) {
+      this.containerRef.style.transform = this.calculateTransform();
+    }
+  }
+
+  calculateTransform = () => {
+    const { column, left, scrollLeft, top, scrollTop } = this.props;
+    const editorLeft = isFrozen(column) ? left : left - scrollLeft;
+    const editorTop = top - scrollTop - window.scrollY;
+    return `translate(${editorLeft}px, ${editorTop}px)`;
   }
 
   isKeyExplicitlyHandled = (key: string): boolean => {
@@ -330,13 +346,11 @@ class EditorContainer extends React.Component {
   };
 
   render() {
-    const { left, top, width, height, column, scrollLeft, scrollTop } = this.props;
-    const editorLeft = isFrozen(column) ? left : left - scrollLeft;
-    const editorTop = top - scrollTop;
+    const { width, height, column } = this.props;
     const zIndex = isFrozen(column) ? zIndexes.FROZEN_EDITOR_CONTAINER  : zIndexes.EDITOR_CONTAINER;
-    const style = { position: 'fixed', height, width, zIndex, transform: `translate(${editorLeft}px, ${editorTop}px)` };
+    const style = { position: 'fixed', height, width, zIndex, transform: this.calculateTransform() };
     return (
-        <div style={style} className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} onContextMenu={this.handleRightClick}>
+        <div ref={ref => this.containerRef = ref} style={style} className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} onContextMenu={this.handleRightClick}>
           {this.createEditor()}
           {this.renderStatusIcon()}
         </div>

--- a/packages/react-data-grid/src/masks/CellMask.js
+++ b/packages/react-data-grid/src/masks/CellMask.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const setMaskStyle = ({ left, top, width, height, zIndex, position }) => {
+  const topWithOffset = top - window.scrollY;
   return {
     height,
     width,
     zIndex,
     position: position || 'absolute',
     pointerEvents: 'none',
-    transform: `translate(${left}px, ${top}px)`
+    transform: `translate(${left}px, ${topWithOffset}px)`
   };
 };
 

--- a/packages/react-data-grid/src/masks/CellMask.js
+++ b/packages/react-data-grid/src/masks/CellMask.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const setMaskStyle = ({ left, top, width, height, zIndex, position }) => {
-  const topWithOffset = top - window.scrollY;
   return {
     height,
     width,
     zIndex,
     position: position || 'absolute',
     pointerEvents: 'none',
-    transform: `translate(${left}px, ${topWithOffset}px)`
+    transform: `translate(${left}px, ${top}px)`
   };
 };
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When the cell is in editing status, and window scroll bar is available, the editor Y position is not updated when scrolling the page.


**What is the new behavior?**
The editor should be scrolled along with the grid, i.e. keep the relative same position in the grid.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

![rdg editorcontainer y position bug](https://user-images.githubusercontent.com/25043398/46900675-9c114480-ce6b-11e8-9e09-4454403f1fae.gif)
