### PR TITLE
Crash when columns are cleared

### DIFF
--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -77,6 +77,26 @@ class InteractionMasks extends React.Component {
     editorPortalTarget: PropTypes.instanceOf(Element).isRequired
   };
 
+  static getDerivedStateFromProps(nextProps) {
+    if(nextProps.columns === undefined || nextProps.columns.length === 0) {
+      return ({
+        selectedPosition: {
+          idx: -1,
+          rowIdx: -1
+        },
+        selectedRange: {
+          topLeft: {
+            idx: -1, rowIdx: -1
+          },
+          bottomRight: {
+            idx: -1, rowIdx: -1
+          }
+        }
+      });
+    }
+    return null;
+  }
+
   state = {
     selectedPosition: {
       idx: -1,


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Page using react datagrid with multi-cell-selection enabled crashes once user selects couple cells and columns are cleared

**What is the new behavior?**
Page doesn't crash


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
**Other information**:

Sample code causing crash: https://codesandbox.io/s/2p1x7lwrlj