### PR TITLE
Make missing exports an error instead of warning

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -37,7 +37,8 @@ module.exports = {
         exclude: /node_modules/,
         use: ['babel-loader']
       }
-    ]
+    ],
+    strictExportPresence: true
   },
   optimization: {
     minimizer: [


### PR DESCRIPTION
https://webpack.js.org/configuration/module/

![image](https://user-images.githubusercontent.com/1452717/55574497-2bd4d480-56d2-11e9-9a16-5b233c77ce66.png)
