### PR TITLE
Move DropTargetRowContainer static styles to CSS class for user customization

### DIFF
--- a/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
@@ -19,7 +19,7 @@ let rowDropTarget = (Row) => class extends React.Component {
     let overlayTop = this.props.idx * this.props.height;
     return connectDropTarget(<div>
       <Row ref={(node) => this.row = node} {...this.props}/>
-      {isOver && canDrop && <div class='rowDropTarget' style={{
+      {isOver && canDrop && <div className="rowDropTarget" style={{
         top: overlayTop,
         height: this.props.height
       }} /> }

--- a/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
@@ -19,14 +19,9 @@ let rowDropTarget = (Row) => class extends React.Component {
     let overlayTop = this.props.idx * this.props.height;
     return connectDropTarget(<div>
       <Row ref={(node) => this.row = node} {...this.props}/>
-      {isOver && canDrop && <div style={{
-        position: 'absolute',
+      {isOver && canDrop && <div class='rowDropTarget' style={{
         top: overlayTop,
-        left: 0,
-        height: this.props.height,
-        width: '100%',
-        zIndex: 1,
-        borderBottom: '1px solid black'
+        height: this.props.height
       }} /> }
     </div>);
   }

--- a/themes/react-data-grid-drop-target.css
+++ b/themes/react-data-grid-drop-target.css
@@ -1,14 +1,14 @@
 .slideUp{
 	animation-name: slideUp;
-	-webkit-animation-name: slideUp;	
+	-webkit-animation-name: slideUp;
 
 	animation-duration: 1s;	
 	-webkit-animation-duration: 1s;
 
-	animation-timing-function: ease;	
+	animation-timing-function: ease;
 	-webkit-animation-timing-function: ease;
 
-	visibility: visible !important;			
+	visibility: visible !important;
 }
 
 @keyframes slideUp {
@@ -26,10 +26,10 @@
 	}
 	95%{
 		transform: translateY(2%);
-	}			
+	}
 	100% {
 		transform: translateY(0%);
-	}	
+	}
 }
 
 
@@ -48,8 +48,16 @@
 	}
 	95%{
 		-webkit-transform: translateY(2%);
-	}			
+	}
 	100% {
 		-webkit-transform: translateY(0%);
-	}	
+	}
+}
+
+.rowDropTarget {
+	position: 'absolute',
+	left: 0,
+	width: '100%',
+  zIndex: 1,
+	borderBottom: '1px solid black'
 }

--- a/themes/react-data-grid-drop-target.css
+++ b/themes/react-data-grid-drop-target.css
@@ -55,9 +55,9 @@
 }
 
 .rowDropTarget {
-	position: 'absolute',
-	left: 0,
-	width: '100%',
-  zIndex: 1,
-	borderBottom: '1px solid black'
+	position: absolute;
+	left: 0;
+	width: 100%;
+	z-index: 1;
+	border-bottom: 1px solid black;
 }


### PR DESCRIPTION
## Description
Updates the `DropTargetRowContainer` to change the `div` to have a defined `className`, allowing for users to modify the CSS styling as desired.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**

`DropTargetRowContainer` defined its CSS style rules inline, making them unable to be changed easily.

**What is the new behavior?**

Outside of `top` and `height`, which are defined from `props`, the rest of the CSS rules have been moved into `react-data-grid-drop-target.css` under a class name of `rowDropTarget`.  This allows a user to define a CSS rule and create their own styles.  The functionality of everything remains the same.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```