### PR TITLE
Fix scroll bug

### DIFF
--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -341,7 +341,7 @@ class InteractionMasks extends React.Component {
     const isCellAtBottomBoundary = cell => cell.rowIdx >= rowVisibleEndIdx - SCROLL_CELL_BUFFER;
     const isCellAtTopBoundary = cell => cell.rowIdx !== 0 && cell.rowIdx <= rowVisibleStartIdx - 1;
     const isCellAtRightBoundary = cell => cell.idx !== 0 && cell.idx >= colVisibleEndIdx - 1;
-    const isCellAtLeftBoundary = cell => cell.idx !== 0 && cell.idx <= colVisibleStartIdx + 1;
+    const isCellAtLeftBoundary = cell => cell.idx <= colVisibleStartIdx + 1;
 
     const keyNavActions = {
       ArrowDown: {

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.js
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.js
@@ -651,6 +651,20 @@ describe('<InteractionMasks/>', () => {
         it('allows the user to exit the grid with Shift+Tab if there are no rows', () => {
           assertExitGridOnTab({ cellNavigationMode, rowsCount: 0 }, true);
         });
+        it('hits boundary when the user presses Shift+Tab and the cell is at a left boundary', () => {
+          const selectedPosition = { rowIdx: 1, idx: 1 };
+          const { wrapper, props } = setup({ cellNavigationMode }, { selectedPosition });
+          const preventDefaultSpy = jasmine.createSpy();
+           simulateTab(wrapper, true, preventDefaultSpy);
+           expect(props.onHitLeftBoundary).toHaveBeenCalled();
+        });
+        it('does not hit boundary when the user presses Shift+Tab and the cell is not at a left boundary ', () => {
+          const selectedPosition = { rowIdx: 1, idx: 3 };
+          const { wrapper, props } = setup({ cellNavigationMode }, { selectedPosition });
+          const preventDefaultSpy = jasmine.createSpy();
+           simulateTab(wrapper, true, preventDefaultSpy);
+           expect(props.onHitLeftBoundary).not.toHaveBeenCalled();
+        });
         it('goes to the first cell in the row when the user presses Tab and they are at the end of a row', () => {
           const selectedPosition = { rowIdx: ROWS_COUNT - 1, idx: NUMBER_OF_COLUMNS - 1 };
           assertSelectedCellOnTab({ cellNavigationMode }, false, { selectedPosition })


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
When scrolling using tab, if you scroll past the current view and the try to use shift tab to move back to the first column, then the grid will not scroll back to the first column. This fix allows you to tab off of the current view and then shift tab back to the first column.


**Please check if the PR fulfills these requirements**
- [v] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [v] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[v] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When scrolling using tab, if you scroll past the current view and the try to use shift tab to move back to the first column, then the first column is not viewable unless the use clicks on the scroll bar and drags to the first column.

**What is the new behavior?**
When scrolling using tab, if you scroll past the current view and the try to use shift tab to move back to the first column, then the grid will show the first column.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[v] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
