### PR TITLE
Fix: resizing right border jumps to the right.

### DIFF
--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -56,8 +56,12 @@ class HeaderCell extends React.Component {
   };
 
   getWidthFromMouseEvent = (e) => {
-    let right = e.pageX || (e.touches && e.touches[0] && e.touches[0].pageX) || (e.changedTouches && e.changedTouches[e.changedTouches.length - 1].pageX);
-    let left = ReactDOM.findDOMNode(this).getBoundingClientRect().left;
+    const right = e.pageX || (e.touches && e.touches[0] && e.touches[0].pageX) || (e.changedTouches && e.changedTouches[e.changedTouches.length - 1].pageX);
+
+    // if headerDom is a draggable div, the first element (which is the only element as well) is the actual column header div with the position info
+    const headerDom = ReactDOM.findDOMNode(this);
+    const left = headerDom.draggable ? headerDom.firstChild.getBoundingClientRect().left : headerDom.getBoundingClientRect().left;
+
     return right - left;
   };
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

fix: draggable + resizable column issue for resizing
If a column is both draggable and resizable, when resizing the right border of the current column jumps to the right.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
before fix:
![draggable resizing issue](https://user-images.githubusercontent.com/25043398/49410931-8f52f380-f72c-11e8-9496-3df00d563570.gif)

after fix:
![draggable resizing issue after fix](https://user-images.githubusercontent.com/25043398/49410937-94b03e00-f72c-11e8-98bd-9a358ec0d1c2.gif)

