### PR TITLE
jm - allow resizing of grid select column

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.spec.js
@@ -284,6 +284,7 @@ describe('Grid', () => {
         rowSelection: {
           enableShiftSelect: true,
           selectBy: { isSelectedKey: 'isSelected' },
+          resizable: true,
           onRowsSelected(selectedRows) {
             _selectedRows = selectedRows;
           },
@@ -312,6 +313,11 @@ describe('Grid', () => {
     it('should set lastRowIdxUiSelected state', () => {
       selectRowCol.onCellChange(1, '', rows[1], buildFakeEvent());
       expect(wrapper.instance().state.lastRowIdxUiSelected).toEqual(1);
+    });
+
+    it('should pass selectColumnProps resizable to the select column', () => {
+      expect(selectRowCol.key).toEqual('select-row');
+      expect(selectRowCol.resizable).toBe(true);
     });
 
     it('should select range when shift selecting below selected row', () => {

--- a/packages/react-data-grid/src/ReactDataGrid.tsx
+++ b/packages/react-data-grid/src/ReactDataGrid.tsx
@@ -84,6 +84,8 @@ export interface DataGridProps<R extends {}> {
     showCheckbox?: boolean;
     /** Method by which rows should be selected */
     selectBy: RowSelection;
+    /** toggle whether to allow resizing of checkbox column to select rows */
+    resizable?: boolean;
   };
   /** Custom checkbox formatter */
   rowActionsCell?: React.ComponentType<CheckboxEditorProps<R>>;
@@ -622,6 +624,7 @@ export default class ReactDataGrid<R extends {}> extends React.Component<DataGri
         filterable: false,
         headerRenderer,
         width: 60,
+        resizable: !!this.props.rowSelection && this.props.rowSelection.resizable !== false,
         frozen: true,
         getRowMetaData: (rowData: R) => rowData,
         cellClass: this.props.rowActionsCell ? 'rdg-row-actions-cell' : ''


### PR DESCRIPTION
## Description
Allow resizable select column with rowSelection props.


**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Cannot resize checkbox column for row selection


**What is the new behavior?**
Can pass `resizable` in `rowSelection` prop to allow resizing


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
