### PR TITLE
Fix cellRangeSelection stealing focus from other elements (#1416).

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -260,9 +260,6 @@ class ReactDataGrid extends React.Component {
   componentDidMount() {
     this._mounted = true;
     window.addEventListener('resize', this.metricsUpdated);
-    if (this.props.cellRangeSelection) {
-      window.addEventListener('mouseup', this.onWindowMouseUp);
-    }
     this.metricsUpdated();
   }
 
@@ -415,6 +412,7 @@ class ReactDataGrid extends React.Component {
   };
 
   onCellMouseDown = (cellPosition) => {
+    window.addEventListener('mouseup', this.onWindowMouseUp);
     this.selectStart(cellPosition);
   };
 
@@ -423,6 +421,7 @@ class ReactDataGrid extends React.Component {
   };
 
   onWindowMouseUp = () => {
+    window.removeEventListener('mouseup', this.onWindowMouseUp);
     this.selectEnd();
   };
 


### PR DESCRIPTION
## Description
Fixes #1416.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Cell range selection was using mouseup listener that was active all the time and was always performing grid focus, effectively stealing focus whenever user clicked other input fields in page. 


**What is the new behavior?**
The mouseup listener is now active only while selection is in progress.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
