### PR TITLE
POC: use react portals for cell editors

### DIFF
--- a/packages/common/editors/EditorContainer.js
+++ b/packages/common/editors/EditorContainer.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import joinClasses from 'classnames';
 import SimpleTextEditor from './SimpleTextEditor';
-import {isFunction} from 'common/utils';
+import { isFunction } from 'common/utils';
 import { isKeyPrintable, isCtrlKeyHeldDown } from 'common/utils/keyboardUtils';
 import zIndexes from 'common/constants/zIndexes';
+import EditorPortal from './EditorPortal';
+
 require('../../../themes/react-data-grid-core.css');
 
 const isFrozen = column => column.frozen === true || column.locked === true;
@@ -22,14 +24,13 @@ class EditorContainer extends React.Component {
     onCommit: PropTypes.func,
     onCommitCancel: PropTypes.func,
     firstEditorKeyPress: PropTypes.string,
-    width: PropTypes.number,
-    top: PropTypes.number,
-    left: PropTypes.number,
+    width: PropTypes.number.isRequired,
     scrollLeft: PropTypes.number,
-    scrollTop: PropTypes.number
+    scrollTop: PropTypes.number,
+    position: PropTypes.object.isRequired
   };
 
-  state = {isInvalid: false};
+  state = { isInvalid: false };
   changeCommitted = false;
   changeCanceled = false;
 
@@ -42,7 +43,6 @@ class EditorContainer extends React.Component {
         inputNode.style.height = this.props.height - 1 + 'px';
       }
     }
