### PR TITLE
Remove utils from documentation as an exported module

### DIFF
--- a/packages/react-data-grid/README.md
+++ b/packages/react-data-grid/README.md
@@ -1,7 +1,7 @@
 # react-data-grid
 
 > The core of react-data-grid
- 
+
 
 ## Install
 
@@ -9,7 +9,7 @@
 npm install --save react-data-grid
 ```
 
-## Usage 
+## Usage
 
 ```sh
 import ReactDataGrid from 'react-data-grid';
@@ -39,7 +39,6 @@ Cell                   | [Cell](./src/Cell.js)                   |
 HeaderCell             | [HeaderCell](./src/HeaderCell.js)       |
 editors                | [Editors](./src/editors)                |
 formatters             | [Formatters](./src/formatters)          |
-utils                  | [utils](./src/utils)                    |
 shapes                 | [shapes](./src/PropTypeShapes)          |
 _constants             | [_constants](./src/AppConstants.js)     |
 _helpers               | [_helpers](./src/helpers)               |


### PR DESCRIPTION
## Description
Remove `utils` as an exported module since this is no longer true

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Other... Please describe:
Documentation changes

```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
