### PR TITLE
Temporary fix for the selection bug

### DIFF
--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -646,9 +646,9 @@ class InteractionMasks extends React.Component {
     this.copyMask = node;
   };
 
-  getSelectedDimensions = (selectedPosition) => {
-    const { scrollLeft, getRowHeight, getRowTop, getRowColumns } = this.props;
-    const columns = getRowColumns(selectedPosition.rowIdx);
+  getSelectedDimensions = (selectedPosition, useGridColumns) => {
+    const { scrollLeft, getRowHeight, getRowTop, getRowColumns, columns: gridColumns } = this.props;
+    const columns = useGridColumns ? gridColumns : getRowColumns(selectedPosition.rowIdx);
     const top = getRowTop(selectedPosition.rowIdx);
     const rowHeight = getRowHeight(selectedPosition.rowIdx);
     return { ...getSelectedDimensions({ selectedPosition, columns, scrollLeft, rowHeight }), top };

--- a/packages/react-data-grid/src/masks/SelectionMask.js
+++ b/packages/react-data-grid/src/masks/SelectionMask.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import CellMask from './CellMask';
 
 function SelectionMask({ selectedPosition, innerRef, getSelectedDimensions, children }) {
-  const dimensions = getSelectedDimensions(selectedPosition);
+  const dimensions = getSelectedDimensions(selectedPosition, true);
   return (
     <CellMask
       {...dimensions}

--- a/themes/react-data-grid-cell.css
+++ b/themes/react-data-grid-cell.css
@@ -176,7 +176,7 @@
    cursor:pointer;
    border:1px solid grey;
    border-radius:14px;
-   z-index: 3;
+   z-index: 2;
    background: white;
 }
 


### PR DESCRIPTION
This issue happens when RowRenderer returns different columns for different rows. 

How to reproduce
- Add 3 rows with 10, 10, and 2 columns
- Select column 5 on row 2. 
- Delete row 2.
- RDG tries to find column 5 on row 2 (which was row 3) and it does not exists.

This is [same behavior as V5](https://github.com/adazzle/react-data-grid/pull/1369/files#diff-04fdd57267f50e49721eb930c70e4059L593) and it needs to be revisited