### PR TITLE
Make TS support ES2019, and iterators

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "style-loader": "^0.23.1",
     "terser-webpack-plugin": "^1.2.3",
     "ts-jest": "^24.0.1",
-    "typescript": "^3.4.1",
+    "typescript": "~3.4.5",
     "webpack": "^4.29.6",
     "webpack-dev-server": "^3.2.1"
   }

--- a/packages/react-data-grid-addons/src/data/__tests__/Selectors.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/Selectors.spec.js
@@ -34,13 +34,6 @@ function executeSpyTests(fn) {
       const expectedComputations = fn(options);
       expect(filterSpy.mock.calls.length).toBe(expectedComputations);
     });
-
-    it('should have filterTerm in every filter object', () => {
-      const filters = options.filters;
-      for (const filter of filters) {
-        expect(filter.filterTerm).toBeDefined();
-      }
-    });
   });
 
   describe('When filters are undefined', () => {

--- a/packages/react-data-grid/src/ColumnMetrics.ts
+++ b/packages/react-data-grid/src/ColumnMetrics.ts
@@ -109,8 +109,7 @@ function compareEachColumn(prevColumns: Column[], nextColumns: Column[], isSameC
 
   if (keys.size > prevColumnsMap.size) return false;
 
-  // We shouldn't need Array.from(), but TS complains
-  for (const key of Array.from(keys)) {
+  for (const key of keys) {
     if (!prevColumnsMap.has(key) || !nextColumnsMap.has(key)) return false;
     const prevColumn = prevColumnsMap.get(key)!;
     const nextColumn = nextColumnsMap.get(key)!;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "downlevelIteration": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "inlineSources": true,
     "jsx": "react",
-    "lib": ["es7", "es6", "dom", "dom.iterable"],
+    "lib": ["es2019", "dom", "dom.iterable"],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitReturns": true,


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/compiler-options.html
- `lib`:
  - core-js 3 with a `core-js/stable` import supports polyfills up to ES2019, so it should be safe to allow all es features up to ES2019.
  - VS Code and the documentation above say that TS does not support `es2019` in the `lib` setting, but that's not true:
    - https://github.com/Microsoft/TypeScript/tree/v3.4.5/src/lib
    - https://github.com/Microsoft/TypeScript/blob/v3.4.5/src/lib/es2019.d.ts
  - the `es2019` lib imports the `es2018` lib, which imports the `es2017` lib, and so on, so we don't need to specify them all.
  - We can now use `promise.finally`, `padStart`, `trimStart`, and so on and TS will type those as they should be.
- `downlevelIteration`:
  - This allows us to iterate on non-array-like data structures.
  - The downside is that the transpiled code will most likely incur a performance penalty, to some extent, so I'm not sure if it's worth it until we drop support for IE11.

Example from `ColumnMetrics.ts`:
```ts
function setColumnWidths(columns: Column[], totalWidth: number): void {
  for (const column of columns) {
    if (typeof column.width === 'string' && /^\d+%$/.test(column.width)) {
      column.width = Math.floor(totalWidth * column.width / 100);
    }
  }
}
```

Without `downlevelIteration`:
```js
function setColumnWidths(columns, totalWidth) {
    for (var _i = 0, columns_1 = columns; _i < columns_1.length; _i++) {
        var column = columns_1[_i];
        if (typeof column.width === 'string' && /^\d+%$/.test(column.width)) {
            column.width = Math.floor(totalWidth * column.width / 100);
        }
    }
}
```

With `downlevelIteration`:
```js
import * as tslib_1 from "tslib";
// ...
function setColumnWidths(columns, totalWidth) {
    var e_1, _a;
    try {
        for (var columns_1 = tslib_1.__values(columns), columns_1_1 = columns_1.next(); !columns_1_1.done; columns_1_1 = columns_1.next()) {
            var column = columns_1_1.value;
            if (typeof column.width === 'string' && /^\d+%$/.test(column.width)) {
                column.width = Math.floor(totalWidth * column.width / 100);
            }
        }
    }
    catch (e_1_1) { e_1 = { error: e_1_1 }; }
    finally {
        try {
            if (columns_1_1 && !columns_1_1.done && (_a = columns_1.return)) _a.call(columns_1);
        }
        finally { if (e_1) throw e_1.error; }
    }
}
```