### PR TITLE
Use row overscan prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 
 Migrations
 --------
-If you intend to do a major release update for you react-data-grid check [the migration documents](migrations).
+If you intend to do a major release update for you react-data-grid check [the migration documents](docs/migrations).
   
 Features
 --------
@@ -86,7 +86,7 @@ and workflows are to create.
 Contributing
 ------------
 
-Please see [CONTRIBUTING](CONTRIBUTING.md)
+Please see [CONTRIBUTING](docs/CONTRIBUTING.md)
 
 Credits 
 ------------

--- a/packages/react-data-grid-examples/src/docs/markdowns/ReactDataGrid.md
+++ b/packages/react-data-grid-examples/src/docs/markdowns/ReactDataGrid.md
@@ -159,10 +159,10 @@ type: `func`
 
 type: `object`
 defaultValue: `{
-  colsStart: 5,
-  colsEnd: 5,
-  rowsStart: 5,
-  rowsEnd: 5
+  colsStart: 2,
+  colsEnd: 2,
+  rowsStart: 2,
+  rowsEnd: 2
 }`
 
 

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -153,6 +153,8 @@ class ReactDataGrid extends React.Component {
     }),
     /** Function called whenever a cell has been expanded */
     onCellExpand: PropTypes.func,
+    /** Object used to configure overscan indices */
+    overScan: PropTypes.object,
     /** Enables drag and drop on the grid */
     enableDragAndDrop: PropTypes.bool,
     onRowExpandToggle: PropTypes.func,

