### PR TITLE
Delete rowUtils

### DIFF
--- a/packages/react-data-grid/src/Row.tsx
+++ b/packages/react-data-grid/src/Row.tsx
@@ -4,7 +4,6 @@ import shallowEqual from 'shallowequal';
 
 import Cell from './Cell';
 import { isFrozen } from './utils/columnUtils';
-import * as rowUtils from './utils/rowUtils';
 import { RowRenderer, RowRendererProps, CellRenderer, CellRendererProps, CalculatedColumn } from './common/types';
 
 export default class Row<R> extends React.Component<RowRendererProps<R>> implements RowRenderer<R> {
@@ -92,7 +91,7 @@ export default class Row<R> extends React.Component<RowRendererProps<R>> impleme
       return isRowSelected;
     }
 
-    return rowUtils.get(row, key);
+    return row[key];
   }
 
   getExpandableOptions(columnKey: keyof R) {

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -68,7 +68,6 @@ export interface ColumnMetrics<TRow> {
 
 export interface RowData {
   name?: string;
-  get?(key: PropertyKey): unknown;
   __metaData?: RowGroupMetaData;
 }
 

--- a/packages/react-data-grid/src/utils/rowUtils.ts
+++ b/packages/react-data-grid/src/utils/rowUtils.ts
@@ -1,9 +1,0 @@
-import { RowData } from '../common/types';
-
-export function get<R>(row: R, property: keyof R) {
-  if (typeof (row as RowData).get === 'function') {
-    return (row as RowData).get!(property) as R[typeof property];
-  }
-
-  return row[property];
-}

--- a/packages/react-data-grid/src/utils/selectedCellUtils.ts
+++ b/packages/react-data-grid/src/utils/selectedCellUtils.ts
@@ -1,5 +1,4 @@
 import { CellNavigationMode, Z_INDEXES } from '../common/enums';
-import * as rowUtils from './rowUtils';
 import { isFrozen, canEdit } from './columnUtils';
 import { CalculatedColumn, Position, Range, Dimension, RowGetter } from '../common/types';
 
@@ -62,7 +61,7 @@ export function getSelectedCellValue<R>({ selectedPosition, columns, rowGetter }
   const column = columns[selectedPosition.idx];
   const row = rowGetter(selectedPosition.rowIdx);
 
-  return row && column ? rowUtils.get(row, column.key) : null;
+  return row && column ? row[column.key] : null;
 }
 
 interface isSelectedCellEditableOpts<R> {


### PR DESCRIPTION
I think the intent with `rowUtils` was to support `ImmutableJS`. We are going to remove `ImmutableJS` so I believe this can be deleted