### PR TITLE
Add prepatch, premajor, preminor release options

### DIFF
--- a/ci/publish/publish.ps1
+++ b/ci/publish/publish.ps1
@@ -1,3 +1,11 @@
+$major = node ./ci/publish/getNextVersion major
+$minor = node ./ci/publish/getNextVersion minor
+$patch = node ./ci/publish/getNextVersion patch
+$premajor = node ./ci/publish/getNextVersion premajor
+$preminor = node ./ci/publish/getNextVersion preminor
+$prepatch = node ./ci/publish/getNextVersion prepatch
+$prerelease = node ./ci/publish/getNextVersion prerelease
+
 function Show-Menu
 {
      param (
@@ -6,9 +14,13 @@ function Show-Menu
      cls
      Write-Host "================ $Title ================"
      
-     Write-Host "Major Release: Press '1' for this option."
-     Write-Host "Minor Release: Press '2' for this option."
-     Write-Host "Patch Release: Press '3' for this option."
+     Write-Host "Major Release -> $($major) Press '1' for this option."
+     Write-Host "Minor Release -> $($minor)  Press '2' for this option."
+     Write-Host "Patch Release -> $($patch) Press '3' for this option."
+     Write-Host "Premajor Release -> $($premajor) Press '4' for this option."
+     Write-Host "Preminor Release -> $($preminor) Press '5' for this option."
+     Write-Host "Prepatch Release -> $($prepatch) Press '6' for this option."
+     Write-Host "Prerelease -> $($prerelease) Press '7' for this option."
      Write-Host "Q: Press 'Q' to quit."
 }
 
@@ -19,21 +31,34 @@ do
      switch ($input)
      {
            '1' {
-            $nextVersion = node ./ci/publish/getNextVersion major
+            $nextVersion = $major
             Write-Host "Attempting to publishing new major version $($nextVersion) to npm"
            } '2' {
-            $nextVersion = node ./ci/publish/getNextVersion minor
+            $nextVersion =$minor
                 Write-Host "Attempting to publishing new minor version $($nextVersion) to npm"
            } '3' {
-            $nextVersion = node ./ci/publish/getNextVersion patch
+            $nextVersion = $patch
                 Write-Host "Attempting to publishing new patch version $($nextVersion) to npm"
+           }'4' {
+            $nextVersion = $premajor
+                Write-Host "Attempting to publishing new premajor version $($nextVersion) to npm"
+           } '5' {
+            $nextVersion = $preminor
+                Write-Host "Attempting to publishing new preminor version $($nextVersion) to npm"
+           } '6' {
+            $nextVersion = $prepatch
+                Write-Host "Attempting to publishing new prepatch version $($nextVersion) to npm"
+           } '7' {
+            $nextVersion = $prerelase
+                Write-Host "Attempting to publishing new prerelease version $($nextVersion) to npm"
            } 'q' {
                 return
            }
      }
      pause
 }
-until ($input -eq 'q' -Or $input -eq '1' -Or $input -eq '2' -Or $input -eq '3')
+until ($input -eq 'q' -Or $input -eq '1' -Or $input -eq '2' -Or $input -eq '3' -Or $input -eq '4' -Or $input -eq '5' -Or $input -eq '6' -Or $input -eq '7' )
+
 
 Write-Host "Installing dependencies before publish"
 npm install

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.8.0",
-  "version": "5.0.4",
+  "version": "6.0.0-alpha.0",
   "packages": [
     "packages/*"
   ]

--- a/packages/react-data-grid-addons/package.json
+++ b/packages/react-data-grid-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid-addons",
-  "version": "5.0.4",
+  "version": "6.0.0-alpha.0",
   "description": "A set of addons for react-data-grid",
   "scripts": {
     "beforepublish": "node ../../ci/publish/replacePackageEntry react-data-grid-addons true",
@@ -18,7 +18,7 @@
     "jquery": "^2.1.1",
     "lodash": "^4.13.1",
     "lodash.groupby": "^4.5.1",
-    "react-data-grid": "^5.0.4"
+    "react-data-grid": "^6.0.0-alpha.0"
   },
   "peerDependencies": {
     "react": "^16.0.0",

--- a/packages/react-data-grid-examples/package.json
+++ b/packages/react-data-grid-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid-examples",
-  "version": "5.0.4",
+  "version": "6.0.0-alpha.0",
   "description": "A set of examples for the grid",
   "main": "main.js",
   "scripts": {
@@ -18,8 +18,8 @@
   "license": "MIT",
   "dependencies": {
     "immutability-helper": "^2.7.0",
-    "react-data-grid": "^5.0.4",
-    "react-data-grid-addons": "^5.0.4",
+    "react-data-grid": "^6.0.0-alpha.0",
+    "react-data-grid-addons": "^6.0.0-alpha.0",
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {

--- a/packages/react-data-grid/package.json
+++ b/packages/react-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid",
-  "version": "5.0.4",
+  "version": "6.0.0-alpha.0",
   "description": "Excel-like grid component built with React, with editors, keyboard navigation, copy & paste, and the like",
   "scripts": {
     "beforepublish": "node ../../ci/publish/replacePackageEntry react-data-grid true",


### PR DESCRIPTION
This PR allows to pubish prepatch, premajor, preminor and prerelease versions.

The following dialogue will be shown on publish as an example

```
================ React Data Grid Publish Options ================
Major Release -> 6.0.0 Press '1' for this option.
Minor Release -> 5.1.0  Press '2' for this option.
Patch Release -> 5.0.5 Press '3' for this option.
Premajor Release -> 6.0.0-0 Press '4' for this option.
Preminor Release -> 5.1.0-0 Press '5' for this option.
Prepatch Release -> 5.0.5-0 Press '6' for this option.
Prerelease -> 5.0.5-0 Press '7' for this option.
Q: Press 'Q' to quit.
Please choose a version type to publish:```