### PR TITLE
fix calculation of percentage based column widths

### DIFF
--- a/packages/react-data-grid/src/ColumnMetrics.js
+++ b/packages/react-data-grid/src/ColumnMetrics.js
@@ -8,9 +8,12 @@ function setColumnWidths(columns, totalWidth) {
   return columns.map(column => {
     const colInfo = Object.assign({}, column);
     if (column.width) {
-      if (/^([0-9]+)%$/.exec(column.width.toString())) {
-        colInfo.width = Math.floor(
-          column.width / 100 * totalWidth);
+      const colWidthStr = column.width.toString();
+
+      if (/^([0-9]+)%$/.exec(colWidthStr)) {
+        const colWidth = colWidthStr.slice(0, -1);
+
+        colInfo.width = Math.floor(colWidth / 100 * totalWidth);
       }
     }
     return colInfo;

--- a/packages/react-data-grid/src/__tests__/ColumnMetrics.spec.js
+++ b/packages/react-data-grid/src/__tests__/ColumnMetrics.spec.js
@@ -13,10 +13,18 @@ describe('Column Metrics Tests', () => {
   describe('Creating metrics', () => {
     describe('When column width not set for all columns', () => {
       const totalWidth = 300;
+      const expectedStaticWidth = 60;
+      const expectedPercentWidth = 30;
+      const knownWidth = expectedStaticWidth + expectedPercentWidth;
+
       const getInitialColumns = () => [{
         key: 'id',
         name: 'ID',
-        width: 60
+        width: expectedStaticWidth
+      }, {
+        key: 'name',
+        name: 'Name',
+        width: '10%'
       }, {
         key: 'title',
         name: 'Title'
@@ -28,21 +36,23 @@ describe('Column Metrics Tests', () => {
       it('should set the unset column widths based on the total width', () => {
         const columns = getInitialColumns();
         const metrics = ColumnMetrics.recalculate({ columns, totalWidth, minColumnWidth: 50 });
-        const expectedCalculatedWidth = getAvailableWidthPerColumn(totalWidth, columns[0].width, 2);
+        const expectedCalculatedWidth = getAvailableWidthPerColumn(totalWidth, knownWidth, 2);
 
-        expect(metrics.columns[0].width).toEqual(60);
-        expect(metrics.columns[1].width).toEqual(expectedCalculatedWidth);
+        expect(metrics.columns[0].width).toEqual(expectedStaticWidth);
+        expect(metrics.columns[1].width).toEqual(expectedPercentWidth);
         expect(metrics.columns[2].width).toEqual(expectedCalculatedWidth);
+        expect(metrics.columns[3].width).toEqual(expectedCalculatedWidth);
       });
 
       it('should set the column left based on the column widths', () => {
         const columns = getInitialColumns();
         const metrics = ColumnMetrics.recalculate({ columns, totalWidth, minColumnWidth: 50 });
-        const expectedLeftValue = columns[0].width + getAvailableWidthPerColumn(totalWidth, columns[0].width, 2);
+        const expectedLeftValue = knownWidth + getAvailableWidthPerColumn(totalWidth, knownWidth, 2);
 
         expect(metrics.columns[0].left).toEqual(0);
-        expect(metrics.columns[1].left).toEqual(columns[0].width);
-        expect(metrics.columns[2].left).toEqual(expectedLeftValue);
+        expect(metrics.columns[1].left).toEqual(expectedStaticWidth);
+        expect(metrics.columns[2].left).toEqual(knownWidth);
+        expect(metrics.columns[3].left).toEqual(expectedLeftValue);
       });
 
       it('should shift all frozen columns to the start of column metrics array', () => {
@@ -62,22 +72,24 @@ describe('Column Metrics Tests', () => {
 
         it('should set the unset column widths based on the total width', () => {
           const columns = getInitialColumns();
-          const metrics = ColumnMetrics.recalculate({ columns: immutableColumns, totalWidth: 300, minColumnWidth: 50 });
-          const expectedCalculatedWidth = getAvailableWidthPerColumn(totalWidth, columns[0].width, 2);
+          const metrics = ColumnMetrics.recalculate({ columns: immutableColumns, totalWidth, minColumnWidth: 50 });
+          const expectedCalculatedWidth = getAvailableWidthPerColumn(totalWidth, knownWidth, 2);
 
-          expect(metrics.columns.get(0).width).toEqual(60);
-          expect(metrics.columns.get(1).width).toEqual(expectedCalculatedWidth);
+          expect(metrics.columns.get(0).width).toEqual(expectedStaticWidth);
+          expect(metrics.columns.get(1).width).toEqual(expectedPercentWidth);
           expect(metrics.columns.get(2).width).toEqual(expectedCalculatedWidth);
+          expect(metrics.columns.get(3).width).toEqual(expectedCalculatedWidth);
         });
 
         it('should set the column left based on the column widths', () => {
           const columns = getInitialColumns();
-          const metrics = ColumnMetrics.recalculate({ columns: immutableColumns, totalWidth: 300, minColumnWidth: 50 });
-          const expectedLeftValue = columns[0].width + getAvailableWidthPerColumn(totalWidth, columns[0].width, 2);
+          const metrics = ColumnMetrics.recalculate({ columns: immutableColumns, totalWidth, minColumnWidth: 50 });
+          const expectedLeftValue = knownWidth + getAvailableWidthPerColumn(totalWidth, knownWidth, 2);
 
           expect(metrics.columns.get(0).left).toEqual(0);
-          expect(metrics.columns.get(1).left).toEqual(columns[0].width);
-          expect(metrics.columns.get(2).left).toEqual(expectedLeftValue);
+          expect(metrics.columns.get(1).left).toEqual(expectedStaticWidth);
+          expect(metrics.columns.get(2).left).toEqual(knownWidth);
+          expect(metrics.columns.get(3).left).toEqual(expectedLeftValue);
         });
       });
     });


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Percentage column widths do not work correctly.


**What is the new behavior?**
Fixed the column width calculation function to correctly strip the '%' from the end of a percent width string prior to using it for math operations.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
