### PR TITLE
Enable the no-class-assign

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     "no-new-symbol": 2,
     "no-this-before-super": 2,
     "arrow-spacing": 1,
+    "no-class-assign": 2,
 /**
  * Variables
  */

--- a/packages/react-data-grid-addons/src/draggable-header/DraggableHeaderCell.js
+++ b/packages/react-data-grid-addons/src/draggable-header/DraggableHeaderCell.js
@@ -87,11 +87,8 @@ DraggableHeaderCell.propTypes = {
   children: PropTypes.element.isRequired
 };
 
-DraggableHeaderCell = DropTarget('Column', target, targetCollect)(
-  DraggableHeaderCell
+export default DragSource('Column', headerCellSource, collect)(
+  DropTarget('Column', target, targetCollect)(
+    DraggableHeaderCell
+  )
 );
-DraggableHeaderCell = DragSource('Column', headerCellSource, collect)(
-  DraggableHeaderCell
-);
-
-export default DraggableHeaderCell;

--- a/packages/react-data-grid/src/index.js
+++ b/packages/react-data-grid/src/index.js
@@ -1,12 +1,15 @@
 import Grid from './ReactDataGrid';
 import RowComparer from 'common/utils/RowComparer';
 import Cell from './Cell';
+import Row from './Row';
+import EmptyChildRow from './EmptyChildRow';
+
 module.exports = Grid;
-module.exports.Row = require('./Row');
+module.exports.Row = Row;
 module.exports.Cell = Cell;
 module.exports.HeaderCell = require('./HeaderCell');
 module.exports.RowComparer = RowComparer;
-module.exports.EmptyChildRow = require('./EmptyChildRow');
+module.exports.EmptyChildRow = EmptyChildRow;
 module.exports.editors = require('common/editors');
 module.exports.formatters = require('./formatters');
 module.exports.shapes = require('common/prop-shapes');


### PR DESCRIPTION
- [x] Enable the `no-class-assign` rule
- [x] Fix row export. This fixes the row re-order example  