### PR TITLE
Fix module not found when using react-data-grid-addons outside react-data-grid itself.

### DIFF
--- a/packages/common/utils/index.js
+++ b/packages/common/utils/index.js
@@ -1,7 +1,7 @@
-const isImmutableLoaded = () => typeof Immutable !== 'undefined';
+import Immutable from 'immutable';
 
 export const isColumnsImmutable = (columns) => {
-  return isImmutableLoaded() && columns instanceof Immutable.List;
+  return columns instanceof Immutable.List;
 };
 
 export const isEmptyArray = (obj) => {
@@ -18,7 +18,7 @@ export const isEmptyObject = (obj) => {
 };
 
 export const isImmutableCollection = objToVerify => {
-  return isImmutableLoaded() && Immutable.Iterable.isIterable(objToVerify);
+  return Immutable.Iterable.isIterable(objToVerify);
 };
 
 export const getMixedTypeValueRetriever = (isImmutable) => {
@@ -31,14 +31,14 @@ export const getMixedTypeValueRetriever = (isImmutable) => {
   return retObj;
 };
 
-export const isImmutableMap = isImmutableLoaded() ? Immutable.Map.isMap : () => false;
+export const isImmutableMap = Immutable.Map.isMap;
 
 export const last = arrayOrList => {
   if (arrayOrList == null) {
     throw new Error('arrayOrCollection is null');
   }
 
-  if (isImmutableLoaded() && Immutable.List.isList(arrayOrList)) {
+  if (Immutable.List.isList(arrayOrList)) {
     return arrayOrList.last();
   }
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When using `Data.Selectors.getRows()` it is not sorting `Immutable` lists, because it does not find `immutable` loaded in runtime.

**What is the new behavior?**

By importing `immutable` inside `common/utils/index.js`, it's working properly for `Immutable` lists as well.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
