### PR TITLE
fix: isSelectedCellEditable row getter idx

### DIFF
--- a/packages/react-data-grid/src/utils/SelectedCellUtils.ts
+++ b/packages/react-data-grid/src/utils/SelectedCellUtils.ts
@@ -75,7 +75,7 @@ interface isSelectedCellEditableOpts<R> {
 
 export function isSelectedCellEditable<R>({ enableCellSelect, selectedPosition, columns, rowGetter, onCheckCellIsEditable }: isSelectedCellEditableOpts<R>): boolean {
   const column = columns[selectedPosition.idx];
-  const row = rowGetter(selectedPosition.idx);
+  const row = rowGetter(selectedPosition.rowIdx);
   const isCellEditable = onCheckCellIsEditable ? onCheckCellIsEditable({ row, column, ...selectedPosition }) : true;
   return isCellEditable && canEdit<R>(column, row, enableCellSelect);
 }


### PR DESCRIPTION
use `selectedPosition.rowIdx` rather than `selectedPosition.idx`