### PR TITLE
Updated docs with rowGroupRenderer's correct on line description

### DIFF
--- a/docs/ReactDataGrid.md
+++ b/docs/ReactDataGrid.md
@@ -373,7 +373,7 @@ Component to render row actions cell when present
 
 ### `rowGroupRenderer`
 
-Function called whenever keyboard key is pressed down
+Component to override the default rendering for the row groups
 
 **type:** func  
 


### PR DESCRIPTION
## Description
Documentation update. Updated README.md with `rowGroupRenderer`'s correct one line description.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Documentation fix.
```

**What is the current behavior?** (You can also link to an open issue here)
One line description for `rowGroupRenderer`: 
`Function called whenever keyboard key is pressed down`.



**What is the new behavior?**
New one line description for `rowGroupRenderer`: 
`Component to override the default rendering for the row groups`.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
