### PR TITLE
feat(Cell): Add rowIdx arg to getCellActions function

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -41,7 +41,7 @@
 > 👋 Need general support? Not sure about how to use React itself, or how to get started with the Grid?
 > Please do not submit support request here. Instead see
 
-> https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
+> https://github.com/adazzle/react-data-grid/blob/master/docs/CONTRIBUTING.md
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 A few sentences describing the overall goals of the pull request's commits.
 
 **Please check if the PR fulfills these requirements**
-- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
+- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/docs/CONTRIBUTING.md
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 
 Migrations
 --------
-If you intend to do a major release update for you react-data-grid check [the migration documents](migrations).
+If you intend to do a major release update for you react-data-grid check [the migration documents](docs/migrations).
   
 Features
 --------
@@ -86,7 +86,7 @@ and workflows are to create.
 Contributing
 ------------
 
-Please see [CONTRIBUTING](CONTRIBUTING.md)
+Please see [CONTRIBUTING](docs/CONTRIBUTING.md)
 
 Credits 
 ------------

--- a/docs/examples/cell-actions.md
+++ b/docs/examples/cell-actions.md
@@ -19,11 +19,12 @@ To use the cell action, create a function called getCellActions which will be pa
  * A function called for each rendered cell. Can be used to render custom cell icons each with corresponding action
  * @param Object column - The column of the rendered cell
  * @param Object row - The row of the rendered cell
+ * @param number rowIdx - The row index of the rendered cell
  * @return Array 
  * */
-function getCellActions(column, row) {
+function getCellActions(column, row, rowIdx) {
 ```
-The function is called by react data grid for each cell with a column and row object, you can then create any condition you deem fit and return an array of objects to be rendered
+The function is called by react data grid for each cell with a column object, row object and rowIdx number, you can then create any condition you deem fit and return an array of objects to be rendered
 
 `[{actionIcon, actionCallback}]` will render an action button
 

--- a/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
+++ b/packages/react-data-grid-examples/src/scripts/example27-cell-actions.js
@@ -130,7 +130,7 @@ class Example extends React.Component {
     return this.getRows().length;
   };
 
-  getCellActions(column, row) {
+  getCellActions(column, row, rowIdx) {
     if (column.key === 'county' && row.id === 'id_0') {
       return [
         {

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -276,9 +276,9 @@ class Cell extends React.PureComponent {
   };
 
   getCellActions() {
-    const { cellMetaData, column, rowData } = this.props;
+    const { cellMetaData, column, rowData, rowIdx } = this.props;
     if (cellMetaData && cellMetaData.getCellActions) {
-      const cellActionButtons = cellMetaData.getCellActions(column, rowData);
+      const cellActionButtons = cellMetaData.getCellActions(column, rowData, rowIdx);
       if (cellActionButtons && cellActionButtons.length) {
         return cellActionButtons.map((action, index) => {
           return <CellAction key={index} action={action} isFirst={index === 0} />;


### PR DESCRIPTION
## Description
- Add `rowIdx` arg to `getCellActions` function
- Update readme

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently, cell actions do not know the `rowIdx`.


**What is the new behavior?**
Cell actions will have access to `rowIdx` prop.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
