### PR TITLE
Remove react-data-grid dependency from the addons package

### DIFF
--- a/packages/react-data-grid-addons/package.json
+++ b/packages/react-data-grid-addons/package.json
@@ -17,7 +17,8 @@
   "devDependencies": {
     "jquery": "^2.1.1",
     "lodash": "^4.13.1",
-    "lodash.groupby": "^4.5.1"
+    "lodash.groupby": "^4.5.1",
+    "react-data-grid": "^5.0.2"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",

--- a/packages/react-data-grid-addons/package.json
+++ b/packages/react-data-grid-addons/package.json
@@ -14,9 +14,6 @@
   ],
   "author": "Adazzle",
   "license": "MIT",
-  "dependencies": {
-    "react-data-grid": "^5.0.2"
-  },
   "devDependencies": {
     "jquery": "^2.1.1",
     "lodash": "^4.13.1",


### PR DESCRIPTION
`react-data-grid-addons` is no longer dependent on `react-data-grid` 
https://github.com/adazzle/react-data-grid/pull/1272 