### PR TITLE
Remove support for react-grid-Row--{even,odd}

### DIFF
--- a/packages/react-data-grid/src/Row.tsx
+++ b/packages/react-data-grid/src/Row.tsx
@@ -120,7 +120,6 @@ export default class Row extends React.Component<RowRendererProps> implements Ro
   render() {
     const className = classNames(
       'react-grid-Row',
-      `react-grid-Row--${this.props.idx % 2 === 0 ? 'even' : 'odd'}`,
       { 'row-selected': this.props.isSelected },
       this.props.extraClasses,
       { 'rdg-scrolling': this.props.isScrolling }


### PR DESCRIPTION
Users can style even/odd rows using proper CSS selectors.