### PR TITLE
fix: IE 11 editor issue for handling clicking outside of the editor

### DIFF
--- a/packages/common/editors/EditorContainer.js
+++ b/packages/common/editors/EditorContainer.js
@@ -301,7 +301,7 @@ class EditorContainer extends React.Component {
 
   isClickInsideEditor = (e) => {
     let relatedTarget = this.getRelatedTarget(e);
-    return (e.currentTarget.contains(relatedTarget) || (relatedTarget.className.indexOf('editing') > -1 || relatedTarget.className.indexOf('react-grid-Cell') > -1));
+    return e.currentTarget.contains(relatedTarget);
   };
 
   getRelatedTarget = (e) => {

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -173,7 +173,7 @@ class Cell extends React.PureComponent {
     );
     let extraClasses = joinClasses({
       'row-selected': this.props.isRowSelected,
-      editing: this.isEditorEnabled(),
+      editing: this.isEditorEnabled(), // I think this attribute is deprecated after changning to the mask, isn't it?
       'cell-tooltip': this.props.tooltip ? true : false,
       'rdg-child-cell': this.props.expandableOptions && this.props.expandableOptions.subRowDetails && this.props.expandableOptions.treeDepth > 0,
       'last-column': this.props.column.isLastColumn


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
For IE 11, when the grid is editable and one cell is in editing status, clicking on another cell will keep the editor being opened.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Abnormal behavior in IE
![ie 11 input issue](https://user-images.githubusercontent.com/25043398/49537098-a52bfa00-f88d-11e8-8245-84fb5ee39cb6.gif)

Correct behavior after fix
![ie 11 input issue after fix](https://user-images.githubusercontent.com/25043398/49537159-de646a00-f88d-11e8-8132-22ab1a7f32c8.gif)