--- a/packages/react-data-grid/src/Viewport.js
+++ b/packages/react-data-grid/src/Viewport.js
@@ -53,6 +53,7 @@ class Viewport extends React.Component {
     contextMenu: PropTypes.element,
     getSubRowDetails: PropTypes.func,
     rowGroupRenderer: PropTypes.func,
+    overScan: PropTypes.object,
     enableCellSelect: PropTypes.bool.isRequired,
     enableCellAutoFocus: PropTypes.bool.isRequired,
     cellNavigationMode: PropTypes.string.isRequired,
@@ -115,8 +116,8 @@ class Viewport extends React.Component {
     const { columns } = this.props.columnMetrics;
     const scrollDirection = getScrollDirection(this.state, scrollTop, scrollLeft);
     const { rowVisibleStartIdx, rowVisibleEndIdx } = getVisibleBoundaries(height, rowHeight, scrollTop, rowsCount);
-    const rowOverscanStartIdx = getRowOverscanStartIdx(scrollDirection, rowVisibleStartIdx);
-    const rowOverscanEndIdx = getRowOverscanEndIdx(scrollDirection, rowVisibleEndIdx, rowsCount);
+    const rowOverscanStartIdx = getRowOverscanStartIdx(scrollDirection, rowVisibleStartIdx, this.props.overScan);
+    const rowOverscanEndIdx = getRowOverscanEndIdx(scrollDirection, rowVisibleEndIdx, rowsCount, this.props.overScan);
     const totalNumberColumns = getSize(columns);
     const lastFrozenColumnIndex = findLastFrozenColumnIndex(columns);
     const nonFrozenColVisibleStartIdx = getNonFrozenVisibleColStartIdx(columns, scrollLeft);

--- a/packages/react-data-grid/src/__tests__/Viewport.spec.js
+++ b/packages/react-data-grid/src/__tests__/Viewport.spec.js
@@ -92,7 +92,7 @@ describe('<Viewport />', () => {
       colOverscanStartIdx: 0,
       colVisibleEndIdx: helpers.columns.length,
       colVisibleStartIdx: 0,
-      rowOverscanEndIdx: 23,
+      rowOverscanEndIdx: 26,
       rowOverscanStartIdx: 6,
       height: viewportProps.minHeight,
       scrollLeft: scrollLeft,

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.js
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.js
@@ -1,4 +1,4 @@
-import { getGridState, getNonFrozenRenderedColumnCount, getVisibleBoundaries, getNonFrozenVisibleColStartIdx, getScrollDirection, SCROLL_DIRECTION, getRowOverscanStartIdx, getRowOverscanEndIdx, OVERSCAN_ROWS, getColOverscanStartIdx, getColOverscanEndIdx } from '../viewportUtils';
+import { getGridState, getNonFrozenRenderedColumnCount, getVisibleBoundaries, getNonFrozenVisibleColStartIdx, getScrollDirection, SCROLL_DIRECTION, getRowOverscanStartIdx, getRowOverscanEndIdx, getColOverscanStartIdx, getColOverscanEndIdx } from '../viewportUtils';
 
 describe('viewportUtils', () => {
   const getColumns = () => [{ width: 100, left: 0 }, { width: 100, left: 200 }, { width: 100, left: 300 }, { width: 100, left: 400 }, { width: 100, left: 500 }, { width: 100, left: 600 }];
@@ -14,7 +14,13 @@ describe('viewportUtils', () => {
         minHeight: 100,
         rowOffsetHeight: 5,
         rowHeight: 20,
-        rowsCount: 100
+        rowsCount: 100,
+        overScan: {
+          colsStart: 5,
+          colsEnd: 5,
+          rowsStart: 5,
+          rowsEnd: 5
+        },
       }, propsOverrides);
       const state = getGridState(props);
 
@@ -243,48 +249,60 @@ describe('viewportUtils', () => {
 
     describe('getRowOverscanStartIdx', () => {
       const rowVisibleStartIdx = 2;
-      it('should return rowVisibleStartIdx - OVERSCAN_ROWS if scroll direction is upwards', () => {
-        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.UP, rowVisibleStartIdx)).toBe(rowVisibleStartIdx - OVERSCAN_ROWS);
+      const overScan = {
+        colsStart: 5,
+        colsEnd: 5,
+        rowsStart: 5,
+        rowsEnd: 5
+      }
+      it('should return rowVisibleStartIdx - overScan.rowsStart (unless less than zero) if scroll direction is upwards', () => {
+        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.UP, rowVisibleStartIdx, overScan)).toBe(Math.max(0, rowVisibleStartIdx - overScan.rowsStart));
       });
 
       it('should return rowVisibleStartIdx if scroll direction is left', () => {
-        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.LEFT, rowVisibleStartIdx)).toBe(rowVisibleStartIdx);
+        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.LEFT, rowVisibleStartIdx, overScan)).toBe(rowVisibleStartIdx);
       });
 
       it('should return rowVisibleStartIdx if scroll direction is right', () => {
-        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.RIGHT, rowVisibleStartIdx)).toBe(rowVisibleStartIdx);
+        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.RIGHT, rowVisibleStartIdx, overScan)).toBe(rowVisibleStartIdx);
       });
 
       it('should return rowVisibleStartIdx if scroll direction is downwards', () => {
-        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.DOWN, rowVisibleStartIdx)).toBe(rowVisibleStartIdx);
+        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.DOWN, rowVisibleStartIdx, overScan)).toBe(rowVisibleStartIdx);
       });
 
       it('should return 0 if rowVisibleStartIdx negative', () => {
-        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.DOWN, -1)).toBe(0);
+        expect(getRowOverscanStartIdx(SCROLL_DIRECTION.DOWN, -1, overScan)).toBe(0);
       });
     });
 
     describe('getRowOverscanEndIdx', () => {
       const rowVisibleEndIdx = 20;
       const totalNumberOfRows = 30;
-      it('should return rowVisibleStartIdx + OVERSCAN_ROWS if scroll direction is downward', () => {
-        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.DOWN, rowVisibleEndIdx, totalNumberOfRows)).toBe(rowVisibleEndIdx + OVERSCAN_ROWS);
+      const overScan = {
+        colsStart: 5,
+        colsEnd: 5,
+        rowsStart: 5,
+        rowsEnd: 5
+      }
+      it('should return rowVisibleStartIdx + overScan.rowsEnd (unless greater than totalNumberOfRows), if scroll direction is downward', () => {
+        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.DOWN, rowVisibleEndIdx, totalNumberOfRows, overScan)).toBe(Math.min(totalNumberOfRows, rowVisibleEndIdx + overScan.rowsEnd));
       });
 
       it('should return totalNumberOfRows if scroll direction is downward and rowVisibleEndIdx == totalNumberRows', () => {
-        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.DOWN, totalNumberOfRows, totalNumberOfRows)).toBe(totalNumberOfRows);
+        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.DOWN, totalNumberOfRows, totalNumberOfRows, overScan)).toBe(totalNumberOfRows);
       });
 
       it('should return rowVisibleEndIdx if scroll direction is left', () => {
-        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.LEFT, rowVisibleEndIdx, totalNumberOfRows)).toBe(rowVisibleEndIdx);
+        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.LEFT, rowVisibleEndIdx, totalNumberOfRows, overScan)).toBe(rowVisibleEndIdx);
       });
 
       it('should return rowVisibleEndIdx if scroll direction is right', () => {
-        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.RIGHT, rowVisibleEndIdx, totalNumberOfRows)).toBe(rowVisibleEndIdx);
+        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.RIGHT, rowVisibleEndIdx, totalNumberOfRows, overScan)).toBe(rowVisibleEndIdx);
       });
 
       it('should return rowVisibleEndIdx if scroll direction is upwards', () => {
-        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.UP, rowVisibleEndIdx, totalNumberOfRows)).toBe(rowVisibleEndIdx);
+        expect(getRowOverscanEndIdx(SCROLL_DIRECTION.UP, rowVisibleEndIdx, totalNumberOfRows, overScan)).toBe(rowVisibleEndIdx);
       });
     });
 

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.js
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.js
@@ -20,7 +20,7 @@ describe('viewportUtils', () => {
           colsEnd: 5,
           rowsStart: 5,
           rowsEnd: 5
-        },
+        }
       }, propsOverrides);
       const state = getGridState(props);
 
