### PR TITLE
Removed default props triggering deprecation warnings

### DIFF
--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -225,10 +225,8 @@ class ReactDataGrid extends React.Component {
     enableCellSelect: false,
     rowHeight: 35,
     headerFiltersHeight: 45,
-    enableRowSelect: false,
     minHeight: 350,
     rowKey: 'id',
-    rowScrollTimeout: 0,
     scrollToRowIndex: 0,
     cellNavigationMode: CellNavigationMode.NONE,
     overScan: {


### PR DESCRIPTION
## Description
Removed default props triggering deprecation warnings in ReactDataGrid.java for enableRowSelect and rowScrollTimeout parameters. Fixes issue #1403.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
Didn't find a rule for commit messages in the guidelines, no tests added because default props are difficult to test and I don't want to include a tests that looks for messages of console.warn...

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
See issue #1403 

**What is the new behavior?**
No warnings in the console any more.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:
I didn't manage to get the tests for chrome to run as I don't want chrome to be installed on my maschine, but firefox tests run fine and looking at the code this shouldn't cause any problems.