### PR TITLE
In case of some older browsers, this may fire after the editor ref ha…

### DIFF
--- a/packages/common/editors/EditorContainer.js
+++ b/packages/common/editors/EditorContainer.js
@@ -231,7 +231,9 @@ class EditorContainer extends React.Component {
   commit = (args) => {
     const { onCommit } = this.props;
     const opts = args || {};
-    const updated = this.getEditor().getValue();
+    const editor = this.getEditor();
+    if (!editor) { return; }
+    const updated = editor.getValue();
     if (this.isNewValueValid(updated)) {
       this.changeCommitted = true;
       const cellKey = this.props.column.key;


### PR DESCRIPTION
This fixes (on the surface): https://github.com/adazzle/react-data-grid/issues/1738. Just a couple of additional checks. No substantive changes.

## Description
A few sentences describing the overall goals of the pull request's commits.
Ensure that there is an editor present before attempting to commit. On IE11 and other older browsers, there may be issues with releasing the listeners in `<ClickOutside />` which will then trigger a commit. In my situation, `this.commit()` is triggered from the `<ClickOutside />` handler after `this.editor` (internal ref) has already been disposed.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/adazzle/react-data-grid/issues/1738


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
