### PR TITLE
Cell value is committed to clicked cell, instead of edited one. When …

### DIFF
--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -450,14 +450,19 @@ class InteractionMasks extends React.Component {
   }
 
   onSelectCellRangeStarted = (selectedPosition) => {
-    this.setState({
-      selectedRange: this.createSingleCellSelectedRange(selectedPosition, true),
-      selectedPosition
-    }, () => {
-      if (isFunction(this.props.onCellRangeSelectionStarted)) {
-        this.props.onCellRangeSelectionStarted(this.state.selectedRange);
-      }
-    });
+    this.setState(
+      {isEditorEnabled: false},
+      () => {
+        this.setState({
+            selectedRange: this.createSingleCellSelectedRange(selectedPosition, true),
+            selectedPosition
+          },
+          () => {
+            if (isFunction(this.props.onCellRangeSelectionStarted)) {
+              this.props.onCellRangeSelectionStarted(this.state.selectedRange);
+            }
+          });
+      });
   };
 
   onSelectCellRangeUpdated = (cellPosition, isFromKeyboard, callback) => {


### PR DESCRIPTION
…cellRangeSelection is enabled.

## Description
Value from editor is committed to clicked cell instead of edited one. When cellRangeSelection is enabled. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md - **I haven't found it**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
As described above.

**What is the new behavior?**
Value is committed where expected


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Value from editor is committed once it loses focus or it is unmounted. Once rangeSelection is enabled selectedPosition changes before it occurs (on mouse down). So once value is committed it places value in other cell than being edited. 