### PR TITLE
Update Migration and Contribution links in README, and typo in overscan docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 
 Migrations
 --------
-If you intend to do a major release update for you react-data-grid check [the migration documents](migrations).
+If you intend to do a major release update for you react-data-grid check [the migration documents](docs/migrations).
   
 Features
 --------
@@ -86,7 +86,7 @@ and workflows are to create.
 Contributing
 ------------
 
-Please see [CONTRIBUTING](CONTRIBUTING.md)
+Please see [CONTRIBUTING](docs/CONTRIBUTING.md)
 
 Credits 
 ------------

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -17,8 +17,8 @@ The most important props that the Viewport passes to the Canvas are the followin
 - rowVisibleEndIdx - The index of the last visible row to be rendered to the canvas.
 - colVisibleStartIdx - The index of the first visible column to be rendered to the canvas.
 - colVisibleEndIdx - The index of the last visible column to be rendered to the canvas.
-- colOverscanStartIdx - The index of the first visible column to be rendered to the canvas.
-- colOverscanEndIdx - The index of the last visible column to be rendered to the canvas.
+- colOverscanStartIdx - The index of the first invisible column to be rendered to the canvas.
+- colOverscanEndIdx - The index of the last invisible column to be rendered to the canvas.
 
 ### Virtualization when scrolliing
 When the grid is being scrolled, it is important that only the minimal necessary amount of rows and columns are rendered to the canvas. One way that ReactDataGrid optimises this range, is using the scroll direction. See the diagrams below for an example of how the rendered rows are calculated on scrolling


### PR DESCRIPTION
Migration and Contribution links were not pointing to the right spots.
there were a couple typos in the overscan implementation docs

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: Doc change
```

**What is the current behavior?** (You can also link to an open issue here)
broken link, typos


**What is the new behavior?**
fixed link and typos


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
