### PR TITLE
Once cell selection is enabled data grid hijacks focus if click on co…

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -132,7 +132,7 @@ class ReactDataGrid extends React.Component {
   constructor(props, context) {
     super(props, context);
     let columnMetrics = this.createColumnMetrics();
-    const initialState = {columnMetrics, selectedRows: [], expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, scrollOffset: 0, lastRowIdxUiSelected: -1};
+    const initialState = {columnMetrics, selectedRows: [], expandedRows: [], canFilter: false, columnFilters: {}, sortDirection: null, sortColumn: null, scrollOffset: 0, lastRowIdxUiSelected: -1, areCellsSelected: false};
     if (this.props.sortColumn && this.props.sortDirection) {
       initialState.sortColumn = this.props.sortColumn;
       initialState.sortDirection = this.props.sortDirection;
@@ -172,7 +172,10 @@ class ReactDataGrid extends React.Component {
   };
 
   selectStart = (cellPosition) => {
-    this.eventBus.dispatch(EventTypes.SELECT_START, cellPosition);
+    this.setState(
+        {areCellsSelected: true},
+        () => this.eventBus.dispatch(EventTypes.SELECT_START, cellPosition)
+    );
   };
 
   selectUpdate = (cellPosition) => {
@@ -180,7 +183,10 @@ class ReactDataGrid extends React.Component {
   };
 
   selectEnd = () => {
-    this.eventBus.dispatch(EventTypes.SELECT_END);
+      this.setState(
+          {areCellsSelected: false},
+          () => this.eventBus.dispatch(EventTypes.SELECT_END)
+      );
   };
 
   handleDragEnter = ({ overRowIdx }) => {
@@ -308,7 +314,9 @@ class ReactDataGrid extends React.Component {
   };
 
   onWindowMouseUp = () => {
-    this.selectEnd();
+    if (this.state.areCellsSelected) {
+        this.selectEnd();
+    }
   };
 
   onCellContextMenu = ({ rowIdx, idx }) => {
@@ -387,7 +395,7 @@ class ReactDataGrid extends React.Component {
     if (isFunction(this.props.onScroll)) {
       this.props.onScroll(scrollState);
     }
-  }
+  };
 
   handleSort = (columnKey, direction) => {
     this.setState({sortDirection: direction, sortColumn: columnKey}, () => {


### PR DESCRIPTION
…ntrol outside it.

## Description
Once data grid is placed aside other components, that can be focused and cell selection is enabled, user is not able to navigate to other components using mouse. Issue occurs also for some components placed inside data grid. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md - **link is out of date - new contibuting.md does not contains any guidelines about mesage** 
- [ ] Tests for the changes have been added (for bug fixes / features) - **tests for this component are commented out**
- [ ] Docs have been added / updated (for bug fixes / features) - **I haven't found release notes** 


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Issue is caused by calling a focus method once mouse-up occurred.


**What is the new behavior?**
The focus method is called only if mouse up occurs after selection start.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Simplest issue reproduction https://codesandbox.io/s/z23945w4kp 

IntelliJ have detected following issue in ReactDataGrid.js:
Warning:(217, 9) Local variable 'updatedMetrics' is redundant
Warning:(408, 7) if statement can be simplified
Warning:(516, 5) if statement can be simplified
I have left them because they are not related to my change. 

My changes are based on 5.0.4 tag because my app uses it.
