### PR TITLE
Replace use of i for column index which is no longer passed in

### DIFF
--- a/packages/react-data-grid/src/Row.js
+++ b/packages/react-data-grid/src/Row.js
@@ -56,7 +56,7 @@ class Row extends React.Component {
     e.preventDefault();
   };
 
-  getCell = (column, i) => {
+  getCell = (column) => {
     const CellRenderer = this.props.cellRenderer;
     const { idx, cellMetaData, isScrolling, row, isSelected, scrollLeft, lastFrozenColumnIndex } = this.props;
     const { key, formatter } = column;
@@ -66,7 +66,7 @@ class Row extends React.Component {
       ref: (node) => {
         this[key] = node;
       },
-      value: this.getCellValue(key || i),
+      value: this.getCellValue(key || column.idx),
       rowData: row,
       isRowSelected: isSelected,
       expandableOptions: this.getExpandableOptions(key),


### PR DESCRIPTION
## Description
In a previous PR, the column index `i` had been partly replaced. However, it wasn't fully rolled out, so the fallback to using the column index as the key is no longer working. This was part of the cause of https://github.com/adazzle/react-data-grid/issues/1343

This PR fully implements the replacement of `i` with `column.idx`.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Nested arrays cannot be displayed correctly in a Grid since v5

**What is the new behavior?**
Nested arrays can now be displayed


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
