### PR TITLE
Enable various react/jsx-* rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -336,7 +336,7 @@ const rules = {
   'react/jsx-filename-extension': [1, { extensions: ['js'] }],
   'react/jsx-first-prop-new-line': 0,
   'react/jsx-handler-names': 0,
-  'react/jsx-indent': 0,
+  'react/jsx-indent': [1, 2],
   'react/jsx-indent-props': 0,
   'react/jsx-key': 0,
   'react/jsx-max-depth': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -329,7 +329,7 @@ const rules = {
   // https://github.com/yannickcr/eslint-plugin-react#jsx-specific-rules
   'react/jsx-boolean-value': 0,
   'react/jsx-child-element-spacing': 0,
-  'react/jsx-closing-bracket-location': 0,
+  'react/jsx-closing-bracket-location': 1,
   'react/jsx-closing-tag-location': 0,
   'react/jsx-curly-spacing': 1,
   'react/jsx-equals-spacing': 1,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -348,7 +348,7 @@ const rules = {
   'react/jsx-no-target-blank': 0,
   'react/jsx-no-undef': 0,
   'react/jsx-one-expression-per-line': 0,
-  'react/jsx-curly-brace-presence': 0,
+  'react/jsx-curly-brace-presence': 1,
   'react/jsx-fragments': 0,
   'react/jsx-pascal-case': 1,
   'react/jsx-props-no-multi-spaces': 1,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -319,7 +319,7 @@ const rules = {
   'react/require-default-props': 0,
   'react/require-optimization': 0,
   'react/require-render-return': 0,
-  'react/self-closing-comp': 0,
+  'react/self-closing-comp': 1,
   'react/sort-comp': 0,
   'react/sort-prop-types': 0,
   'react/style-prop-object': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -362,7 +362,7 @@ const rules = {
   }],
   'react/jsx-uses-react': 1,
   'react/jsx-uses-vars': 1,
-  'react/jsx-wrap-multilines': [0, {
+  'react/jsx-wrap-multilines': [1, {
     declaration: 'parens-new-line',
     assignment: 'parens-new-line',
     return: 'parens-new-line',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -172,7 +172,7 @@ const rules = {
   'id-length': 0,
   'id-match': 0,
   'implicit-arrow-linebreak': 0,
-  'indent': 0,
+  'indent': [1, 2],
   'jsx-quotes': 1,
   'key-spacing': 1,
   'keyword-spacing': 1,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -334,7 +334,7 @@ const rules = {
   'react/jsx-curly-spacing': 1,
   'react/jsx-equals-spacing': 1,
   'react/jsx-filename-extension': [1, { extensions: ['js'] }],
-  'react/jsx-first-prop-new-line': 0,
+  'react/jsx-first-prop-new-line': 1,
   'react/jsx-handler-names': 0,
   'react/jsx-indent': [1, 2],
   'react/jsx-indent-props': [1, 2],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -337,7 +337,7 @@ const rules = {
   'react/jsx-first-prop-new-line': 0,
   'react/jsx-handler-names': 0,
   'react/jsx-indent': [1, 2],
-  'react/jsx-indent-props': 0,
+  'react/jsx-indent-props': [1, 2],
   'react/jsx-key': 0,
   'react/jsx-max-depth': 0,
   'react/jsx-max-props-per-line': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -340,7 +340,7 @@ const rules = {
   'react/jsx-indent-props': [1, 2],
   'react/jsx-key': 0,
   'react/jsx-max-depth': 0,
-  'react/jsx-max-props-per-line': 0,
+  'react/jsx-max-props-per-line': [1, { when: 'multiline' }],
   'react/jsx-no-bind': 0,
   'react/jsx-no-comment-textnodes': 1,
   'react/jsx-no-duplicate-props': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -327,7 +327,7 @@ const rules = {
 
   // JSX rules
   // https://github.com/yannickcr/eslint-plugin-react#jsx-specific-rules
-  'react/jsx-boolean-value': 0,
+  'react/jsx-boolean-value': 1,
   'react/jsx-child-element-spacing': 0,
   'react/jsx-closing-bracket-location': 1,
   'react/jsx-closing-tag-location': 0,

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
@@ -73,7 +73,8 @@ export default class AutoCompleteFilter extends React.Component {
         onChange={this.handleChange}
         escapeClearsValue={true}
         multi={this.props.multiSelection !== undefined && this.props.multiSelection !== null ? this.props.multiSelection : true}
-        value={this.state.filters} />
+        value={this.state.filters}
+      />
     );
   }
 }

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/AutoCompleteFilter.js
@@ -71,7 +71,7 @@ export default class AutoCompleteFilter extends React.Component {
         options={this.state.options}
         placeholder={this.state.placeholder}
         onChange={this.handleChange}
-        escapeClearsValue={true}
+        escapeClearsValue
         multi={this.props.multiSelection !== undefined && this.props.multiSelection !== null ? this.props.multiSelection : true}
         value={this.state.filters}
       />

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/MultiSelectFilter.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/MultiSelectFilter.js
@@ -3,5 +3,5 @@ import React from 'react';
 import AutoCompleteFilter from './AutoCompleteFilter';
 
 export default function MultiSelectFilter(props) {
-  return <AutoCompleteFilter {...props} multiSelection={true} />;
+  return <AutoCompleteFilter {...props} multiSelection />;
 }

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -37,9 +37,9 @@ describe('AutoCompleteFilter', () => {
     beforeEach(() => {
       component = TestUtils.renderIntoDocument(
         <AutoCompleteFilter
-        onChange={fakeOnChange}
-        column={fakeColumn}
-        getValidFilterValues={fakeGetValidFilterValues}
+          onChange={fakeOnChange}
+          column={fakeColumn}
+          getValidFilterValues={fakeGetValidFilterValues}
         />);
       rows = createRows();
     });

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/AutoCompleteFilter.spec.js
@@ -57,8 +57,8 @@ describe('AutoCompleteFilter', () => {
     it('When options are valid', () => {
       const request = component.getOptions();
       const result = [
-         { label: 'Title 1', value: 1 },
-         { label: 'Title 2', value: 2 }
+        { label: 'Title 1', value: 1 },
+        { label: 'Title 2', value: 2 }
       ];
       expect(request).toEqual(result);
     });

--- a/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/NumericFilter.spec.js
+++ b/packages/react-data-grid-addons/src/cells/headerCells/filters/__tests__/NumericFilter.spec.js
@@ -21,9 +21,9 @@ describe('NumericFilter', () => {
     it('When using numbers with , as separator', () => {
       const request = component.getRules('1,3,4,10');
       const result = [{ type: 1, value: 1 },
-      { type: 1, value: 3 },
-      { type: 1, value: 4 },
-      { type: 1, value: 10 }];
+        { type: 1, value: 3 },
+        { type: 1, value: 4 },
+        { type: 1, value: 10 }];
       expect(request).toEqual(result);
     });
 
@@ -48,11 +48,11 @@ describe('NumericFilter', () => {
     it('When using mixed filters', () => {
       const request = component.getRules('61,72,33-53,<6,>900,10');
       const result = [{ type: 1, value: 61 },
-      { type: 1, value: 72 },
-      { type: 2, begin: 33, end: 53 },
-      { type: 4, value: 6 },
-      { type: 3, value: 900 },
-      { type: 1, value: 10 }];
+        { type: 1, value: 72 },
+        { type: 2, begin: 33, end: 53 },
+        { type: 4, value: 6 },
+        { type: 3, value: 900 },
+        { type: 1, value: 10 }];
       expect(request).toEqual(result);
     });
 

--- a/packages/react-data-grid-addons/src/data/__tests__/RowFilterer.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/RowFilterer.spec.js
@@ -6,8 +6,8 @@ import filterRows from '../RowFilterer';
 import AutoCompleteFilter from '../../cells/headerCells/filters/AutoCompleteFilter';
 
 const rows = [{ colOne: 'v1', colTwo: 'b1' },
-              { colOne: 'v2', colTwo: 'b2' },
-              { colOne: 'v3', colTwo: 'b3' }];
+  { colOne: 'v2', colTwo: 'b2' },
+  { colOne: 'v3', colTwo: 'b3' }];
 const filters = { colOne: { filterTerm: 'v1' } };
 
 const fakeColumn = { name: 'Col One', key: 'colOne', width: 100 };

--- a/packages/react-data-grid-addons/src/data/__tests__/RowGrouper.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/RowGrouper.spec.js
@@ -3,8 +3,8 @@ import Immutable from 'immutable';
 import groupRows from '../RowGrouper';
 
 const rows = [{ colOne: 'v1', colTwo: 'b1' },
-              { colOne: 'v2', colTwo: 'b2' },
-              { colOne: 'v1', colTwo: 'b3' }];
+  { colOne: 'v2', colTwo: 'b2' },
+  { colOne: 'v1', colTwo: 'b3' }];
 const grpDetails = { oneCol: ['colOne'], expRows: {}, multiCol: ['colOne', 'colTwo'] };
 
 describe('Row Grouper', () => {
@@ -29,8 +29,8 @@ describe('Row Grouper', () => {
     const groupingResult = groupRows(rows, grpDetails.multiCol, grpDetails.expRows);
 
     expect(groupingResult
-            .slice(0, grpDetails.multiCol.length)
-            .every(x => x.__metaData)).toBe(true);
+      .slice(0, grpDetails.multiCol.length)
+      .every(x => x.__metaData)).toBe(true);
   });
   it('It can group an array of rows (two grouping columns) - correct total of elements', () => {
     const groupingResult = groupRows(rows, grpDetails.multiCol, grpDetails.expRows);
@@ -48,15 +48,15 @@ describe('Row Grouper', () => {
     const groupingResult = groupRows(immutableList, grpDetails.multiCol, grpDetails.expRows);
 
     expect(groupingResult
-            .slice(0, grpDetails.multiCol.length)
-            .every(x => x.__metaData)).toBe(true);
+      .slice(0, grpDetails.multiCol.length)
+      .every(x => x.__metaData)).toBe(true);
   });
   it('It can group an Immutable List (not list of immutable maps)', () => {
     const immutableList = Immutable.List(rows); // eslint-disable-line new-cap
     const groupingResult = groupRows(immutableList, grpDetails.multiCol, grpDetails.expRows);
 
     expect(groupingResult
-            .slice(0, grpDetails.multiCol.length)
-            .every(x => x.__metaData)).toBe(true);
+      .slice(0, grpDetails.multiCol.length)
+      .every(x => x.__metaData)).toBe(true);
   });
 });

--- a/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
@@ -19,13 +19,15 @@ const rowDropTarget = (Row) => class extends React.Component {
     const overlayTop = this.props.idx * this.props.height;
     return connectDropTarget(<div>
       <Row ref={(node) => this.row = node} {...this.props} />
-      {isOver && canDrop && <div
-        className="rowDropTarget"
-        style={{
-        top: overlayTop,
-        height: this.props.height
-      }}
-                            /> }
+      {isOver && canDrop && (
+        <div
+          className="rowDropTarget"
+          style={{
+            top: overlayTop,
+            height: this.props.height
+          }}
+        />
+      )}
     </div>);
   }
 };

--- a/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
@@ -19,7 +19,8 @@ const rowDropTarget = (Row) => class extends React.Component {
     const overlayTop = this.props.idx * this.props.height;
     return connectDropTarget(<div>
       <Row ref={(node) => this.row = node} {...this.props} />
-      {isOver && canDrop && <div className="rowDropTarget" style={{
+      {isOver && canDrop && <div className="rowDropTarget"
+        style={{
         top: overlayTop,
         height: this.props.height
       }}

--- a/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
@@ -19,7 +19,8 @@ const rowDropTarget = (Row) => class extends React.Component {
     const overlayTop = this.props.idx * this.props.height;
     return connectDropTarget(<div>
       <Row ref={(node) => this.row = node} {...this.props} />
-      {isOver && canDrop && <div className="rowDropTarget"
+      {isOver && canDrop && <div
+        className="rowDropTarget"
         style={{
         top: overlayTop,
         height: this.props.height

--- a/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DropTargetRowContainer.js
@@ -22,7 +22,8 @@ const rowDropTarget = (Row) => class extends React.Component {
       {isOver && canDrop && <div className="rowDropTarget" style={{
         top: overlayTop,
         height: this.props.height
-      }} /> }
+      }}
+                            /> }
     </div>);
   }
 };

--- a/packages/react-data-grid-addons/src/draggable/RowActionsCell.js
+++ b/packages/react-data-grid-addons/src/draggable/RowActionsCell.js
@@ -22,7 +22,7 @@ class RowActionsCell extends React.Component {
 
     return connectDragSource(
       <div>
-        <div className="rdg-drag-row-handle" style={rowHandleStyle}></div>
+        <div className="rdg-drag-row-handle" style={rowHandleStyle} />
         {!isSelected ? this.renderRowIndex() : null}
         {rowSelection != null && <div className={editorClass}>
           <CheckboxEditor column={this.props.column} rowIdx={this.props.rowIdx} dependentValues={this.props.dependentValues} value={this.props.value} />

--- a/packages/react-data-grid-addons/src/draggable/RowActionsCell.js
+++ b/packages/react-data-grid-addons/src/draggable/RowActionsCell.js
@@ -9,9 +9,11 @@ const { CheckboxEditor } = editors;
 class RowActionsCell extends React.Component {
 
   renderRowIndex() {
-    return (<div className="rdg-row-index">
-      { this.props.rowIdx + 1 }
-    </div>);
+    return (
+      <div className="rdg-row-index">
+        { this.props.rowIdx + 1 }
+      </div>
+    );
   }
 
   render() {
@@ -24,9 +26,11 @@ class RowActionsCell extends React.Component {
       <div>
         <div className="rdg-drag-row-handle" style={rowHandleStyle} />
         {!isSelected ? this.renderRowIndex() : null}
-        {rowSelection != null && <div className={editorClass}>
-          <CheckboxEditor column={this.props.column} rowIdx={this.props.rowIdx} dependentValues={this.props.dependentValues} value={this.props.value} />
-        </div>}
+        {rowSelection != null && (
+          <div className={editorClass}>
+            <CheckboxEditor column={this.props.column} rowIdx={this.props.rowIdx} dependentValues={this.props.dependentValues} value={this.props.value} />
+          </div>
+        )}
       </div>);
   }
 }

--- a/packages/react-data-grid-addons/src/editors/AutoCompleteEditor.js
+++ b/packages/react-data-grid-addons/src/editors/AutoCompleteEditor.js
@@ -103,8 +103,10 @@ export default class AutoCompleteEditor extends React.Component {
 
   render() {
     const label = this.props.label != null ? this.props.label : 'title';
-    return (<div height={this.props.height} onKeyDown={this.props.onKeyDown}>
-      <ReactAutocomplete search={this.props.search} ref={this.setAutocompleteRef} label={label} onChange={this.handleChange} onFocus={this.props.onFocus} resultIdentifier={this.props.resultIdentifier} options={this.props.options} value={this.getEditorDisplayValue()} />
-    </div>);
+    return (
+      <div height={this.props.height} onKeyDown={this.props.onKeyDown}>
+        <ReactAutocomplete search={this.props.search} ref={this.setAutocompleteRef} label={label} onChange={this.handleChange} onFocus={this.props.onFocus} resultIdentifier={this.props.resultIdentifier} options={this.props.options} value={this.getEditorDisplayValue()} />
+      </div>
+    );
   }
 }

--- a/packages/react-data-grid-addons/src/editors/DropDownEditor.js
+++ b/packages/react-data-grid-addons/src/editors/DropDownEditor.js
@@ -23,7 +23,8 @@ export default class DropDownEditor extends EditorBase {
     return (
       <select style={this.getStyle()} defaultValue={this.props.value} onBlur={this.props.onBlur} onChange={this.onChange}>
         {this.renderOptions()}
-      </select>);
+      </select>
+    );
   }
 
   renderOptions() {

--- a/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor-integration.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor-integration.spec.js
@@ -13,17 +13,18 @@ describe('AutoCompleteEditor integration', () => {
   const commitSpy = jasmine.createSpy();
 
   beforeEach(() => {
-    component = ReactDOM.render(<AutoCompleteEditor
-      onCommit={commitSpy}
-      options={fakeOptions}
-      label="title"
-      valueParams={fakeParams}
-      value="value"
-      column={fakeColumn}
-      resultIdentifier="id"
-      height={30}
-      onKeyDown={fakeCb}
-                                />, document.body);
+    component = ReactDOM.render(
+      <AutoCompleteEditor
+        onCommit={commitSpy}
+        options={fakeOptions}
+        label="title"
+        valueParams={fakeParams}
+        value="value"
+        column={fakeColumn}
+        resultIdentifier="id"
+        height={30}
+        onKeyDown={fakeCb}
+      />, document.body);
   });
 
   afterEach(() => {

--- a/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor-integration.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor-integration.spec.js
@@ -22,7 +22,8 @@ describe('AutoCompleteEditor integration', () => {
       column={fakeColumn}
       resultIdentifier="id"
       height={30}
-      onKeyDown={fakeCb} />, document.body);
+      onKeyDown={fakeCb}
+                                />, document.body);
   });
 
   afterEach(() => {

--- a/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor.spec.js
@@ -13,18 +13,20 @@ describe('AutoCompleteEditor', () => {
   describe('Unit Tests', () => {
     describe('Basic tests', () => {
       function setup() {
-        const wrapper = shallow(<AutoCompleteEditor
-          onCommit={fakeCb}
-          options={fakeOptions}
-          label="title"
-          value="value"
-          valueParams={fakeParams}
-          column={fakeColumn}
-          resultIdentifier="id"
-          search="test"
-          height={30}
-          onKeyDown={fakeCb}
-                                />);
+        const wrapper = shallow(
+          <AutoCompleteEditor
+            onCommit={fakeCb}
+            options={fakeOptions}
+            label="title"
+            value="value"
+            valueParams={fakeParams}
+            column={fakeColumn}
+            resultIdentifier="id"
+            search="test"
+            height={30}
+            onKeyDown={fakeCb}
+          />
+        );
         const autocomplete = wrapper.find(ReactAutocomplete);
         return { wrapper, autocomplete };
       }

--- a/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/AutoCompleteEditor.spec.js
@@ -23,7 +23,8 @@ describe('AutoCompleteEditor', () => {
           resultIdentifier="id"
           search="test"
           height={30}
-          onKeyDown={fakeCb} />);
+          onKeyDown={fakeCb}
+                                />);
         const autocomplete = wrapper.find(ReactAutocomplete);
         return { wrapper, autocomplete };
       }

--- a/packages/react-data-grid-addons/src/editors/__tests__/ContainerEditorWrapper.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/ContainerEditorWrapper.spec.js
@@ -7,7 +7,7 @@ import ContainerEditorWrapper from '../ContainerEditorWrapper';
 class FakeComponent extends React.Component {
     getValue = jasmine.createSpy()
     getInputNode = jasmine.createSpy()
-    render() { return (<div></div>); }
+    render() { return (<div />); }
 }
 
 class FakeContainer extends React.Component {

--- a/packages/react-data-grid-addons/src/editors/__tests__/ContainerEditorWrapper.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/ContainerEditorWrapper.spec.js
@@ -11,7 +11,7 @@ class FakeComponent extends React.Component {
 }
 
 class FakeContainer extends React.Component {
-    render() { return (<FakeComponent ref={this.props.refCallback} />); }
+  render() { return (<FakeComponent ref={this.props.refCallback} />); }
 }
 
 FakeContainer.propTypes = {

--- a/packages/react-data-grid-addons/src/editors/__tests__/DropDownEditor.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/DropDownEditor.spec.js
@@ -17,7 +17,8 @@ describe('DropDownEditor', () => {
         options={fakeOptions}
         value={'option2'}
         onCommit={fakeCommitCb}
-        column={fakeColumn} />);
+        column={fakeColumn}
+                                               />);
     });
 
     it('should create a new DropDownEditor instance', () => {
@@ -70,7 +71,8 @@ describe('DropDownEditor', () => {
         options={fakeOptions}
         value={'Choose a thing'}
         onCommit={fakeCommitCb}
-        column={fakeColumn} />);
+        column={fakeColumn}
+                                               />);
     });
 
     it('should display value unless text is specified', () => {

--- a/packages/react-data-grid-addons/src/editors/__tests__/DropDownEditor.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/DropDownEditor.spec.js
@@ -12,13 +12,15 @@ describe('DropDownEditor', () => {
     function fakeCommitCb() { return true; }
 
     beforeEach(() => {
-      component = TestUtils.renderIntoDocument(<DropDownEditor
-        name="DropDownEditor"
-        options={fakeOptions}
-        value="option2"
-        onCommit={fakeCommitCb}
-        column={fakeColumn}
-                                               />);
+      component = TestUtils.renderIntoDocument(
+        <DropDownEditor
+          name="DropDownEditor"
+          options={fakeOptions}
+          value="option2"
+          onCommit={fakeCommitCb}
+          column={fakeColumn}
+        />
+      );
     });
 
     it('should create a new DropDownEditor instance', () => {
@@ -66,13 +68,15 @@ describe('DropDownEditor', () => {
     function fakeCommitCb() { return true; }
 
     beforeEach(() => {
-      component = TestUtils.renderIntoDocument(<DropDownEditor
-        name="DropDownEditor"
-        options={fakeOptions}
-        value="Choose a thing"
-        onCommit={fakeCommitCb}
-        column={fakeColumn}
-                                               />);
+      component = TestUtils.renderIntoDocument(
+        <DropDownEditor
+          name="DropDownEditor"
+          options={fakeOptions}
+          value="Choose a thing"
+          onCommit={fakeCommitCb}
+          column={fakeColumn}
+        />
+      );
     });
 
     it('should display value unless text is specified', () => {

--- a/packages/react-data-grid-addons/src/editors/__tests__/DropDownEditor.spec.js
+++ b/packages/react-data-grid-addons/src/editors/__tests__/DropDownEditor.spec.js
@@ -13,9 +13,9 @@ describe('DropDownEditor', () => {
 
     beforeEach(() => {
       component = TestUtils.renderIntoDocument(<DropDownEditor
-        name={'DropDownEditor'}
+        name="DropDownEditor"
         options={fakeOptions}
-        value={'option2'}
+        value="option2"
         onCommit={fakeCommitCb}
         column={fakeColumn}
                                                />);
@@ -67,9 +67,9 @@ describe('DropDownEditor', () => {
 
     beforeEach(() => {
       component = TestUtils.renderIntoDocument(<DropDownEditor
-        name={'DropDownEditor'}
+        name="DropDownEditor"
         options={fakeOptions}
-        value={'Choose a thing'}
+        value="Choose a thing"
         onCommit={fakeCommitCb}
         column={fakeColumn}
                                                />);

--- a/packages/react-data-grid-addons/src/toolbars/AdvancedToolbar.js
+++ b/packages/react-data-grid-addons/src/toolbars/AdvancedToolbar.js
@@ -16,9 +16,7 @@ export default class AdvancedToolbar extends Component {
     return (
       <div className="react-grid-Toolbar">
         {this.props.children}
-        <div className="tools">
-
-        </div>
+        <div className="tools" />
       </div>);
   }
 }

--- a/packages/react-data-grid-addons/src/toolbars/AdvancedToolbar.js
+++ b/packages/react-data-grid-addons/src/toolbars/AdvancedToolbar.js
@@ -17,7 +17,8 @@ export default class AdvancedToolbar extends Component {
       <div className="react-grid-Toolbar">
         {this.props.children}
         <div className="tools" />
-      </div>);
+      </div>
+    );
   }
 }
 

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
@@ -7,7 +7,7 @@ export default class GroupedColumnButton extends Component {
       <div className="grouped-col-btn btn btn-sm">
         <span className="grouped-col-btn__name">{this.props.name}</span>
         <span className="grouped-col-btn__remove glyphicon glyphicon-trash"
-              onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)}
+          onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)}
         />
       </div>
     );

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
@@ -7,7 +7,8 @@ export default class GroupedColumnButton extends Component {
       <div className="grouped-col-btn btn btn-sm">
         <span className="grouped-col-btn__name">{this.props.name}</span>
         <span className="grouped-col-btn__remove glyphicon glyphicon-trash"
-              onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)} />
+              onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)}
+        />
       </div>
     );
   }

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnButton.js
@@ -6,7 +6,8 @@ export default class GroupedColumnButton extends Component {
     return (
       <div className="grouped-col-btn btn btn-sm">
         <span className="grouped-col-btn__name">{this.props.name}</span>
-        <span className="grouped-col-btn__remove glyphicon glyphicon-trash"
+        <span
+          className="grouped-col-btn__remove glyphicon glyphicon-trash"
           onClick={this.props.onColumnGroupDeleted.bind(null, this.props.columnKey)}
         />
       </div>

--- a/packages/react-data-grid-addons/src/toolbars/GroupedColumnsPanel.js
+++ b/packages/react-data-grid-addons/src/toolbars/GroupedColumnsPanel.js
@@ -49,7 +49,8 @@ class GroupedColumnsPanel extends Component {
         zIndex: 1,
         opacity: 0.5,
         backgroundColor: color
-      }} />
+      }}
+      />
     );
   }
 

--- a/packages/react-data-grid-addons/src/toolbars/Toolbar.js
+++ b/packages/react-data-grid-addons/src/toolbars/Toolbar.js
@@ -37,8 +37,8 @@ export default class Toolbar extends React.Component {
   renderToggleFilterButton = () => {
     if (this.props.enableFilter) {
       return (<button type="button" className="btn" onClick={this.props.onToggleFilter}>
-      {this.props.filterRowsButtonText}
-    </button>);
+        {this.props.filterRowsButtonText}
+      </button>);
     }
   };
 

--- a/packages/react-data-grid-addons/src/toolbars/Toolbar.js
+++ b/packages/react-data-grid-addons/src/toolbars/Toolbar.js
@@ -28,17 +28,21 @@ export default class Toolbar extends React.Component {
 
   renderAddRowButton = () => {
     if (this.props.onAddRow) {
-      return (<button type="button" className="btn" onClick={this.onAddRow}>
-        {this.props.addRowButtonText}
-      </button>);
+      return (
+        <button type="button" className="btn" onClick={this.onAddRow}>
+          {this.props.addRowButtonText}
+        </button>
+      );
     }
   };
 
   renderToggleFilterButton = () => {
     if (this.props.enableFilter) {
-      return (<button type="button" className="btn" onClick={this.props.onToggleFilter}>
-        {this.props.filterRowsButtonText}
-      </button>);
+      return (
+        <button type="button" className="btn" onClick={this.props.onToggleFilter}>
+          {this.props.filterRowsButtonText}
+        </button>
+      );
     }
   };
 
@@ -50,6 +54,7 @@ export default class Toolbar extends React.Component {
           {this.renderToggleFilterButton()}
           {this.props.children}
         </div>
-      </div>);
+      </div>
+    );
   }
 }

--- a/packages/react-data-grid-examples/src/components/Home.js
+++ b/packages/react-data-grid-examples/src/components/Home.js
@@ -9,7 +9,7 @@ export default function Home() {
       <header id="head">
         <div className="container">
           <div className="row">
-            <div className="main-logo"></div>
+            <div className="main-logo" />
             <h1 className="lead">React Data Grid </h1>
             <p className="tagline">Excel-like grid component built with React</p>
             <p>
@@ -24,25 +24,25 @@ export default function Home() {
         <div className="container">
           <div className="row" id="demo">
             <div className="col-md-3 col-sm-6">
-              <div className="h-caption"><h4><i className="fa fa-flash fa-5"></i>Lightning Fast Rendering</h4></div>
+              <div className="h-caption"><h4><i className="fa fa-flash fa-5" />Lightning Fast Rendering</h4></div>
               <div className="h-body text-center">
                 <p>Combines the performance power of React as well as partial rendering techniques in order to smoothly scroll though hundreds of thousands of rows.</p>
               </div>
             </div>
             <div className="col-md-3 col-sm-6">
-              <div className="h-caption"><h4><i className="fa fa-edit fa-5"></i>Rich Editing and Formatting</h4></div>
+              <div className="h-caption"><h4><i className="fa fa-edit fa-5" />Rich Editing and Formatting</h4></div>
               <div className="h-body text-center">
                 <p>View and edit cells using a wide range of formatters and editors. If these don't suit your needs, you can easily create and plugin your own</p>
               </div>
             </div>
             <div className="col-md-3 col-sm-6">
-              <div className="h-caption"><h4><i className="fa fa-cogs fa-5"></i>Configurable & Customizable</h4></div>
+              <div className="h-caption"><h4><i className="fa fa-cogs fa-5" />Configurable & Customizable</h4></div>
               <div className="h-body text-center">
                 <p>Quickly configure and customise features such as grid and column properties, row and cell renderers. As the Grid is a React component it is easy to extend and add custom functionality.</p>
               </div>
             </div>
             <div className="col-md-3 col-sm-6">
-              <div className="h-caption"><h4><i className="fa fa-file-excel-o fa-5"></i>Packed full of Excel Features</h4></div>
+              <div className="h-caption"><h4><i className="fa fa-file-excel-o fa-5" />Packed full of Excel Features</h4></div>
               <div className="h-body text-center">
                 <p>Full keyboard navigation, cell copy & paste, cell drag down, frozen columns, column resizing, sorting, filtering and many more features on the way.</p>
               </div>
@@ -103,10 +103,7 @@ export default function Home() {
 
         <div className="footer1">
           <div className="container">
-            <div className="row">
-
-
-            </div>
+            <div className="row" />
           </div>
         </div>
 
@@ -116,16 +113,12 @@ export default function Home() {
 
               <div className="col-md-6 widget">
                 <div className="widget-body">
-                  <p className="simplenav">
-
-                  </p>
+                  <p className="simplenav" />
                 </div>
               </div>
 
               <div className="col-md-6 widget">
-                <div className="widget-body">
-
-                </div>
+                <div className="widget-body" />
               </div>
 
             </div>

--- a/packages/react-data-grid-examples/src/components/Navbar.js
+++ b/packages/react-data-grid-examples/src/components/Navbar.js
@@ -13,11 +13,10 @@ export default class Navbar extends React.Component {
               <img className="github-ribbon"
                 src="http://aral.github.com/fork-me-on-github-retina-ribbons/right-green@2x.png"
                 alt="Fork me on GitHub"
-              >
-              </img>
+              />
             </a>
 
-            <button type="button" className="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse"><span className="icon-bar"></span> <span className="icon-bar"></span> <span className="icon-bar"></span> </button>
+            <button type="button" className="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse"><span className="icon-bar" /> <span className="icon-bar" /> <span className="icon-bar" /> </button>
             <a className="navbar-brand" href="https://www.adazzle.com"><img className="header-logo" src="assets/images/AdazzleHeaderLogo.png" /></a> <Link className="navbar-brand" to="/">React Data Grid</Link>
           </div>
           <div className="navbar-collapse collapse">
@@ -26,7 +25,7 @@ export default class Navbar extends React.Component {
                 <Link to="/">Home</Link>
               </li>
               <li className="dropdown">
-                <a href="#" className="dropdown-toggle" data-toggle="dropdown">Documentation <b className="caret"></b></a>
+                <a href="#" className="dropdown-toggle" data-toggle="dropdown">Documentation <b className="caret" /></a>
                 <ul className="dropdown-menu">
                   <li><Link to="/documentation/gettingstarted">Getting Started</Link></li>
                   <li><Link to="/documentation/apireference">API Reference</Link></li>
@@ -35,7 +34,7 @@ export default class Navbar extends React.Component {
               </li>
 
               <li className="dropdown">
-                <a href="#" className="dropdown-toggle" data-toggle="dropdown">Examples <b className="caret"></b></a>
+                <a href="#" className="dropdown-toggle" data-toggle="dropdown">Examples <b className="caret" /></a>
                 <ExampleList className="dropdown-menu" />
               </li>
             </ul>

--- a/packages/react-data-grid-examples/src/components/Navbar.js
+++ b/packages/react-data-grid-examples/src/components/Navbar.js
@@ -12,7 +12,8 @@ export default class Navbar extends React.Component {
             <a href="https://github.com/adazzle/react-data-grid/fork">
               <img className="github-ribbon"
                 src="http://aral.github.com/fork-me-on-github-retina-ribbons/right-green@2x.png"
-                alt="Fork me on GitHub">
+                alt="Fork me on GitHub"
+              >
               </img>
             </a>
 

--- a/packages/react-data-grid-examples/src/components/Navbar.js
+++ b/packages/react-data-grid-examples/src/components/Navbar.js
@@ -10,7 +10,8 @@ export default class Navbar extends React.Component {
         <div className="container">
           <div className="navbar-header">
             <a href="https://github.com/adazzle/react-data-grid/fork">
-              <img className="github-ribbon"
+              <img
+                className="github-ribbon"
                 src="http://aral.github.com/fork-me-on-github-retina-ribbons/right-green@2x.png"
                 alt="Fork me on GitHub"
               />

--- a/packages/react-data-grid-examples/src/layout/Container.js
+++ b/packages/react-data-grid-examples/src/layout/Container.js
@@ -4,8 +4,7 @@ export default function Container({ children }) {
   return (
     <div className="container-fluid top-space">
       <div className="row">
-        <div className="col-md-2 top-space" role="complementary">
-        </div>
+        <div className="col-md-2 top-space" role="complementary" />
         <div className="col-md-10">
           {children}
         </div>

--- a/packages/react-data-grid-examples/src/scripts/documentation03-components.js
+++ b/packages/react-data-grid-examples/src/scripts/documentation03-components.js
@@ -21,7 +21,7 @@ class DocumentContainer extends React.Component {
     return (
       <div className={'pull-left'} style={{ marginLeft: '100px' }}>
         <h3>{this.props.documentName}</h3>
-        <div dangerouslySetInnerHTML={this.getHtml()}></div>
+        <div dangerouslySetInnerHTML={this.getHtml()} />
       </div>
     );
   }

--- a/packages/react-data-grid-examples/src/scripts/documentation03-components.js
+++ b/packages/react-data-grid-examples/src/scripts/documentation03-components.js
@@ -82,7 +82,8 @@ export default class ComponentDocs extends React.Component {
         <DocumentContainer
           documentContent={this.state.documentContent}
           documentName={generatedDocs[selectedDocumentIndex].name}
-          documentPath={generatedDocs[selectedDocumentIndex].path} />
+          documentPath={generatedDocs[selectedDocumentIndex].path}
+        />
       </div>
     );
   }

--- a/packages/react-data-grid-examples/src/scripts/documentation03-components.js
+++ b/packages/react-data-grid-examples/src/scripts/documentation03-components.js
@@ -19,7 +19,7 @@ class DocumentContainer extends React.Component {
 
   render() {
     return (
-      <div className={'pull-left'} style={{ marginLeft: '100px' }}>
+      <div className="pull-left" style={{ marginLeft: '100px' }}>
         <h3>{this.props.documentName}</h3>
         <div dangerouslySetInnerHTML={this.getHtml()} />
       </div>

--- a/packages/react-data-grid-examples/src/scripts/example01-basic.js
+++ b/packages/react-data-grid-examples/src/scripts/example01-basic.js
@@ -11,12 +11,14 @@ const columns = [
 const rows = [{ id: 0, title: 'row1', count: 20 }, { id: 1, title: 'row1', count: 40 }, { id: 2, title: 'row1', count: 60 }];
 
 function HelloWorld() {
-  return (<ReactDataGrid
-    columns={columns}
-    rowGetter={i => rows[i]}
-    rowsCount={3}
-    minHeight={150}
-          />);
+  return (
+    <ReactDataGrid
+      columns={columns}
+      rowGetter={i => rows[i]}
+      rowsCount={3}
+      minHeight={150}
+    />
+  );
 }
 
 export default exampleWrapper({

--- a/packages/react-data-grid-examples/src/scripts/example01-basic.js
+++ b/packages/react-data-grid-examples/src/scripts/example01-basic.js
@@ -15,7 +15,8 @@ function HelloWorld() {
   columns={columns}
   rowGetter={i => rows[i]}
   rowsCount={3}
-  minHeight={150} />);
+  minHeight={150}
+          />);
 }
 
 export default exampleWrapper({

--- a/packages/react-data-grid-examples/src/scripts/example01-basic.js
+++ b/packages/react-data-grid-examples/src/scripts/example01-basic.js
@@ -12,10 +12,10 @@ const rows = [{ id: 0, title: 'row1', count: 20 }, { id: 1, title: 'row1', count
 
 function HelloWorld() {
   return (<ReactDataGrid
-  columns={columns}
-  rowGetter={i => rows[i]}
-  rowsCount={3}
-  minHeight={150}
+    columns={columns}
+    rowGetter={i => rows[i]}
+    rowsCount={3}
+    minHeight={150}
           />);
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example02-resizable-cols.js
+++ b/packages/react-data-grid-examples/src/scripts/example02-resizable-cols.js
@@ -82,7 +82,8 @@ class Example extends React.Component {
         rowsCount={this._rows.length}
         minHeight={500}
         minColumnWidth={120}
-      />);
+      />
+    );
   }
 }
 
@@ -92,7 +93,8 @@ const exampleDescription = (
     <p>If you need to know when a column has been resized, use the <code>onColumnResize</code> prop. This will be triggered when a column is
     resized and will report the column index and its new width. These can be saved on the back-end and used to restore column widths when
     the component is initialized, by setting <code>width</code> key in each column.</p>
-  </div>);
+  </div>
+);
 
 export default exampleWrapper({
   WrappedComponent: Example,

--- a/packages/react-data-grid-examples/src/scripts/example03-frozen-cols.js
+++ b/packages/react-data-grid-examples/src/scripts/example03-frozen-cols.js
@@ -85,7 +85,8 @@ class Example extends React.Component {
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
-        minHeight={500} />);
+        minHeight={500}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example03-frozen-cols.js
+++ b/packages/react-data-grid-examples/src/scripts/example03-frozen-cols.js
@@ -86,7 +86,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
         minHeight={500}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example04-editable.js
+++ b/packages/react-data-grid-examples/src/scripts/example04-editable.js
@@ -92,7 +92,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-        onGridRowsUpdated={this.handleGridRowsUpdated} />);
+        onGridRowsUpdated={this.handleGridRowsUpdated}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example04-editable.js
+++ b/packages/react-data-grid-examples/src/scripts/example04-editable.js
@@ -93,7 +93,8 @@ class Example extends React.Component {
         rowsCount={this.state.rows.length}
         minHeight={500}
         onGridRowsUpdated={this.handleGridRowsUpdated}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example04-editable.js
+++ b/packages/react-data-grid-examples/src/scripts/example04-editable.js
@@ -87,7 +87,7 @@ class Example extends React.Component {
   render() {
     return (
       <ReactDataGrid
-        enableCellSelect={true}
+        enableCellSelect
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}

--- a/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
+++ b/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
@@ -92,7 +92,8 @@ class Example extends React.Component {
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
-        minHeight={500} />);
+        minHeight={500}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
+++ b/packages/react-data-grid-examples/src/scripts/example05-custom-formatters.js
@@ -17,7 +17,8 @@ class PercentCompleteFormatter extends React.Component {
         <div className="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style={{ width: percentComplete }}>
           {percentComplete}
         </div>
-      </div>);
+      </div>
+    );
   }
 }
 
@@ -93,7 +94,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
         minHeight={500}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
+++ b/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
@@ -92,7 +92,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-        onGridRowsUpdated={this.handleGridRowsUpdated} />);
+        onGridRowsUpdated={this.handleGridRowsUpdated}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
+++ b/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
@@ -93,7 +93,8 @@ class Example extends React.Component {
         rowsCount={this.state.rows.length}
         minHeight={500}
         onGridRowsUpdated={this.handleGridRowsUpdated}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
+++ b/packages/react-data-grid-examples/src/scripts/example06-built-in-editors.js
@@ -87,7 +87,7 @@ class Example extends React.Component {
   render() {
     return (
       <ReactDataGrid
-        enableCellSelect={true}
+        enableCellSelect
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}

--- a/packages/react-data-grid-examples/src/scripts/example08-sortable-cols.js
+++ b/packages/react-data-grid-examples/src/scripts/example08-sortable-cols.js
@@ -101,7 +101,8 @@ class Example extends React.Component {
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
-        minHeight={500} />);
+        minHeight={500}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example08-sortable-cols.js
+++ b/packages/react-data-grid-examples/src/scripts/example08-sortable-cols.js
@@ -102,7 +102,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example09-filterable-grid.js
+++ b/packages/react-data-grid-examples/src/scripts/example09-filterable-grid.js
@@ -110,7 +110,8 @@ class Example extends React.Component {
         minHeight={500}
         toolbar={<Toolbar enableFilter={true} />}
         onAddFilter={this.handleFilterChange}
-        onClearFilters={this.onClearFilters} />);
+        onClearFilters={this.onClearFilters}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example09-filterable-grid.js
+++ b/packages/react-data-grid-examples/src/scripts/example09-filterable-grid.js
@@ -105,10 +105,10 @@ class Example extends React.Component {
       <ReactDataGrid
         columns={this._columns}
         rowGetter={this.rowGetter}
-        enableCellSelect={true}
+        enableCellSelect
         rowsCount={this.getSize()}
         minHeight={500}
-        toolbar={<Toolbar enableFilter={true} />}
+        toolbar={<Toolbar enableFilter />}
         onAddFilter={this.handleFilterChange}
         onClearFilters={this.onClearFilters}
       />);

--- a/packages/react-data-grid-examples/src/scripts/example09-filterable-grid.js
+++ b/packages/react-data-grid-examples/src/scripts/example09-filterable-grid.js
@@ -111,7 +111,8 @@ class Example extends React.Component {
         toolbar={<Toolbar enableFilter />}
         onAddFilter={this.handleFilterChange}
         onClearFilters={this.onClearFilters}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example10-one-million-rows.js
+++ b/packages/react-data-grid-examples/src/scripts/example10-one-million-rows.js
@@ -43,7 +43,8 @@ class Example extends React.Component {
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
-        minHeight={500} />);
+        minHeight={500}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example10-one-million-rows.js
+++ b/packages/react-data-grid-examples/src/scripts/example10-one-million-rows.js
@@ -44,7 +44,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
         minHeight={500}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example11-immutable-data.js
+++ b/packages/react-data-grid-examples/src/scripts/example11-immutable-data.js
@@ -48,7 +48,8 @@ export class Example extends React.Component {
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.size}
-        minHeight={1200} />);
+        minHeight={1200}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example11-immutable-data.js
+++ b/packages/react-data-grid-examples/src/scripts/example11-immutable-data.js
@@ -49,7 +49,8 @@ export class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.size}
         minHeight={1200}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example11-immutable-data.js
+++ b/packages/react-data-grid-examples/src/scripts/example11-immutable-data.js
@@ -44,7 +44,7 @@ export class Example extends React.Component {
   render() {
     return (
       <ReactDataGrid
-        enableCellSelect={true}
+        enableCellSelect
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.size}

--- a/packages/react-data-grid-examples/src/scripts/example12-customRowRenderer.js
+++ b/packages/react-data-grid-examples/src/scripts/example12-customRowRenderer.js
@@ -107,7 +107,8 @@ class Example extends React.Component {
         rowsCount={this._rows.length}
         minHeight={500}
         rowRenderer={RowRenderer}
-      />);
+      />
+    );
   }
 }
 
@@ -116,7 +117,8 @@ const exampleDescription = (
     <p>This shows how you can easily override the default row renderer</p>
     <p>Here we are just using that to wrap the default renderer, and then going back into the 'normal' flow, just changing the text colour</p>
     <p>NOTE: if you want to use fixed columns as well, make sure you implement and pass through the call to setScrollLeft</p>
-  </div>);
+  </div>
+);
 
 export default exampleWrapper({
   WrappedComponent: Example,

--- a/packages/react-data-grid-examples/src/scripts/example12-customRowRenderer.js
+++ b/packages/react-data-grid-examples/src/scripts/example12-customRowRenderer.js
@@ -106,7 +106,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
         minHeight={500}
-        rowRenderer={RowRenderer} />);
+        rowRenderer={RowRenderer}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example13-all-features.js
+++ b/packages/react-data-grid-examples/src/scripts/example13-all-features.js
@@ -260,7 +260,8 @@ class Example extends React.Component {
         rowHeight={50}
         minHeight={600}
         rowScrollTimeout={200}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example13-all-features.js
+++ b/packages/react-data-grid-examples/src/scripts/example13-all-features.js
@@ -250,13 +250,13 @@ class Example extends React.Component {
     return (
       <ReactDataGrid
         ref={node => this.grid = node}
-        enableCellSelect={true}
+        enableCellSelect
         columns={this.getColumns()}
         rowGetter={this.getRowAt}
         rowsCount={this.getSize()}
         onGridRowsUpdated={this.handleGridRowsUpdated}
         toolbar={<Toolbar onAddRow={this.handleAddRow} />}
-        enableRowSelect={true}
+        enableRowSelect
         rowHeight={50}
         minHeight={600}
         rowScrollTimeout={200}

--- a/packages/react-data-grid-examples/src/scripts/example13-all-features.js
+++ b/packages/react-data-grid-examples/src/scripts/example13-all-features.js
@@ -259,7 +259,8 @@ class Example extends React.Component {
         enableRowSelect={true}
         rowHeight={50}
         minHeight={600}
-        rowScrollTimeout={200} />);
+        rowScrollTimeout={200}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
+++ b/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
@@ -244,7 +244,7 @@ export class Component extends React.Component {
         rowHeight={50}
         minHeight={600}
       />
-      );
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
+++ b/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
@@ -242,7 +242,8 @@ export class Component extends React.Component {
         onGridRowsUpdated={this.handleGridRowsUpdated}
         toolbar={<Toolbar onAddRow={this.handleAddRow} onToggleFilter={() => {}} numberOfRows={this.getSize()} />}
         rowHeight={50}
-        minHeight={600} />
+        minHeight={600}
+      />
       );
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
+++ b/packages/react-data-grid-examples/src/scripts/example14-all-features-immutable.js
@@ -235,7 +235,7 @@ export class Component extends React.Component {
       <ReactDataGrid
         contextMenu={<MyContextMenu />}
         ref={(node) => this.reactDataGrid = node}
-        enableCellSelect={true}
+        enableCellSelect
         columns={columns}
         rowGetter={this.getRowAt}
         rowsCount={this.getSize()}

--- a/packages/react-data-grid-examples/src/scripts/example15-empty-rows.js
+++ b/packages/react-data-grid-examples/src/scripts/example15-empty-rows.js
@@ -33,7 +33,8 @@ class Example extends React.Component {
         rowsCount={this._rows.length}
         minHeight={500}
         emptyRowsView={EmptyRowsView}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example15-empty-rows.js
+++ b/packages/react-data-grid-examples/src/scripts/example15-empty-rows.js
@@ -32,7 +32,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
         minHeight={500}
-        emptyRowsView={EmptyRowsView} />);
+        emptyRowsView={EmptyRowsView}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
@@ -66,7 +66,7 @@ class Example extends React.Component {
   render() {
     return (
       <ReactDataGrid
-        enableCellSelect={true}
+        enableCellSelect
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}

--- a/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
@@ -72,7 +72,8 @@ class Example extends React.Component {
         rowsCount={this.state.rows.length}
         minHeight={500}
         onGridRowsUpdated={this.handleGridRowsUpdated}
-      />);
+      />
+    );
   }
 }
 
@@ -80,7 +81,8 @@ const exampleDescription = (
   <div>
     <p>This example demonstrates how you can easily update multiple cells by dragging from the drag handle of an editable cell.</p>
     <p>Alternatively by double clicking on the drag handle, you can update all the cells underneath the active cell.</p>
-  </div>);
+  </div>
+);
 
 export default exampleWrapper({
   WrappedComponent: Example,

--- a/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-cell-drag-down.js
@@ -71,7 +71,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-        onGridRowsUpdated={this.handleGridRowsUpdated} />);
+        onGridRowsUpdated={this.handleGridRowsUpdated}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example16-filterable-sortable-grid.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-filterable-sortable-grid.js
@@ -119,7 +119,8 @@ class Example extends React.Component {
         minHeight={500}
         toolbar={<Toolbar enableFilter={true} />}
         onAddFilter={this.handleFilterChange}
-        onClearFilters={this.onClearFilters} />);
+        onClearFilters={this.onClearFilters}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example16-filterable-sortable-grid.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-filterable-sortable-grid.js
@@ -112,12 +112,12 @@ class Example extends React.Component {
     return (
       <ReactDataGrid
         onGridSort={this.handleGridSort}
-        enableCellSelect={true}
+        enableCellSelect
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.getSize()}
         minHeight={500}
-        toolbar={<Toolbar enableFilter={true} />}
+        toolbar={<Toolbar enableFilter />}
         onAddFilter={this.handleFilterChange}
         onClearFilters={this.onClearFilters}
       />);

--- a/packages/react-data-grid-examples/src/scripts/example16-filterable-sortable-grid.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-filterable-sortable-grid.js
@@ -120,7 +120,8 @@ class Example extends React.Component {
         toolbar={<Toolbar enableFilter />}
         onAddFilter={this.handleFilterChange}
         onClearFilters={this.onClearFilters}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example16-row-select.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-row-select.js
@@ -66,7 +66,8 @@ class Example extends React.Component {
             }
           }}
         />
-      </div>);
+      </div>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example16-row-select.js
+++ b/packages/react-data-grid-examples/src/scripts/example16-row-select.js
@@ -64,7 +64,8 @@ class Example extends React.Component {
             selectBy: {
               indexes: this.state.selectedIndexes
             }
-          }} />
+          }}
+        />
       </div>);
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example17-grid-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example17-grid-events.js
@@ -76,7 +76,8 @@ class Example extends React.Component {
           }
         }}
         onRowClick={this.onRowClick}
-        onGridKeyDown={this.onKeyDown} />);
+        onGridKeyDown={this.onKeyDown}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example17-grid-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example17-grid-events.js
@@ -77,7 +77,8 @@ class Example extends React.Component {
         }}
         onRowClick={this.onRowClick}
         onGridKeyDown={this.onKeyDown}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example18-context-menu.js
+++ b/packages/react-data-grid-examples/src/scripts/example18-context-menu.js
@@ -66,7 +66,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-        RowsContainer={ContextMenuTrigger} />
+        RowsContainer={ContextMenuTrigger}
+      />
     );
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example19-column-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example19-column-events.js
@@ -100,7 +100,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         onGridRowsUpdated={this.handleGridRowsUpdated}
         rowsCount={this.state.rows.length}
-        minHeight={500} />
+        minHeight={500}
+      />
     );
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example19-column-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example19-column-events.js
@@ -96,7 +96,7 @@ class Example extends React.Component {
       <ReactDataGrid
         ref={(node) => this.grid = node}
         columns={this.getColumns()}
-        enableCellSelect={true}
+        enableCellSelect
         rowGetter={this.rowGetter}
         onGridRowsUpdated={this.handleGridRowsUpdated}
         rowsCount={this.state.rows.length}

--- a/packages/react-data-grid-examples/src/scripts/example20-cell-navigation.js
+++ b/packages/react-data-grid-examples/src/scripts/example20-cell-navigation.js
@@ -82,7 +82,8 @@ class Example extends React.Component {
         minHeight={500}
         enableCellSelect
         cellNavigationMode="changeRow"
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example20-cell-navigation.js
+++ b/packages/react-data-grid-examples/src/scripts/example20-cell-navigation.js
@@ -80,7 +80,7 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this._rows.length}
         minHeight={500}
-        enableCellSelect={true}
+        enableCellSelect
         cellNavigationMode="changeRow"
       />);
   }

--- a/packages/react-data-grid-examples/src/scripts/example20-cell-navigation.js
+++ b/packages/react-data-grid-examples/src/scripts/example20-cell-navigation.js
@@ -81,7 +81,8 @@ class Example extends React.Component {
         rowsCount={this._rows.length}
         minHeight={500}
         enableCellSelect={true}
-        cellNavigationMode="changeRow" />);
+        cellNavigationMode="changeRow"
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example21-cell-selection-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-cell-selection-events.js
@@ -58,7 +58,7 @@ class Example extends React.Component {
           enableRowSelect="multi"
           minHeight={500}
           onRowSelect={this.onRowSelect}
-          enableCellSelect={true}
+          enableCellSelect
           onCellSelected={this.onCellSelected}
           onCellDeSelected={this.onCellDeSelected}
         />

--- a/packages/react-data-grid-examples/src/scripts/example21-cell-selection-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-cell-selection-events.js
@@ -62,7 +62,8 @@ class Example extends React.Component {
           onCellSelected={this.onCellSelected}
           onCellDeSelected={this.onCellDeSelected}
         />
-      </div>);
+      </div>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example21-cell-selection-events.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-cell-selection-events.js
@@ -60,7 +60,8 @@ class Example extends React.Component {
           onRowSelect={this.onRowSelect}
           enableCellSelect={true}
           onCellSelected={this.onCellSelected}
-          onCellDeSelected={this.onCellDeSelected} />
+          onCellDeSelected={this.onCellDeSelected}
+        />
       </div>);
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -191,16 +191,16 @@ class Example extends React.Component {
     return (
       <DraggableContainer>
         <ReactDataGrid
-            ref={node => this.grid = node}
-            enableCellSelect={true}
-            enableDragAndDrop={true}
-            columns={columns}
-            rowGetter={this.getRowAt}
-            rowsCount={this.getSize()}
-            onRowExpandToggle={this.onRowExpandToggle}
-            toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
-            rowHeight={50}
-            minHeight={600}
+          ref={node => this.grid = node}
+          enableCellSelect={true}
+          enableDragAndDrop={true}
+          columns={columns}
+          rowGetter={this.getRowAt}
+          rowsCount={this.getSize()}
+          onRowExpandToggle={this.onRowExpandToggle}
+          toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
+          rowHeight={50}
+          minHeight={600}
         />
       </DraggableContainer>
     );

--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -137,7 +137,7 @@ class CustomToolbar extends React.Component {
   render() {
     return (<Toolbar>
       <GroupedColumnsPanel groupBy={this.props.groupBy} onColumnGroupAdded={this.props.onColumnGroupAdded} onColumnGroupDeleted={this.props.onColumnGroupDeleted} />
-      </Toolbar>);
+    </Toolbar>);
   }
 }
 
@@ -190,7 +190,7 @@ class Example extends React.Component {
   render() {
     return (
       <DraggableContainer>
-          <ReactDataGrid
+        <ReactDataGrid
             ref={node => this.grid = node}
             enableCellSelect={true}
             enableDragAndDrop={true}
@@ -201,7 +201,7 @@ class Example extends React.Component {
             toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
             rowHeight={50}
             minHeight={600}
-          />
+        />
       </DraggableContainer>
     );
   }

--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -192,8 +192,8 @@ class Example extends React.Component {
       <DraggableContainer>
         <ReactDataGrid
           ref={node => this.grid = node}
-          enableCellSelect={true}
-          enableDragAndDrop={true}
+          enableCellSelect
+          enableDragAndDrop
           columns={columns}
           rowGetter={this.getRowAt}
           rowsCount={this.getSize()}

--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -201,7 +201,7 @@ class Example extends React.Component {
             toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
             rowHeight={50}
             minHeight={600}
-            />
+          />
       </DraggableContainer>
     );
   }

--- a/packages/react-data-grid-examples/src/scripts/example21-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example21-grouping.js
@@ -135,9 +135,11 @@ class CustomToolbar extends React.Component {
   };
 
   render() {
-    return (<Toolbar>
-      <GroupedColumnsPanel groupBy={this.props.groupBy} onColumnGroupAdded={this.props.onColumnGroupAdded} onColumnGroupDeleted={this.props.onColumnGroupDeleted} />
-    </Toolbar>);
+    return (
+      <Toolbar>
+        <GroupedColumnsPanel groupBy={this.props.groupBy} onColumnGroupAdded={this.props.onColumnGroupAdded} onColumnGroupDeleted={this.props.onColumnGroupDeleted} />
+      </Toolbar>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example22-custom-filters.js
+++ b/packages/react-data-grid-examples/src/scripts/example22-custom-filters.js
@@ -121,7 +121,8 @@ class Example extends React.Component {
         toolbar={<Toolbar enableFilter={true} />}
         onAddFilter={this.handleFilterChange}
         getValidFilterValues={this.getValidFilterValues}
-        onClearFilters={this.handleOnClearFilters} />);
+        onClearFilters={this.handleOnClearFilters}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example22-custom-filters.js
+++ b/packages/react-data-grid-examples/src/scripts/example22-custom-filters.js
@@ -122,7 +122,8 @@ class Example extends React.Component {
         onAddFilter={this.handleFilterChange}
         getValidFilterValues={this.getValidFilterValues}
         onClearFilters={this.handleOnClearFilters}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example22-custom-filters.js
+++ b/packages/react-data-grid-examples/src/scripts/example22-custom-filters.js
@@ -113,12 +113,12 @@ class Example extends React.Component {
   render() {
     return (
       <ReactDataGrid
-        enableCellSelect={true}
+        enableCellSelect
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.rowsCount()}
         minHeight={500}
-        toolbar={<Toolbar enableFilter={true} />}
+        toolbar={<Toolbar enableFilter />}
         onAddFilter={this.handleFilterChange}
         getValidFilterValues={this.getValidFilterValues}
         onClearFilters={this.handleOnClearFilters}

--- a/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
@@ -89,16 +89,16 @@ class Example extends React.Component {
     return (
       <DraggableContainer>
         <ReactDataGrid
-            ref={node => this.grid = node}
-            enableCellSelect={true}
-            enableDragAndDrop={true}
-            columns={_cols}
-            rowGetter={this.getRowAt}
-            rowsCount={this.getSize()}
-            onRowExpandToggle={this.onRowExpandToggle}
-            toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
-            rowHeight={50}
-            minHeight={600}
+          ref={node => this.grid = node}
+          enableCellSelect={true}
+          enableDragAndDrop={true}
+          columns={_cols}
+          rowGetter={this.getRowAt}
+          rowsCount={this.getSize()}
+          onRowExpandToggle={this.onRowExpandToggle}
+          toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
+          rowHeight={50}
+          minHeight={600}
         />
       </DraggableContainer>
     );

--- a/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
@@ -90,8 +90,8 @@ class Example extends React.Component {
       <DraggableContainer>
         <ReactDataGrid
           ref={node => this.grid = node}
-          enableCellSelect={true}
-          enableDragAndDrop={true}
+          enableCellSelect
+          enableDragAndDrop
           columns={_cols}
           rowGetter={this.getRowAt}
           rowsCount={this.getSize()}

--- a/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
@@ -88,7 +88,7 @@ class Example extends React.Component {
   render() {
     return (
       <DraggableContainer>
-          <ReactDataGrid
+        <ReactDataGrid
             ref={node => this.grid = node}
             enableCellSelect={true}
             enableDragAndDrop={true}
@@ -99,7 +99,7 @@ class Example extends React.Component {
             toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
             rowHeight={50}
             minHeight={600}
-          />
+        />
       </DraggableContainer>
     );
   }

--- a/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
@@ -99,7 +99,7 @@ class Example extends React.Component {
             toolbar={<CustomToolbar groupBy={this.state.groupBy} onColumnGroupAdded={this.onColumnGroupAdded} onColumnGroupDeleted={this.onColumnGroupDeleted} />}
             rowHeight={50}
             minHeight={600}
-            />
+          />
       </DraggableContainer>
     );
   }

--- a/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-immutable-data-grouping.js
@@ -39,7 +39,8 @@ class CustomToolbar extends React.Component {
     return (
       <Toolbar>
         <GroupedColumnsPanel groupBy={this.props.groupBy} onColumnGroupAdded={this.props.onColumnGroupAdded} onColumnGroupDeleted={this.props.onColumnGroupDeleted} />
-      </Toolbar>);
+      </Toolbar>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
@@ -113,7 +113,8 @@ class Example extends React.Component {
             }
           }}
         />
-      </DraggableContainer>);
+      </DraggableContainer>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
@@ -96,7 +96,7 @@ class Example extends React.Component {
     return (
       <DraggableContainer>
         <ReactDataGrid
-          enableCellSelection={true}
+          enableCellSelection
           rowActionsCell={RowActionsCell}
           columns={this._columns}
           rowGetter={this.rowGetter}

--- a/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
+++ b/packages/react-data-grid-examples/src/scripts/example23-row-reordering.js
@@ -111,7 +111,8 @@ class Example extends React.Component {
             selectBy: {
               keys: { rowKey: this.props.rowKey, values: this.state.selectedIds }
             }
-          }} />
+          }}
+        />
       </DraggableContainer>);
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example24-draggable-header.js
+++ b/packages/react-data-grid-examples/src/scripts/example24-draggable-header.js
@@ -77,7 +77,8 @@ class Example extends React.Component {
   render() {
     return (
       <DraggableContainer
-        onHeaderDrop={this.onHeaderDrop}>
+        onHeaderDrop={this.onHeaderDrop}
+      >
         <ReactDataGrid
           columns={this.state.columns}
           rowGetter={this.rowGetter}

--- a/packages/react-data-grid-examples/src/scripts/example25-tree-view.js
+++ b/packages/react-data-grid-examples/src/scripts/example25-tree-view.js
@@ -126,17 +126,19 @@ class Example extends React.Component {
   };
 
   render() {
-    return (<ReactDataGrid
-      enableCellSelect
-      columns={columns}
-      rowGetter={this.getRows}
-      rowsCount={this.state.rows.length}
-      getSubRowDetails={this.getSubRowDetails}
-      onDeleteSubRow={this.onDeleteSubRow}
-      minHeight={500}
-      onCellExpand={this.onCellExpand}
-      onAddSubRow={this.onAddSubRow}
-            />);
+    return (
+      <ReactDataGrid
+        enableCellSelect
+        columns={columns}
+        rowGetter={this.getRows}
+        rowsCount={this.state.rows.length}
+        getSubRowDetails={this.getSubRowDetails}
+        onDeleteSubRow={this.onDeleteSubRow}
+        minHeight={500}
+        onCellExpand={this.onCellExpand}
+        onAddSubRow={this.onAddSubRow}
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example25-tree-view.js
+++ b/packages/react-data-grid-examples/src/scripts/example25-tree-view.js
@@ -135,7 +135,8 @@ class Example extends React.Component {
       onDeleteSubRow={this.onDeleteSubRow}
       minHeight={500}
       onCellExpand={this.onCellExpand}
-      onAddSubRow={this.onAddSubRow} />);
+      onAddSubRow={this.onAddSubRow}
+            />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example25-tree-view.js
+++ b/packages/react-data-grid-examples/src/scripts/example25-tree-view.js
@@ -127,7 +127,7 @@ class Example extends React.Component {
 
   render() {
     return (<ReactDataGrid
-      enableCellSelect={true}
+      enableCellSelect
       columns={columns}
       rowGetter={this.getRows}
       rowsCount={this.state.rows.length}

--- a/packages/react-data-grid-examples/src/scripts/example26-tree-view-no-add-delete.js
+++ b/packages/react-data-grid-examples/src/scripts/example26-tree-view-no-add-delete.js
@@ -102,15 +102,17 @@ class Example extends React.Component {
   };
 
   render() {
-    return (<ReactDataGrid
-      enableCellSelect
-      columns={columns}
-      rowGetter={this.getRows}
-      rowsCount={this.state.rows.length}
-      getSubRowDetails={this.getSubRowDetails}
-      minHeight={500}
-      onCellExpand={this.onCellExpand}
-            />);
+    return (
+      <ReactDataGrid
+        enableCellSelect
+        columns={columns}
+        rowGetter={this.getRows}
+        rowsCount={this.state.rows.length}
+        getSubRowDetails={this.getSubRowDetails}
+        minHeight={500}
+        onCellExpand={this.onCellExpand}
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example26-tree-view-no-add-delete.js
+++ b/packages/react-data-grid-examples/src/scripts/example26-tree-view-no-add-delete.js
@@ -109,7 +109,8 @@ class Example extends React.Component {
       rowsCount={this.state.rows.length}
       getSubRowDetails={this.getSubRowDetails}
       minHeight={500}
-      onCellExpand={this.onCellExpand} />);
+      onCellExpand={this.onCellExpand}
+            />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example26-tree-view-no-add-delete.js
+++ b/packages/react-data-grid-examples/src/scripts/example26-tree-view-no-add-delete.js
@@ -103,7 +103,7 @@ class Example extends React.Component {
 
   render() {
     return (<ReactDataGrid
-      enableCellSelect={true}
+      enableCellSelect
       columns={columns}
       rowGetter={this.getRows}
       rowsCount={this.state.rows.length}

--- a/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
+++ b/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
@@ -134,7 +134,7 @@ class Example extends React.Component {
     if (column.key === 'county' && row.id === 'id_0') {
       return [
         {
-          icon: <span className="glyphicon glyphicon-remove"></span>,
+          icon: <span className="glyphicon glyphicon-remove" />,
           callback: () => { alert('Deleting'); }
         },
         {

--- a/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
+++ b/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
@@ -158,7 +158,7 @@ class Example extends React.Component {
     return (
       <ReactDataGrid
         ref={node => this.grid = node}
-        enableCellSelect={true}
+        enableCellSelect
         columns={columns}
         rowGetter={this.getRowAt}
         rowsCount={this.getSize()}

--- a/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
+++ b/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
@@ -164,7 +164,8 @@ class Example extends React.Component {
         rowsCount={this.getSize()}
         rowHeight={55}
         minHeight={600}
-        getCellActions={this.getCellActions} />
+        getCellActions={this.getCellActions}
+      />
     );
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example28-scroll-to-row-index.js
+++ b/packages/react-data-grid-examples/src/scripts/example28-scroll-to-row-index.js
@@ -58,7 +58,8 @@ class Example extends React.Component {
           minHeight={500}
           scrollToRowIndex={+this.state.scrollToRowIndex}
         />
-      </div>);
+      </div>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example28-scroll-to-row-index.js
+++ b/packages/react-data-grid-examples/src/scripts/example28-scroll-to-row-index.js
@@ -44,17 +44,20 @@ class Example extends React.Component {
             style={{ marginRight: '10px', border: '1px outset lightgray', padding: '3px' }}
             type="text"
             value={this.state.value}
-            onChange={(event) => { this.setState({ value: event.target.value }); }} />
+            onChange={(event) => { this.setState({ value: event.target.value }); }}
+          />
           <button
             style={{ padding: '5px' }}
-            onClick={() => this.setState({ scrollToRowIndex: this.state.value })}>Scroll to row</button>
+            onClick={() => this.setState({ scrollToRowIndex: this.state.value })}
+          >Scroll to row</button>
         </div>
         <ReactDataGrid
           columns={this._columns}
           rowGetter={this.rowGetter}
           rowsCount={this._rows.length}
           minHeight={500}
-          scrollToRowIndex={+this.state.scrollToRowIndex} />
+          scrollToRowIndex={+this.state.scrollToRowIndex}
+        />
       </div>);
   }
 }

--- a/packages/react-data-grid-examples/src/scripts/example29-descendingFirstSortable.js
+++ b/packages/react-data-grid-examples/src/scripts/example29-descendingFirstSortable.js
@@ -103,7 +103,8 @@ class Example extends React.Component {
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-      />);
+      />
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example29-descendingFirstSortable.js
+++ b/packages/react-data-grid-examples/src/scripts/example29-descendingFirstSortable.js
@@ -102,7 +102,8 @@ class Example extends React.Component {
         columns={this._columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
-        minHeight={500} />);
+        minHeight={500}
+      />);
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
+++ b/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
@@ -15,7 +15,8 @@ const ExpensiveFormatter = ({ isScrolling }) => {
   }
   const items = [...Array(1000).keys()].map(i => ({ name: `Page ${i}`, uv: getRandom(0, 4000), pv: getRandom(0, 4000), amt: getRandom(0, 4000) })).slice(0, 50);
   return (
-    <AreaChart width={500}
+    <AreaChart
+      width={500}
       height={50}
       data={items}
       margin={{ top: 5, right: 0, left: 0, bottom: 5 }}

--- a/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
+++ b/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
@@ -61,7 +61,8 @@ class Example extends React.Component {
           rowsCount={this.state.rows.length}
           minHeight={800}
           onScroll={this.onScroll}
-        /></div>);
+        /></div>
+    );
   }
 }
 

--- a/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
+++ b/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
@@ -16,7 +16,7 @@ const ExpensiveFormatter = ({ isScrolling }) => {
   const items = [...Array(1000).keys()].map(i => ({ name: `Page ${i}`, uv: getRandom(0, 4000), pv: getRandom(0, 4000), amt: getRandom(0, 4000) })).slice(0, 50);
   return (
     <AreaChart width={500} height={50} data={items}
-          margin={{ top: 5, right: 0, left: 0, bottom: 5 }}
+      margin={{ top: 5, right: 0, left: 0, bottom: 5 }}
     >
       <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
     </AreaChart>

--- a/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
+++ b/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
@@ -15,7 +15,9 @@ const ExpensiveFormatter = ({ isScrolling }) => {
   }
   const items = [...Array(1000).keys()].map(i => ({ name: `Page ${i}`, uv: getRandom(0, 4000), pv: getRandom(0, 4000), amt: getRandom(0, 4000) })).slice(0, 50);
   return (
-    <AreaChart width={500} height={50} data={items}
+    <AreaChart width={500}
+      height={50}
+      data={items}
       margin={{ top: 5, right: 0, left: 0, bottom: 5 }}
     >
       <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />

--- a/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
+++ b/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
@@ -16,7 +16,8 @@ const ExpensiveFormatter = ({ isScrolling }) => {
   const items = [...Array(1000).keys()].map(i => ({ name: `Page ${i}`, uv: getRandom(0, 4000), pv: getRandom(0, 4000), amt: getRandom(0, 4000) })).slice(0, 50);
   return (
     <AreaChart width={500} height={50} data={items}
-          margin={{ top: 5, right: 0, left: 0, bottom: 5 }}>
+          margin={{ top: 5, right: 0, left: 0, bottom: 5 }}
+    >
       <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
     </AreaChart>
   );

--- a/packages/react-data-grid/src/Canvas.js
+++ b/packages/react-data-grid/src/Canvas.js
@@ -394,7 +394,8 @@ export default class Canvas extends React.PureComponent {
         ref={this.setCanvasRef}
         style={style}
         onScroll={this.onScroll}
-        className="react-grid-Canvas">
+        className="react-grid-Canvas"
+      >
         <InteractionMasks
           ref={this.setInteractionMasksRef}
           rowGetter={rowGetter}

--- a/packages/react-data-grid/src/CellAction.js
+++ b/packages/react-data-grid/src/CellAction.js
@@ -60,7 +60,7 @@ export default class CellAction extends React.Component {
     return (
       <div className={cellActionClasses} onMouseLeave={this.onActionButtonBlur}>
         <div className={actionButtonClasses} onClick={this.onActionIconClick}>
-            { typeof (this.props.action.icon) === 'string' ? <span className={this.props.action.icon} /> : this.props.action.icon }
+          { typeof (this.props.action.icon) === 'string' ? <span className={this.props.action.icon} /> : this.props.action.icon }
         </div>
         {
           isActionMenu &&

--- a/packages/react-data-grid/src/CellAction.js
+++ b/packages/react-data-grid/src/CellAction.js
@@ -64,11 +64,11 @@ export default class CellAction extends React.Component {
         </div>
         {
           isActionMenu &&
-          this.state.isMenuOpen &&
-          <div className="rdg-cell-action-menu">
-            {this.onGetMenuOptions()}
-          </div>
-        }
+          this.state.isMenuOpen && (
+            <div className="rdg-cell-action-menu">
+              {this.onGetMenuOptions()}
+            </div>
+          )}
       </div>
     );
   }

--- a/packages/react-data-grid/src/CellAction.js
+++ b/packages/react-data-grid/src/CellAction.js
@@ -60,7 +60,7 @@ export default class CellAction extends React.Component {
     return (
       <div className={cellActionClasses} onMouseLeave={this.onActionButtonBlur}>
         <div className={actionButtonClasses} onClick={this.onActionIconClick}>
-            { typeof (this.props.action.icon) === 'string' ? <span className={this.props.action.icon}></span> : this.props.action.icon }
+            { typeof (this.props.action.icon) === 'string' ? <span className={this.props.action.icon} /> : this.props.action.icon }
         </div>
         {
           isActionMenu &&

--- a/packages/react-data-grid/src/ChildRowDeleteButton.js
+++ b/packages/react-data-grid/src/ChildRowDeleteButton.js
@@ -11,9 +11,13 @@ export default function ChildRowDeleteButton({ treeDepth, cellHeight, siblingInd
   const width = 12;
   const left = treeDepth * 15;
   const top = (cellHeight - 12) / 2;
-  return (<div>
-    <div className={className} />
-    {isDeleteSubRowEnabled && <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={onDeleteSubRow}>
-      <div className="glyphicon glyphicon-remove-sign" />
-    </div>}</div>);
+  return (
+    <div>
+      <div className={className} />
+      {isDeleteSubRowEnabled && (
+        <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={onDeleteSubRow}>
+          <div className="glyphicon glyphicon-remove-sign" />
+        </div>
+      )}</div>
+  );
 }

--- a/packages/react-data-grid/src/ChildRowDeleteButton.js
+++ b/packages/react-data-grid/src/ChildRowDeleteButton.js
@@ -14,6 +14,6 @@ export default function ChildRowDeleteButton({ treeDepth, cellHeight, siblingInd
   return (<div>
     <div className={className} />
     {isDeleteSubRowEnabled && <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={onDeleteSubRow}>
-      <div className="glyphicon glyphicon-remove-sign"></div>
+      <div className="glyphicon glyphicon-remove-sign" />
     </div>}</div>);
 }

--- a/packages/react-data-grid/src/Draggable.js
+++ b/packages/react-data-grid/src/Draggable.js
@@ -79,7 +79,8 @@ export default class Draggable extends React.Component {
         onDragEnd={onDragEnd}
         onMouseDown={this.onMouseDown}
         onTouchStart={this.onMouseDown}
-        className="react-grid-HeaderCell__draggable" />
+        className="react-grid-HeaderCell__draggable"
+      />
     );
   }
 }

--- a/packages/react-data-grid/src/EmptyChildRow.js
+++ b/packages/react-data-grid/src/EmptyChildRow.js
@@ -40,7 +40,7 @@ export default class EmptyChildRow extends React.Component {
         <div className="rdg-empty-child-row" style={{ marginLeft: '30px', lineHeight: `${cellHeight}px` }}>
           <div className="'rdg-child-row-action-cross rdg-child-row-action-cross-last" />
           <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={this.onAddSubRow}>
-            <div className="glyphicon glyphicon-plus-sign"></div>
+            <div className="glyphicon glyphicon-plus-sign" />
           </div>
         </div>
       </div>

--- a/packages/react-data-grid/src/EmptyChildRow.js
+++ b/packages/react-data-grid/src/EmptyChildRow.js
@@ -35,16 +35,18 @@ export default class EmptyChildRow extends React.Component {
     const expandColumn = getColumn(this.props.columns.filter(c => c.key === this.props.expandColumnKey), 0);
 
     const cellLeft = expandColumn ? expandColumn.left : 0;
-    return (<div className="react-grid-Row rdg-add-child-row-container" style={style}>
-      <div className="react-grid-Cell" style={{ position: 'absolute', height: cellHeight, width: '100%', left: cellLeft }}>
-        <div className="rdg-empty-child-row" style={{ marginLeft: '30px', lineHeight: `${cellHeight}px` }}>
-          <div className="'rdg-child-row-action-cross rdg-child-row-action-cross-last" />
-          <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={this.onAddSubRow}>
-            <div className="glyphicon glyphicon-plus-sign" />
+    return (
+      <div className="react-grid-Row rdg-add-child-row-container" style={style}>
+        <div className="react-grid-Cell" style={{ position: 'absolute', height: cellHeight, width: '100%', left: cellLeft }}>
+          <div className="rdg-empty-child-row" style={{ marginLeft: '30px', lineHeight: `${cellHeight}px` }}>
+            <div className="'rdg-child-row-action-cross rdg-child-row-action-cross-last" />
+            <div style={{ left: left, top: top, width: width, height: height }} className="rdg-child-row-btn" onClick={this.onAddSubRow}>
+              <div className="glyphicon glyphicon-plus-sign" />
+            </div>
           </div>
         </div>
       </div>
-    </div>);
+    );
   }
 }
 

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -165,13 +165,13 @@ export default class Grid extends React.Component {
           getValidFilterValues={this.props.getValidFilterValues}
           cellMetaData={this.props.cellMetaData}
         />
-          {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
-            <div
+        {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
+          <div
               ref={this.setViewportContainerRef}
               onKeyDown={this.props.onViewportKeydown}
               onKeyUp={this.props.onViewportKeyup}
-            >
-                <Viewport
+          >
+            <Viewport
                   {...this.props}
                   ref={this.setViewportRef}
                   rowKey={this.props.rowKey}
@@ -212,12 +212,12 @@ export default class Grid extends React.Component {
                   onCommit={this.props.onCommit}
                   RowsContainer={this.props.RowsContainer}
                   editorPortalTarget={this.props.editorPortalTarget}
-                />
-            </div>
+            />
+          </div>
         :
-            <div ref={this.setEmptyViewRef} className="react-grid-Empty">
-                <EmptyRowsView />
-            </div>
+          <div ref={this.setEmptyViewRef} className="react-grid-Empty">
+            <EmptyRowsView />
+          </div>
         }
       </div>
     );

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -167,51 +167,51 @@ export default class Grid extends React.Component {
         />
         {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
           <div
-              ref={this.setViewportContainerRef}
-              onKeyDown={this.props.onViewportKeydown}
-              onKeyUp={this.props.onViewportKeyup}
+            ref={this.setViewportContainerRef}
+            onKeyDown={this.props.onViewportKeydown}
+            onKeyUp={this.props.onViewportKeyup}
           >
             <Viewport
-                  {...this.props}
-                  ref={this.setViewportRef}
-                  rowKey={this.props.rowKey}
-                  width={this.props.columnMetrics.width}
-                  rowHeight={this.props.rowHeight}
-                  rowRenderer={this.props.rowRenderer}
-                  rowGetter={this.props.rowGetter}
-                  rowsCount={this.props.rowsCount}
-                  selectedRows={this.props.selectedRows}
-                  expandedRows={this.props.expandedRows}
-                  columnMetrics={this.props.columnMetrics}
-                  totalWidth={this.props.totalWidth}
-                  onScroll={this.onScroll}
-                  onRows={this.props.onRows}
-                  cellMetaData={this.props.cellMetaData}
-                  rowOffsetHeight={this.props.rowOffsetHeight || this.props.rowHeight * headerRows.length}
-                  minHeight={this.props.minHeight}
-                  rowScrollTimeout={this.props.rowScrollTimeout}
-                  scrollToRowIndex={this.props.scrollToRowIndex}
-                  contextMenu={this.props.contextMenu}
-                  rowSelection={this.props.rowSelection}
-                  getSubRowDetails={this.props.getSubRowDetails}
-                  rowGroupRenderer={this.props.rowGroupRenderer}
-                  overScan={this.props.overScan}
-                  enableCellSelect={this.props.enableCellSelect}
-                  enableCellAutoFocus={this.props.enableCellAutoFocus}
-                  cellNavigationMode={this.props.cellNavigationMode}
-                  eventBus={this.props.eventBus}
-                  onCheckCellIsEditable={this.props.onCheckCellIsEditable}
-                  onCellCopyPaste={this.props.onCellCopyPaste}
-                  onGridRowsUpdated={this.props.onGridRowsUpdated}
-                  onDragHandleDoubleClick={this.props.onDragHandleDoubleClick}
-                  onCellSelected={this.props.onCellSelected}
-                  onCellDeSelected={this.props.onCellDeSelected}
-                  onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
-                  onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
-                  onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
-                  onCommit={this.props.onCommit}
-                  RowsContainer={this.props.RowsContainer}
-                  editorPortalTarget={this.props.editorPortalTarget}
+              {...this.props}
+              ref={this.setViewportRef}
+              rowKey={this.props.rowKey}
+              width={this.props.columnMetrics.width}
+              rowHeight={this.props.rowHeight}
+              rowRenderer={this.props.rowRenderer}
+              rowGetter={this.props.rowGetter}
+              rowsCount={this.props.rowsCount}
+              selectedRows={this.props.selectedRows}
+              expandedRows={this.props.expandedRows}
+              columnMetrics={this.props.columnMetrics}
+              totalWidth={this.props.totalWidth}
+              onScroll={this.onScroll}
+              onRows={this.props.onRows}
+              cellMetaData={this.props.cellMetaData}
+              rowOffsetHeight={this.props.rowOffsetHeight || this.props.rowHeight * headerRows.length}
+              minHeight={this.props.minHeight}
+              rowScrollTimeout={this.props.rowScrollTimeout}
+              scrollToRowIndex={this.props.scrollToRowIndex}
+              contextMenu={this.props.contextMenu}
+              rowSelection={this.props.rowSelection}
+              getSubRowDetails={this.props.getSubRowDetails}
+              rowGroupRenderer={this.props.rowGroupRenderer}
+              overScan={this.props.overScan}
+              enableCellSelect={this.props.enableCellSelect}
+              enableCellAutoFocus={this.props.enableCellAutoFocus}
+              cellNavigationMode={this.props.cellNavigationMode}
+              eventBus={this.props.eventBus}
+              onCheckCellIsEditable={this.props.onCheckCellIsEditable}
+              onCellCopyPaste={this.props.onCellCopyPaste}
+              onGridRowsUpdated={this.props.onGridRowsUpdated}
+              onDragHandleDoubleClick={this.props.onDragHandleDoubleClick}
+              onCellSelected={this.props.onCellSelected}
+              onCellDeSelected={this.props.onCellDeSelected}
+              onCellRangeSelectionStarted={this.props.onCellRangeSelectionStarted}
+              onCellRangeSelectionUpdated={this.props.onCellRangeSelectionUpdated}
+              onCellRangeSelectionCompleted={this.props.onCellRangeSelectionCompleted}
+              onCommit={this.props.onCommit}
+              RowsContainer={this.props.RowsContainer}
+              editorPortalTarget={this.props.editorPortalTarget}
             />
           </div>
         :

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -164,13 +164,13 @@ export default class Grid extends React.Component {
           onHeaderDrop={this.props.onHeaderDrop}
           getValidFilterValues={this.props.getValidFilterValues}
           cellMetaData={this.props.cellMetaData}
-          />
+        />
           {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
             <div
               ref={this.setViewportContainerRef}
               onKeyDown={this.props.onViewportKeydown}
               onKeyUp={this.props.onViewportKeyup}
-              >
+            >
                 <Viewport
                   {...this.props}
                   ref={this.setViewportRef}

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -165,7 +165,7 @@ export default class Grid extends React.Component {
           getValidFilterValues={this.props.getValidFilterValues}
           cellMetaData={this.props.cellMetaData}
         />
-        {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ?
+        {this.props.rowsCount >= 1 || (this.props.rowsCount === 0 && !this.props.emptyRowsView) ? (
           <div
             ref={this.setViewportContainerRef}
             onKeyDown={this.props.onViewportKeydown}
@@ -214,11 +214,11 @@ export default class Grid extends React.Component {
               editorPortalTarget={this.props.editorPortalTarget}
             />
           </div>
-          :
+        ) : (
           <div ref={this.setEmptyViewRef} className="react-grid-Empty">
             <EmptyRowsView />
           </div>
-        }
+        )}
       </div>
     );
   }

--- a/packages/react-data-grid/src/Grid.js
+++ b/packages/react-data-grid/src/Grid.js
@@ -214,7 +214,7 @@ export default class Grid extends React.Component {
               editorPortalTarget={this.props.editorPortalTarget}
             />
           </div>
-        :
+          :
           <div ref={this.setEmptyViewRef} className="react-grid-Empty">
             <EmptyRowsView />
           </div>

--- a/packages/react-data-grid/src/Header.js
+++ b/packages/react-data-grid/src/Header.js
@@ -196,7 +196,8 @@ export default class Header extends React.Component {
         height={height}
         onScroll={onScroll}
         style={this.getStyle()}
-        className={className} onClick={this.onHeaderClick}
+        className={className}
+        onClick={this.onHeaderClick}
       >
         {headerRows}
       </div>

--- a/packages/react-data-grid/src/Header.js
+++ b/packages/react-data-grid/src/Header.js
@@ -54,7 +54,7 @@ export default class Header extends React.Component {
         columnMetrics: { ...state.columnMetrics }
       };
       resizing.columnMetrics = ColumnMetrics.resizeColumn(
-          resizing.columnMetrics, pos, width);
+        resizing.columnMetrics, pos, width);
 
       // we don't want to influence scrollLeft while resizing
       if (resizing.columnMetrics.totalWidth < state.columnMetrics.totalWidth) {

--- a/packages/react-data-grid/src/HeaderRow.js
+++ b/packages/react-data-grid/src/HeaderRow.js
@@ -111,7 +111,7 @@ export default class HeaderRow extends React.Component {
 
     for (let i = 0, len = getSize(columns); i < len; i++) {
       const column = { rowType, ...getColumn(columns, i) };
-      const _renderer = column.key === 'select-row' && rowType === HeaderRowType.FILTER ? <div></div> : this.getHeaderRenderer(column);
+      const _renderer = column.key === 'select-row' && rowType === HeaderRowType.FILTER ? <div /> : this.getHeaderRenderer(column);
 
       const cell = (
         <BaseHeaderCell

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -823,7 +823,8 @@ export default class ReactDataGrid extends React.Component {
     }
     return (
       <div className="react-grid-Container" style={{ width: containerWidth }}
-        ref={this.setGridRef}>
+        ref={this.setGridRef}
+      >
         {toolbar}
         <div className="react-grid-Main">
           <BaseGrid

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -822,7 +822,8 @@ export default class ReactDataGrid extends React.Component {
       gridWidth = '100%';
     }
     return (
-      <div className="react-grid-Container"
+      <div
+        className="react-grid-Container"
         style={{ width: containerWidth }}
         ref={this.setGridRef}
       >

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -822,7 +822,8 @@ export default class ReactDataGrid extends React.Component {
       gridWidth = '100%';
     }
     return (
-      <div className="react-grid-Container" style={{ width: containerWidth }}
+      <div className="react-grid-Container"
+        style={{ width: containerWidth }}
         ref={this.setGridRef}
       >
         {toolbar}

--- a/packages/react-data-grid/src/ResizeHandle.js
+++ b/packages/react-data-grid/src/ResizeHandle.js
@@ -15,7 +15,8 @@ const style = {
 export default class ResizeHandle extends React.Component {
   render() {
     return (
-      <Draggable {...this.props}
+      <Draggable
+        {...this.props}
         className="react-grid-HeaderCell__resizeHandle"
         style={style}
       />

--- a/packages/react-data-grid/src/RowGroup.js
+++ b/packages/react-data-grid/src/RowGroup.js
@@ -92,7 +92,8 @@ class Defaultbase extends Component {
         <span
           className="row-expand-icon"
           style={{ float: 'left', marginLeft, cursor: 'pointer' }}
-          onClick={onRowExpandClick}>
+          onClick={onRowExpandClick}
+        >
           {isExpanded ? String.fromCharCode(9660) : String.fromCharCode(9658)}
         </span>
         <strong>{columnGroupDisplayName}: {name}</strong>

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -260,7 +260,8 @@ export default class Viewport extends React.Component {
       <div
         className="react-grid-Viewport"
         style={style}
-        ref={this.setViewportRef}>
+        ref={this.setViewportRef}
+      >
         <Canvas
           ref={this.setCanvasRef}
           rowKey={this.props.rowKey}

--- a/packages/react-data-grid/src/__tests__/Canvas.spec.js
+++ b/packages/react-data-grid/src/__tests__/Canvas.spec.js
@@ -142,7 +142,7 @@ describe('Canvas Tests', () => {
 
     it('can render a custom renderer if __metadata property exists', () => {
       const EmptyChildRow = () => {
-        return (<div className="test-row-renderer"></div>);
+        return (<div className="test-row-renderer" />);
       };
       const rowGetter = () => { return { id: 0, __metaData: { getRowRenderer: EmptyChildRow } }; };
       const props = { rowOverscanStartIdx: 0, rowOverscanEndIdx: 1, columns: COLUMNS, rowGetter, rowsCount: 1, getSubRowDetails: getFakeSubRowDetails(1) };

--- a/packages/react-data-grid/src/__tests__/ColumnUtils.spec.js
+++ b/packages/react-data-grid/src/__tests__/ColumnUtils.spec.js
@@ -10,7 +10,7 @@ const render = function(element, mountPoint) {
   if (!instance.renderWithProps) {
     instance.renderWithProps = function(newProps) {
       return render(
-       React.cloneElement(element, newProps), mount);
+        React.cloneElement(element, newProps), mount);
     };
   }
   return instance;

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -11,16 +11,18 @@ function shallowRenderGrid({
   numRows = helpers.rowsCount(),
   onCellSelected, onCellDeSelected
 }) {
-  const wrapper = shallow(<ReactDataGrid
-    columns={helpers.columns}
-    rowGetter={helpers.rowGetter}
-    rowsCount={numRows}
-    enableCellSelect
-    enableCellAutoFocus={enableCellAutoFocus}
-    cellNavigationMode={cellNavigationMode}
-    onCellSelected={onCellSelected}
-    onCellDeSelected={onCellDeSelected}
-                          />);
+  const wrapper = shallow(
+    <ReactDataGrid
+      columns={helpers.columns}
+      rowGetter={helpers.rowGetter}
+      rowsCount={numRows}
+      enableCellSelect
+      enableCellAutoFocus={enableCellAutoFocus}
+      cellNavigationMode={cellNavigationMode}
+      onCellSelected={onCellSelected}
+      onCellDeSelected={onCellDeSelected}
+    />
+  );
   return {
     wrapper
   };

--- a/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
+++ b/packages/react-data-grid/src/__tests__/ReactDataGrid.spec.js
@@ -20,7 +20,7 @@ function shallowRenderGrid({
     cellNavigationMode={cellNavigationMode}
     onCellSelected={onCellSelected}
     onCellDeSelected={onCellDeSelected}
-  />);
+                          />);
   return {
     wrapper
   };

--- a/packages/react-data-grid/src/common/cells/headerCells/SortableHeaderCell.js
+++ b/packages/react-data-grid/src/common/cells/headerCells/SortableHeaderCell.js
@@ -58,7 +58,8 @@ export default class SortableHeaderCell extends React.Component {
     return (
       <div className={className}
         onClick={this.onClick}
-        style={{ cursor: 'pointer' }}>
+        style={{ cursor: 'pointer' }}
+      >
         <span className="pull-right">{this.getSortByText()}</span>
         {content}
       </div>

--- a/packages/react-data-grid/src/common/cells/headerCells/SortableHeaderCell.js
+++ b/packages/react-data-grid/src/common/cells/headerCells/SortableHeaderCell.js
@@ -56,7 +56,8 @@ export default class SortableHeaderCell extends React.Component {
     });
     const content = this.props.headerRenderer ? React.cloneElement(this.props.headerRenderer, this.props) : this.props.column.name;
     return (
-      <div className={className}
+      <div
+        className={className}
         onClick={this.onClick}
         style={{ cursor: 'pointer' }}
       >

--- a/packages/react-data-grid/src/common/cells/headerCells/SortableHeaderCell.js
+++ b/packages/react-data-grid/src/common/cells/headerCells/SortableHeaderCell.js
@@ -22,18 +22,18 @@ export default class SortableHeaderCell extends React.Component {
     let direction;
     const { sortDirection, sortDescendingFirst } = this.props;
     switch (sortDirection) {
-      default:
-      case null:
-      case undefined:
-      case DEFINE_SORT.NONE:
-        direction = sortDescendingFirst ? DEFINE_SORT.DESC : DEFINE_SORT.ASC;
-        break;
-      case DEFINE_SORT.ASC:
-        direction = sortDescendingFirst ? DEFINE_SORT.NONE : DEFINE_SORT.DESC;
-        break;
-      case DEFINE_SORT.DESC:
-        direction = sortDescendingFirst ? DEFINE_SORT.ASC : DEFINE_SORT.NONE;
-        break;
+    default:
+    case null:
+    case undefined:
+    case DEFINE_SORT.NONE:
+      direction = sortDescendingFirst ? DEFINE_SORT.DESC : DEFINE_SORT.ASC;
+      break;
+    case DEFINE_SORT.ASC:
+      direction = sortDescendingFirst ? DEFINE_SORT.NONE : DEFINE_SORT.DESC;
+      break;
+    case DEFINE_SORT.DESC:
+      direction = sortDescendingFirst ? DEFINE_SORT.ASC : DEFINE_SORT.NONE;
+      break;
     }
     this.props.onSort(
       this.props.columnKey,

--- a/packages/react-data-grid/src/common/editors/CheckboxEditor.js
+++ b/packages/react-data-grid/src/common/editors/CheckboxEditor.js
@@ -24,7 +24,7 @@ export default class CheckboxEditor extends React.Component {
     return (
       <div className="react-grid-checkbox-container checkbox-align" onClick={this.handleChange}>
         <input className="react-grid-checkbox" type="checkbox" name={checkboxName} checked={checked} readOnly />
-        <label htmlFor={checkboxName} className="react-grid-checkbox-label"></label>
+        <label htmlFor={checkboxName} className="react-grid-checkbox-label" />
       </div>);
   }
 }

--- a/packages/react-data-grid/src/common/editors/CheckboxEditor.js
+++ b/packages/react-data-grid/src/common/editors/CheckboxEditor.js
@@ -25,6 +25,7 @@ export default class CheckboxEditor extends React.Component {
       <div className="react-grid-checkbox-container checkbox-align" onClick={this.handleChange}>
         <input className="react-grid-checkbox" type="checkbox" name={checkboxName} checked={checked} readOnly />
         <label htmlFor={checkboxName} className="react-grid-checkbox-label" />
-      </div>);
+      </div>
+    );
   }
 }

--- a/packages/react-data-grid/src/common/editors/EditorContainer.js
+++ b/packages/react-data-grid/src/common/editors/EditorContainer.js
@@ -301,7 +301,7 @@ export default class EditorContainer extends React.Component {
 
   renderStatusIcon = () => {
     if (this.state.isInvalid === true) {
-      return <span className="glyphicon glyphicon-remove form-control-feedback"></span>;
+      return <span className="glyphicon glyphicon-remove form-control-feedback" />;
     }
   };
 

--- a/packages/react-data-grid/src/common/editors/SimpleTextEditor.js
+++ b/packages/react-data-grid/src/common/editors/SimpleTextEditor.js
@@ -10,7 +10,8 @@ export default class SimpleTextEditor extends EditorBase {
     return (
       <input
         ref={this.setInputRef}
-        type="text" onBlur={this.props.onBlur}
+        type="text"
+        onBlur={this.props.onBlur}
         className="form-control"
         defaultValue={this.props.value}
       />

--- a/packages/react-data-grid/src/common/editors/SimpleTextEditor.js
+++ b/packages/react-data-grid/src/common/editors/SimpleTextEditor.js
@@ -12,7 +12,8 @@ export default class SimpleTextEditor extends EditorBase {
         ref={this.setInputRef}
         type="text" onBlur={this.props.onBlur}
         className="form-control"
-        defaultValue={this.props.value} />
+        defaultValue={this.props.value}
+      />
     );
   }
 }

--- a/packages/react-data-grid/src/common/editors/__tests__/CheckboxEditor.spec.js
+++ b/packages/react-data-grid/src/common/editors/__tests__/CheckboxEditor.spec.js
@@ -18,7 +18,7 @@ describe('CheckboxEditor', () => {
     beforeEach(() => {
       spyOn(testColumn, 'onCellChange');
       componentWrapper = mount(<CheckboxEditor
-        value={true}
+        value
         rowIdx={1}
         column={testColumn}
                                />);

--- a/packages/react-data-grid/src/common/editors/__tests__/CheckboxEditor.spec.js
+++ b/packages/react-data-grid/src/common/editors/__tests__/CheckboxEditor.spec.js
@@ -20,7 +20,8 @@ describe('CheckboxEditor', () => {
       componentWrapper = mount(<CheckboxEditor
         value={true}
         rowIdx={1}
-        column={testColumn} />);
+        column={testColumn}
+                               />);
       component = componentWrapper.instance();
     });
 

--- a/packages/react-data-grid/src/common/editors/__tests__/CheckboxEditor.spec.js
+++ b/packages/react-data-grid/src/common/editors/__tests__/CheckboxEditor.spec.js
@@ -17,11 +17,13 @@ describe('CheckboxEditor', () => {
 
     beforeEach(() => {
       spyOn(testColumn, 'onCellChange');
-      componentWrapper = mount(<CheckboxEditor
-        value
-        rowIdx={1}
-        column={testColumn}
-                               />);
+      componentWrapper = mount(
+        <CheckboxEditor
+          value
+          rowIdx={1}
+          column={testColumn}
+        />
+      );
       component = componentWrapper.instance();
     });
 

--- a/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.js
+++ b/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.js
@@ -17,7 +17,7 @@ describe('SimpleTextEditor', () => {
         onKeyDown={fakeFunction}
         commit={fakeFunction}
         column={fakeColumn}
-      />).instance();
+                        />).instance();
     });
 
     it('should create a new SimpleTextEditor instance', () => {

--- a/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.js
+++ b/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.js
@@ -11,13 +11,15 @@ describe('SimpleTextEditor', () => {
     function fakeBlurCb() { return true; }
     function fakeFunction() { }
     beforeEach(() => {
-      component = mount(<SimpleTextEditor
-        value="This is a test"
-        onBlur={fakeBlurCb}
-        onKeyDown={fakeFunction}
-        commit={fakeFunction}
-        column={fakeColumn}
-                        />).instance();
+      component = mount(
+        <SimpleTextEditor
+          value="This is a test"
+          onBlur={fakeBlurCb}
+          onKeyDown={fakeFunction}
+          commit={fakeFunction}
+          column={fakeColumn}
+        />
+      ).instance();
     });
 
     it('should create a new SimpleTextEditor instance', () => {

--- a/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.js
+++ b/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.js
@@ -12,7 +12,7 @@ describe('SimpleTextEditor', () => {
     function fakeFunction() { }
     beforeEach(() => {
       component = mount(<SimpleTextEditor
-        value={'This is a test'}
+        value="This is a test"
         onBlur={fakeBlurCb}
         onKeyDown={fakeFunction}
         commit={fakeFunction}

--- a/packages/react-data-grid/src/formatters/SelectAll.js
+++ b/packages/react-data-grid/src/formatters/SelectAll.js
@@ -12,7 +12,7 @@ export default function SelectAll(props) {
         ref={props.inputRef}
         onChange={props.onChange}
       />
-      <label htmlFor="select-all-checkbox" className="react-grid-checkbox-label"></label>
+      <label htmlFor="select-all-checkbox" className="react-grid-checkbox-label" />
     </div>
   );
 }


### PR DESCRIPTION
All auto fixed except the `indent` rule. It was mostly auto-fixed but had to manually make some [changes](https://github.com/adazzle/react-data-grid/pull/1512/commits/b43c25ade00f398837303de39a9e6eb47d54bbed)