### PR TITLE
fix resizing of draggable header cell

### DIFF
--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import Column from 'common/prop-shapes/Column';
 import { isFrozen } from './ColumnUtils';
 import { HeaderRowType } from 'common/constants';
-const ResizeHandle   = require('./ResizeHandle');
+const ResizeHandle = require('./ResizeHandle');
 
 require('../../../themes/react-data-grid-header.css');
 
@@ -59,7 +59,9 @@ class HeaderCell extends React.Component {
 
   getWidthFromMouseEvent = (e) => {
     const right = e.pageX || (e.touches && e.touches[0] && e.touches[0].pageX) || (e.changedTouches && e.changedTouches[e.changedTouches.length - 1].pageX);
-    const left = ReactDOM.findDOMNode(this).getBoundingClientRect().left;
+    // if headerDom is a draggable div, the first element (which is the only element as well) is the actual column header div with the position info
+    const headerDom = ReactDOM.findDOMNode(this);
+    const left = headerDom.draggable ? headerDom.firstChild.getBoundingClientRect().left : headerDom.getBoundingClientRect().left;
     return right - left;
   };
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
While resizing draggable header cell, it computes the left position incorrectly


**What is the new behavior?**
While resizing draggable header cell, it computes the left position correctly


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
It's separated from https://github.com/adazzle/react-data-grid/pull/1449 we need to merge as soon as possible :) 