### PR TITLE
Add border-box sizing to header cell and grid cell

### DIFF
--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -4,15 +4,18 @@
   padding-right: 8px;
   border-right: 1px solid #eee;
   border-bottom: 1px solid #dddddd;
+  box-sizing: border-box;
 }
 
 .rdg-selected {
   border: 2px solid #66afe9;
+  box-sizing: border-box;
 }
 
 .rdg-selected-range {
   border: 1px solid #66afe9;
   background-color: #66afe930;
+  box-sizing: border-box;
 }
 
 .moving-element {

--- a/themes/react-data-grid-header.css
+++ b/themes/react-data-grid-header.css
@@ -21,6 +21,7 @@
   font-weight: bold;
   border-right: 1px solid #dddddd;
   border-bottom: 1px solid #dddddd;
+  box-sizing: border-box;
 }
 .react-grid-HeaderCell__value {
   white-space: nowrap;


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
Add `box-sizing: border-box` CSS rule to `.react-grid-HeaderCell, .react-grid-Cell, .rdg-selected, .rdg-selected-range` classnames to fix misplaced cell/selection-box borders when no Bootstrap CSS is being used.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Cell borders are misplaced if no bootstrap CSS is being used.


**What is the new behavior?**
Cell and selection borders are in place even without need of adding Bootstrap CSS


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Closes: #634 