@@ -254,7 +254,7 @@ describe('viewportUtils', () => {
         colsEnd: 5,
         rowsStart: 5,
         rowsEnd: 5
-      }
+      };
       it('should return rowVisibleStartIdx - overScan.rowsStart (unless less than zero) if scroll direction is upwards', () => {
         expect(getRowOverscanStartIdx(SCROLL_DIRECTION.UP, rowVisibleStartIdx, overScan)).toBe(Math.max(0, rowVisibleStartIdx - overScan.rowsStart));
       });
@@ -284,7 +284,7 @@ describe('viewportUtils', () => {
         colsEnd: 5,
         rowsStart: 5,
         rowsEnd: 5
-      }
+      };
       it('should return rowVisibleStartIdx + overScan.rowsEnd (unless greater than totalNumberOfRows), if scroll direction is downward', () => {
         expect(getRowOverscanEndIdx(SCROLL_DIRECTION.DOWN, rowVisibleEndIdx, totalNumberOfRows, overScan)).toBe(Math.min(totalNumberOfRows, rowVisibleEndIdx + overScan.rowsEnd));
       });

--- a/packages/react-data-grid/src/utils/viewportUtils.js
+++ b/packages/react-data-grid/src/utils/viewportUtils.js
@@ -1,7 +1,5 @@
 import { getSize, getColumn, isFrozen } from '../ColumnUtils';
 
-export const OVERSCAN_ROWS = 2;
-
 export const SCROLL_DIRECTION = {
   UP: 'upwards',
   DOWN: 'downwards',
@@ -113,12 +111,13 @@ export const getScrollDirection = (lastScroll, scrollTop, scrollLeft) => {
   return SCROLL_DIRECTION.NONE;
 };
 
-export const getRowOverscanStartIdx = (scrollDirection, rowVisibleStartIdx) => {
-  return scrollDirection === SCROLL_DIRECTION.UP ? max(0, rowVisibleStartIdx - OVERSCAN_ROWS) : max(0, rowVisibleStartIdx);
+export const getRowOverscanStartIdx = (scrollDirection, rowVisibleStartIdx, overScan) => {
+  const overscanBoundaryIdx = rowVisibleStartIdx - overScan.rowsStart;
+  return scrollDirection === SCROLL_DIRECTION.UP ? max(0, overscanBoundaryIdx) : max(0, rowVisibleStartIdx);
 };
 
-export const getRowOverscanEndIdx = (scrollDirection, rowVisibleEndIdx, rowsCount) => {
-  const overscanBoundaryIdx = rowVisibleEndIdx + OVERSCAN_ROWS;
+export const getRowOverscanEndIdx = (scrollDirection, rowVisibleEndIdx, rowsCount, overScan) => {
+  const overscanBoundaryIdx = rowVisibleEndIdx + overScan.rowsEnd;
   return scrollDirection === SCROLL_DIRECTION.DOWN ? min(overscanBoundaryIdx, rowsCount) : rowVisibleEndIdx;
 };
 


### PR DESCRIPTION
## Description
Fixes #1683 
The overscan prop is now used for row rendering.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#1683 

**What is the new behavior?**
The overscan prop is now used for row rendering.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
