### PR TITLE
Prevent react propTypes warning for CheckboxEditor checkbox

### DIFF
--- a/packages/common/editors/CheckboxEditor.js
+++ b/packages/common/editors/CheckboxEditor.js
@@ -22,7 +22,7 @@ class CheckboxEditor extends React.Component {
     const checkboxName = 'checkbox' + this.props.rowIdx;
     return (
       <div className="react-grid-checkbox-container checkbox-align" onClick={this.handleChange}>
-          <input className="react-grid-checkbox" type="checkbox" name={checkboxName} checked={checked} />
+          <input className="react-grid-checkbox" type="checkbox" name={checkboxName} checked={checked} readOnly />
           <label htmlFor={checkboxName} className="react-grid-checkbox-label"></label>
       </div>);
   }

--- a/packages/common/editors/__tests__/CheckboxEditor.spec.js
+++ b/packages/common/editors/__tests__/CheckboxEditor.spec.js
@@ -1,26 +1,44 @@
 const React          = require('react');
 const ReactDOM = require('react-dom');
 const TestUtils      = require('react-dom/test-utils');
-const CheckboxEditor = require('../CheckboxEditor');
 const { mount } = require('enzyme');
+const sinon = require('sinon');
+const CheckboxEditor = require('../CheckboxEditor');
 
 describe('CheckboxEditor', () => {
   let component;
   let componentWrapper;
+  let consoleErrorStub;
   const testColumn = {
     key: 'columnKey',
     onCellChange: function() {}
   };
 
   describe('Basic tests', () => {
+    afterEach(() => {
+      consoleErrorStub.restore();
+    });
+
     beforeEach(() => {
       spyOn(testColumn, 'onCellChange');
+      consoleErrorStub = sinon.stub(console, 'error');
       componentWrapper = mount(<CheckboxEditor
         value={true}
         rowIdx={1}
         column={testColumn}/>);
       component = componentWrapper.instance();
     });
+
+    it('should not send warning message to console.error', () => {
+      expect(consoleErrorStub.callCount).toBe(0);
+    });
+
+    it('should have a readOnly flag set', () => {
+      const Input = TestUtils.findRenderedDOMComponentWithTag(component, 'input');
+      const checkboxNode = ReactDOM.findDOMNode(Input);
+      expect(checkboxNode.readOnly).toBe(true);
+    });
+
 
     it('should create a new CheckboxEditor instance', () => {
       expect(component).toBeDefined();

--- a/packages/common/editors/__tests__/CheckboxEditor.spec.js
+++ b/packages/common/editors/__tests__/CheckboxEditor.spec.js
@@ -2,35 +2,25 @@ const React          = require('react');
 const ReactDOM = require('react-dom');
 const TestUtils      = require('react-dom/test-utils');
 const { mount } = require('enzyme');
-const sinon = require('sinon');
 const CheckboxEditor = require('../CheckboxEditor');
 
 describe('CheckboxEditor', () => {
   let component;
   let componentWrapper;
-  let consoleErrorStub;
   const testColumn = {
     key: 'columnKey',
     onCellChange: function() {}
   };
 
   describe('Basic tests', () => {
-    afterEach(() => {
-      consoleErrorStub.restore();
-    });
 
     beforeEach(() => {
       spyOn(testColumn, 'onCellChange');
-      consoleErrorStub = sinon.stub(console, 'error');
       componentWrapper = mount(<CheckboxEditor
         value={true}
         rowIdx={1}
         column={testColumn}/>);
       component = componentWrapper.instance();
-    });
-
-    it('should not send warning message to console.error', () => {
-      expect(consoleErrorStub.callCount).toBe(0);
     });
 
     it('should have a readOnly flag set', () => {


### PR DESCRIPTION
## Description
Addressing closed issue #949, this PR makes the CheckboxEditor checkbox input element readOnly. The element is not attached to a form, and this change makes no functional difference. It does prevent a React propTypes warning that gets printed to console.error when running downstream tests, etc. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md

I don't actually see any such guidelines, so I'll assume not much attention is being paid.  

- [x] Tests for the changes have been added (for bug fixes / features)

Two tests added to demonstrate desired behavior. 

- [x] Docs have been added / updated (for bug fixes / features)

This seems unnecessary for such a minor change with no functional impact. 

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
```
    console.error node_modules/prop-types/checkPropTypes.js:19
      Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.
          in input (created by CheckboxEditor)
          in div (created by CheckboxEditor)
          in CheckboxEditor
          in span (created by Cell)
          in div (created by Cell)
          in div (created by Cell)
          in div (created by Cell)
          in Cell (created by Row)
          in div (created by Row)
          in Row (created by Canvas)
          in div (created by Canvas)
          in RowsContainer (created by Canvas)
          in div (created by Canvas)
          in Canvas (created by Viewport)
          in div (created by Viewport)
          in Viewport (created by Grid)
          in div (created by Grid)
          in div (created by Grid)
          in Grid (created by ReactDataGrid)
          in div (created by ReactDataGrid)
          in div (created by ReactDataGrid)
          in ReactDataGrid (at RequestTable.js:172)
          in div (at RequestTable.js:171)
          in RequestTable (created by WrapperComponent)
          in WrapperComponent
```


**What is the new behavior?**
No functional change, but the warning message is no longer sent to console.error.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