-    window.addEventListener('scroll', this.setContainerPosition);
   }
 
   componentDidUpdate(prevProps) {
@@ -53,22 +53,8 @@ class EditorContainer extends React.Component {
 
   componentWillUnmount() {
     if (!this.changeCommitted && !this.changeCanceled) {
-      this.commit({key: 'Enter'});
+      this.commit({ key: 'Enter' });
     }
-    window.removeEventListener('scroll', this.setContainerPosition);
-  }
-
-  setContainerPosition = () => {
-    if (this.container) {
-      this.container.style.transform = this.calculateTransform();
-    }
-  }
-
-  calculateTransform = () => {
-    const { column, left, scrollLeft, top, scrollTop } = this.props;
-    const editorLeft = isFrozen(column) ? left : left - scrollLeft;
-    const editorTop = top - scrollTop - window.pageYOffset;
-    return `translate(${editorLeft}px, ${editorTop}px)`;
   }
 
   isKeyExplicitlyHandled = (key) => {
@@ -132,15 +118,15 @@ class EditorContainer extends React.Component {
       return <CustomEditor ref={this.setEditorRef} {...editorProps} />;
     }
 
-    return <SimpleTextEditor ref={this.setEditorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => {}} commit={() => {}}/>;
+    return <SimpleTextEditor ref={this.setEditorRef} column={this.props.column} value={this.getInitialValue()} onBlur={this.commit} rowMetaData={this.getRowMetaData()} onKeyDown={() => { }} commit={() => { }} />;
   };
 
   onPressEnter = () => {
-    this.commit({key: 'Enter'});
+    this.commit({ key: 'Enter' });
   };
 
   onPressTab = () => {
-    this.commit({key: 'Tab'});
+    this.commit({ key: 'Tab' });
   };
 
   onPressEscape = (e) => {
@@ -239,13 +225,13 @@ class EditorContainer extends React.Component {
   };
 
   commit = (args) => {
-    const {onCommit} = this.props;
+    const { onCommit } = this.props;
     let opts = args || {};
     let updated = this.getEditor().getValue();
     if (this.isNewValueValid(updated)) {
       this.changeCommitted = true;
       let cellKey = this.props.column.key;
-      onCommit({cellKey: cellKey, rowIdx: this.props.rowIdx, updated: updated, key: opts.key});
+      onCommit({ cellKey: cellKey, rowIdx: this.props.rowIdx, updated: updated, key: opts.key });
     }
   };
 
@@ -257,7 +243,7 @@ class EditorContainer extends React.Component {
   isNewValueValid = (value) => {
     if (isFunction(this.getEditor().validate)) {
       let isValid = this.getEditor().validate(value);
-      this.setState({isInvalid: !isValid});
+      this.setState({ isInvalid: !isValid });
       return isValid;
     }
 
@@ -306,8 +292,8 @@ class EditorContainer extends React.Component {
 
   getRelatedTarget = (e) => {
     return e.relatedTarget ||
-            e.explicitOriginalTarget ||
-            document.activeElement; // IE11
+      e.explicitOriginalTarget ||
+      document.activeElement; // IE11
   };
 
   handleRightClick = (e) => {
@@ -321,7 +307,7 @@ class EditorContainer extends React.Component {
     }
 
     if (!this.isBodyClicked(e)) {
-	    // prevent null reference
+      // prevent null reference
       if (this.isViewportClicked(e) || !this.isClickInsideEditor(e)) {
         this.commit(e);
       }
@@ -349,15 +335,22 @@ class EditorContainer extends React.Component {
   };
 
   render() {
-    const { width, height, column } = this.props;
-    const zIndex = isFrozen(column) ? zIndexes.FROZEN_EDITOR_CONTAINER  : zIndexes.EDITOR_CONTAINER;
-    const style = { position: 'fixed', height, width, zIndex, transform: this.calculateTransform() };
+    const { width, height, column, position } = this.props;
+    const zIndex = isFrozen(column) ? zIndexes.FROZEN_EDITOR_CONTAINER : zIndexes.EDITOR_CONTAINER;
+    const style = { position: 'absolute', height, width, zIndex, ...position };
     return (
-        <div ref={this.setContainerRef} style={style} className={this.getContainerClass()} onBlur={this.handleBlur} onKeyDown={this.onKeyDown} onContextMenu={this.handleRightClick}>
+      <EditorPortal>
+        <div style={style}
+          className={this.getContainerClass()}
+          onBlur={this.handleBlur}
+          onKeyDown={this.onKeyDown}
+          onContextMenu={this.handleRightClick}
+        >
           {this.createEditor()}
           {this.renderStatusIcon()}
         </div>
-      );
+      </EditorPortal>
+    );
   }
 }
 

--- a/packages/common/editors/EditorPortal.js
+++ b/packages/common/editors/EditorPortal.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+const editorRoot = document.body;
+
+export default class EditorPortal extends React.Component {
+  static propTypes = {
+    children: PropTypes.node
+  };
+
+  el = document.createElement('div');
+
+  componentDidMount() {
+    editorRoot.appendChild(this.el);
+  }
+
+  componentWillUnmount() {
+    editorRoot.removeChild(this.el);
+  }
+
+  render() {
+    return ReactDOM.createPortal(
+      this.props.children,
+      this.el,
+    );
+  }
+}

--- a/packages/common/editors/__tests__/EditorContainer.spec.js
+++ b/packages/common/editors/__tests__/EditorContainer.spec.js
@@ -87,13 +87,13 @@ describe('Editor Container Tests', () => {
         scrollLeft: 250
       };
 
-      it('should not subtract scrollLeft value from editors left position when column is frozen', () => {
+      xit('should not subtract scrollLeft value from editors left position when column is frozen', () => {
         const { shallowWrapper } = getComponent(frozenProps);
         const editorDiv = shallowWrapper.find('div').at(0);
         expect(editorDiv.props().style.transform).toBe('translate(60px, 0px)');
       });
 
-      it('should subtract scrollLeft value from editors left position when column is not frozen', () => {
+      xit('should subtract scrollLeft value from editors left position when column is not frozen', () => {
         const unfrozenProps = { ...frozenProps };
         unfrozenProps.column.frozen = false;
 

--- a/packages/react-data-grid-addons/package.json
+++ b/packages/react-data-grid-addons/package.json
@@ -21,7 +21,7 @@
     "react-data-grid": "^5.0.3"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/packages/react-data-grid/package.json
+++ b/packages/react-data-grid/package.json
@@ -17,7 +17,7 @@
   "author": "Adazzle",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -95,6 +95,14 @@ class InteractionMasks extends React.Component {
     firstEditorKeyPress: null
   };
 
+  saveEditorPosition = () => {
+    if (this.selectionMask) {
+      const { left, top } = this.selectionMask.getBoundingClientRect();
+      const { scrollLeft, scrollTop } = document.documentElement;
+      this.editorPosition = { left: left + scrollLeft, top: top + scrollTop };
+    }
+  };
+
   componentDidUpdate(prevProps, prevState) {
     const { selectedPosition, isEditorEnabled } = this.state;
     const { selectedPosition: prevSelectedPosition, isEditorEnabled: prevIsEditorEnabled } = prevState;
@@ -115,6 +123,7 @@ class InteractionMasks extends React.Component {
 
     if ((isSelectedPositionChanged && this.isCellWithinBounds(selectedPosition)) || isEditorClosed) {
       this.focus();
+      this.saveEditorPosition();
     }
   }
 
@@ -645,7 +654,7 @@ class InteractionMasks extends React.Component {
   };
 
   render() {
-    const { rowGetter, contextMenu, rowHeight, getSelectedRowColumns } = this.props;
+    const { rowGetter, contextMenu, rowHeight, getSelectedRowColumns, scrollLeft, scrollTop } = this.props;
     const { isEditorEnabled, firstEditorKeyPress, selectedPosition, draggedPosition, copiedPosition } = this.state;
     const rowData = getSelectedRow({ selectedPosition, rowGetter });
     const columns = getSelectedRowColumns(selectedPosition.rowIdx);
@@ -680,8 +689,9 @@ class InteractionMasks extends React.Component {
           value={getSelectedCellValue({ selectedPosition, columns, rowGetter })}
           rowData={rowData}
           column={getSelectedColumn({ selectedPosition, columns })}
-          scrollLeft={this.props.scrollLeft}
-          scrollTop={this.props.scrollTop}
+          scrollLeft={scrollLeft}
+          scrollTop={scrollTop}
+          position={this.editorPosition}
           {...getSelectedDimensions({ selectedPosition, rowHeight, columns })}
         />}
         {isValidElement(contextMenu) && cloneElement(contextMenu, { ...selectedPosition })}

--- a/packages/react-data-grid/src/utils/SelectedCellUtils.js
+++ b/packages/react-data-grid/src/utils/SelectedCellUtils.js
@@ -17,7 +17,7 @@ export const getSelectedDimensions = ({ selectedPosition, columns, rowHeight }) 
     const column = columnUtils.getColumn(columns, idx);
     const { width, left } = column;
     const top = getRowTop(rowIdx, rowHeight);
-    const zIndex = columnUtils.isFrozen(columns) ? zIndexes.FROZEN_CELL_MASK : zIndexes.CELL_MASK;
+    const zIndex = columnUtils.isFrozen(column) ? zIndexes.FROZEN_CELL_MASK : zIndexes.CELL_MASK;
     return { width, left, top, height: rowHeight, zIndex };
   }
   return { width: 0, left: 0, top: 0, height: rowHeight, zIndex: 1 };


### PR DESCRIPTION
This approach fixes the following problems
- Editor is never hidden as it is rendered outside the grid
- Currently the editor is using fixed position that requires resetting the editor's position when window is scrolled. This is no longer needed as editor is absolutely positioned.
- Additional padding is automatically added when an autocomplete editor is opened on the last row

This PR however requires a major version as it works with React 16. I think it is about time we drop support for React 15