### PR TITLE
Remove overscanRowCount, overscanColumnCount, SCROLL_DIRECTION

### DIFF
--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -5,10 +5,10 @@ import Row from './Row';
 import RowGroup from './RowGroup';
 import InteractionMasks from './masks/InteractionMasks';
 import { getColumnScrollPosition, isPositionStickySupported, getScrollbarSize } from './utils';
-import { EventTypes, SCROLL_DIRECTION } from './common/enums';
-import { CalculatedColumn, Position, ScrollState, SubRowDetails, RowRenderer, RowRendererProps, RowData } from './common/types';
+import { EventTypes } from './common/enums';
+import { CalculatedColumn, Position, ScrollPosition, SubRowDetails, RowRenderer, RowRendererProps, RowData } from './common/types';
 import { GridProps } from './Grid';
-import { getScrollDirection, getVerticalRangeToRender, getHorizontalRangeToRender } from './utils/viewportUtils';
+import { getVerticalRangeToRender, getHorizontalRangeToRender } from './utils/viewportUtils';
 
 type SharedGridProps<R> = Pick<GridProps<R>,
 | 'rowKey'
@@ -31,15 +31,13 @@ type SharedGridProps<R> = Pick<GridProps<R>,
 | 'RowsContainer'
 | 'editorPortalTarget'
 | 'interactionMasksMetaData'
-| 'overscanRowCount'
-| 'overscanColumnCount'
 | 'onCanvasKeydown'
 | 'onCanvasKeyup'
 >;
 
 export interface CanvasProps<R> extends SharedGridProps<R> {
   height: number;
-  onScroll(position: ScrollState): void;
+  onScroll(position: ScrollPosition): void;
 }
 
 interface RendererProps<R> extends Pick<CanvasProps<R>, 'cellMetaData' | 'onRowSelectionChange'> {
@@ -73,8 +71,6 @@ export default function Canvas<R>({
   onCanvasKeyup,
   onRowSelectionChange,
   onScroll,
-  overscanColumnCount,
-  overscanRowCount,
   rowGetter,
   rowGroupRenderer,
   rowHeight,
@@ -87,7 +83,6 @@ export default function Canvas<R>({
 }: CanvasProps<R>) {
   const [scrollTop, setScrollTop] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
-  const [scrollDirection, setScrollDirection] = useState(SCROLL_DIRECTION.NONE);
   const canvas = useRef<HTMLDivElement>(null);
   const interactionMasks = useRef<InteractionMasks<R>>(null);
   const prevScrollToRowIndex = useRef<number | undefined>();
@@ -99,20 +94,16 @@ export default function Canvas<R>({
       height: clientHeight,
       rowHeight,
       scrollTop,
-      rowsCount,
-      scrollDirection,
-      overscanRowCount
+      rowsCount
     });
-  }, [clientHeight, overscanRowCount, rowHeight, rowsCount, scrollDirection, scrollTop]);
+  }, [clientHeight, rowHeight, rowsCount, scrollTop]);
 
   const { colOverscanStartIdx, colOverscanEndIdx, colVisibleStartIdx, colVisibleEndIdx } = useMemo(() => {
     return getHorizontalRangeToRender({
       columnMetrics,
-      scrollLeft,
-      scrollDirection,
-      overscanColumnCount
+      scrollLeft
     });
-  }, [columnMetrics, overscanColumnCount, scrollDirection, scrollLeft]);
+  }, [columnMetrics, scrollLeft]);
 
   useEffect(() => {
     return eventBus.subscribe(EventTypes.SCROLL_TO_COLUMN, idx => scrollToColumn(idx, columnMetrics.columns));
@@ -132,14 +123,9 @@ export default function Canvas<R>({
     // Freeze columns on legacy browsers
     setComponentsScrollLeft(newScrollLeft);
 
-    const scrollDirection = getScrollDirection(
-      { scrollLeft, scrollTop },
-      { scrollLeft: newScrollLeft, scrollTop: newScrollTop }
-    );
     setScrollLeft(newScrollLeft);
     setScrollTop(newScrollTop);
-    setScrollDirection(scrollDirection);
-    onScroll({ scrollLeft: newScrollLeft, scrollTop: newScrollTop, scrollDirection });
+    onScroll({ scrollLeft: newScrollLeft, scrollTop: newScrollTop });
   }
 
   function getClientHeight() {

--- a/packages/react-data-grid/src/Grid.tsx
+++ b/packages/react-data-grid/src/Grid.tsx
@@ -3,7 +3,7 @@ import { isValidElementType } from 'react-is';
 
 import Header, { HeaderHandle, HeaderProps } from './Header';
 import Canvas from './Canvas';
-import { HeaderRowData, CellMetaData, InteractionMasksMetaData, ColumnMetrics, ScrollState } from './common/types';
+import { HeaderRowData, CellMetaData, InteractionMasksMetaData, ColumnMetrics, ScrollPosition } from './common/types';
 import { DEFINE_SORT } from './common/enums';
 import { ReactDataGridProps } from './ReactDataGrid';
 import EventBus from './EventBus';
@@ -22,8 +22,6 @@ type SharedDataGridProps<R> = Pick<ReactDataGridProps<R>,
 | 'emptyRowsView'
 | 'onHeaderDrop'
 | 'getSubRowDetails'
-| 'overscanRowCount'
-| 'overscanColumnCount'
 | 'selectedRows'
 | 'onSelectedRowsChange'
 | 'sortColumn'
@@ -66,13 +64,13 @@ export default function Grid<R>({
   const header = useRef<HeaderHandle>(null);
   const scrollLeft = useRef(0);
 
-  function onScroll(scrollState: ScrollState) {
-    if (header.current && scrollLeft.current !== scrollState.scrollLeft) {
-      scrollLeft.current = scrollState.scrollLeft;
-      header.current.setScrollLeft(scrollState.scrollLeft);
+  function onScroll(scrollPosition: ScrollPosition) {
+    if (header.current && scrollLeft.current !== scrollPosition.scrollLeft) {
+      scrollLeft.current = scrollPosition.scrollLeft;
+      header.current.setScrollLeft(scrollPosition.scrollLeft);
     }
     if (props.onScroll) {
-      props.onScroll(scrollState);
+      props.onScroll(scrollPosition);
     }
   }
 
@@ -129,8 +127,6 @@ export default function Grid<R>({
           interactionMasksMetaData={props.interactionMasksMetaData}
           RowsContainer={props.RowsContainer}
           editorPortalTarget={props.editorPortalTarget}
-          overscanRowCount={props.overscanRowCount}
-          overscanColumnCount={props.overscanColumnCount}
           onCanvasKeydown={props.onCanvasKeydown}
           onCanvasKeyup={props.onCanvasKeyup}
         />

--- a/packages/react-data-grid/src/ReactDataGrid.tsx
+++ b/packages/react-data-grid/src/ReactDataGrid.tsx
@@ -32,7 +32,7 @@ import {
   SubRowDetails,
   SubRowOptions,
   RowRendererProps,
-  ScrollState
+  ScrollPosition
 } from './common/types';
 
 export interface ReactDataGridProps<R extends {}> {
@@ -110,7 +110,7 @@ export interface ReactDataGridProps<R extends {}> {
   /** The direction to sort the sortColumn*/
   sortDirection?: DEFINE_SORT;
   /** Called when the grid is scrolled */
-  onScroll?(scrollState: ScrollState): void;
+  onScroll?(scrollPosition: ScrollPosition): void;
   /** Component used to render a draggable header cell */
   draggableHeaderCell?: React.ComponentType<{ column: CalculatedColumn<R>; onHeaderDrop(): void }>;
   getValidFilterValues?(columnKey: keyof R): unknown;
@@ -138,16 +138,6 @@ export interface ReactDataGridProps<R extends {}> {
   onCellDeSelected?(position: Position): void;
   /** called before cell is set active, returns a boolean to determine whether cell is editable */
   onCheckCellIsEditable?(event: CheckCellIsEditableEvent<R>): boolean;
-  /**
-   * The number of rows to render outside of the visible area
-   * Note that overscanning too much can negatively impact performance. By default, grid overscans by two items.
-   */
-  overscanRowCount?: number;
-  /**
-   * The number of columns to render outside of the visible area
-   * Note that overscanning too much can negatively impact performance. By default, grid overscans by two items.
-   */
-  overscanColumnCount?: number;
 }
 
 export interface ReactDataGridHandle {
@@ -435,8 +425,6 @@ const ReactDataGridBase = forwardRef(function ReactDataGrid<R extends {}>({
           getSubRowDetails={props.getSubRowDetails}
           editorPortalTarget={editorPortalTarget}
           interactionMasksMetaData={interactionMasksMetaData}
-          overscanRowCount={props.overscanRowCount}
-          overscanColumnCount={props.overscanColumnCount}
         />
       )}
     </div>

--- a/packages/react-data-grid/src/common/enums.ts
+++ b/packages/react-data-grid/src/common/enums.ts
@@ -41,14 +41,6 @@ export enum UpdateActions {
   CELL_DRAG = 'CELL_DRAG'
 }
 
-export enum SCROLL_DIRECTION {
-  UP = 'upwards',
-  DOWN = 'downwards',
-  LEFT = 'left',
-  RIGHT = 'right',
-  NONE = 'none'
-}
-
 export enum DEFINE_SORT {
   ASC = 'ASC',
   DESC = 'DESC',

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { KeyboardEvent, ReactNode } from 'react';
 import { List } from 'immutable';
-import { HeaderRowType, UpdateActions, SCROLL_DIRECTION } from './enums';
+import { HeaderRowType, UpdateActions } from './enums';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -245,12 +245,6 @@ export interface RowRenderer<TRow> {
   setScrollLeft(scrollLeft: number): void;
   getRowTop?(): number;
   getRowHeight?(): number;
-}
-
-export interface ScrollState {
-  scrollTop: number;
-  scrollLeft: number;
-  scrollDirection: SCROLL_DIRECTION;
 }
 
 export interface ScrollPosition {

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
@@ -1,11 +1,9 @@
 import {
-  getScrollDirection,
   getVerticalRangeToRender,
   VerticalRangeToRenderParams,
   getHorizontalRangeToRender,
   HorizontalRangeToRenderParams
 } from '../viewportUtils';
-import { SCROLL_DIRECTION } from '../../common/enums';
 import { ColumnMetrics } from '../../common/types';
 
 interface Row {
@@ -20,7 +18,6 @@ describe('viewportUtils', () => {
         rowHeight: 50,
         scrollTop: 200,
         rowsCount: 1000,
-        scrollDirection: SCROLL_DIRECTION.DOWN,
         ...overrides
       });
     }
@@ -52,20 +49,6 @@ describe('viewportUtils', () => {
         rowOverscanEndIdx: 4
       });
     });
-
-    it('should use overscanRowCount to calculate the range', () => {
-      expect(getRange({ overscanRowCount: 10 })).toEqual({
-        rowOverscanStartIdx: 2,
-        rowOverscanEndIdx: 24
-      });
-    });
-
-    it('should use scrollDirection to calculate the range', () => {
-      expect(getRange({ overscanRowCount: 10, scrollDirection: SCROLL_DIRECTION.UP })).toEqual({
-        rowOverscanStartIdx: 0,
-        rowOverscanEndIdx: 16
-      });
-    });
   });
 
   describe('getHorizontalRangeToRender', () => {
@@ -85,7 +68,6 @@ describe('viewportUtils', () => {
       return getHorizontalRangeToRender({
         columnMetrics: getColumnMetrics(),
         scrollLeft: 200,
-        scrollDirection: SCROLL_DIRECTION.RIGHT,
         ...overrides
       });
     }
@@ -115,31 +97,12 @@ describe('viewportUtils', () => {
       columnMetrics.viewportWidth = 500;
       expect(getHorizontalRangeToRender({
         columnMetrics,
-        scrollLeft: 200,
-        scrollDirection: SCROLL_DIRECTION.RIGHT
+        scrollLeft: 200
       })).toEqual({
         colVisibleStartIdx: 2,
         colVisibleEndIdx: 7,
         colOverscanStartIdx: 0,
         colOverscanEndIdx: 9
-      });
-    });
-
-    it('should use overscanColumnCount to calculate the range', () => {
-      expect(getRange({ overscanColumnCount: 5 })).toEqual({
-        colVisibleStartIdx: 2,
-        colVisibleEndIdx: 12,
-        colOverscanStartIdx: 0,
-        colOverscanEndIdx: 17
-      });
-    });
-
-    it('should use overscanColumnCount to calculate the range', () => {
-      expect(getRange({ overscanColumnCount: 5, scrollDirection: SCROLL_DIRECTION.LEFT, scrollLeft: 1000 })).toEqual({
-        colVisibleStartIdx: 10,
-        colVisibleEndIdx: 20,
-        colOverscanStartIdx: 5,
-        colOverscanEndIdx: 22
       });
     });
 
@@ -156,29 +119,6 @@ describe('viewportUtils', () => {
         colOverscanStartIdx: 6,
         colOverscanEndIdx: 17
       });
-    });
-  });
-
-  describe('getScrollDirection', () => {
-    const prevScroll = { scrollTop: 100, scrollLeft: 100 };
-    it('should return SCROLL_DIRECTION.DOWN iF previous scrollTop is less than current scrollTop', () => {
-      expect(getScrollDirection(prevScroll, { ...prevScroll, scrollTop: 101 })).toBe(SCROLL_DIRECTION.DOWN);
-    });
-
-    it('should return SCROLL_DIRECTION.UP iF previous scrollTop is greater than current scrollTop', () => {
-      expect(getScrollDirection(prevScroll, { ...prevScroll, scrollTop: 99 })).toBe(SCROLL_DIRECTION.UP);
-    });
-
-    it('should return SCROLL_DIRECTION.RIGHT iF previous scrollLeft is less than current scrollLeft', () => {
-      expect(getScrollDirection(prevScroll, { ...prevScroll, scrollLeft: 101 })).toBe(SCROLL_DIRECTION.RIGHT);
-    });
-
-    it('should return SCROLL_DIRECTION.LEFT iF previous scrollLeft is greater than current scrollLeft', () => {
-      expect(getScrollDirection(prevScroll, { ...prevScroll, scrollLeft: 99 })).toBe(SCROLL_DIRECTION.LEFT);
-    });
-
-    it('should return SCROLL_DIRECTION.NONE if current scroll is equal to previous scroll', () => {
-      expect(getScrollDirection(prevScroll, { ...prevScroll })).toBe(SCROLL_DIRECTION.NONE);
     });
   });
 });

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -1,5 +1,4 @@
-import { SCROLL_DIRECTION } from '../common/enums';
-import { CalculatedColumn, ScrollPosition, ColumnMetrics } from '../common/types';
+import { CalculatedColumn, ColumnMetrics } from '../common/types';
 
 function getTotalFrozenColumnWidth<R>(columns: CalculatedColumn<R>[], lastFrozenColumnIndex: number): number {
   if (lastFrozenColumnIndex === -1) {
@@ -30,8 +29,6 @@ export interface VerticalRangeToRenderParams {
   rowHeight: number;
   scrollTop: number;
   rowsCount: number;
-  scrollDirection: SCROLL_DIRECTION;
-  overscanRowCount?: number;
 }
 
 export interface VerticalRangeToRender {
@@ -43,14 +40,12 @@ export function getVerticalRangeToRender({
   height,
   rowHeight,
   scrollTop,
-  rowsCount,
-  scrollDirection,
-  overscanRowCount = 2
+  rowsCount
 }: VerticalRangeToRenderParams): VerticalRangeToRender {
   const rowVisibleStartIdx = Math.floor(scrollTop / rowHeight);
   const rowVisibleEndIdx = Math.min(rowsCount - 1, Math.floor((scrollTop + height) / rowHeight));
-  const rowOverscanStartIdx = Math.max(0, rowVisibleStartIdx - (scrollDirection === SCROLL_DIRECTION.UP ? overscanRowCount : 2));
-  const rowOverscanEndIdx = Math.min(rowsCount - 1, rowVisibleEndIdx + (scrollDirection === SCROLL_DIRECTION.DOWN ? overscanRowCount : 2));
+  const rowOverscanStartIdx = Math.max(0, rowVisibleStartIdx - 2);
+  const rowOverscanEndIdx = Math.min(rowsCount - 1, rowVisibleEndIdx + 2);
 
   return { rowOverscanStartIdx, rowOverscanEndIdx };
 }
@@ -65,15 +60,11 @@ export interface HorizontalRangeToRender {
 export interface HorizontalRangeToRenderParams<R> {
   columnMetrics: ColumnMetrics<R>;
   scrollLeft: number;
-  scrollDirection: SCROLL_DIRECTION;
-  overscanColumnCount?: number;
 }
 
 export function getHorizontalRangeToRender<R>({
   columnMetrics,
-  scrollLeft,
-  scrollDirection,
-  overscanColumnCount = 2
+  scrollLeft
 }: HorizontalRangeToRenderParams<R>): HorizontalRangeToRender {
   const { columns, totalColumnWidth, lastFrozenColumnIndex } = columnMetrics;
   let { viewportWidth } = columnMetrics;
@@ -97,16 +88,8 @@ export function getHorizontalRangeToRender<R>({
   const availableWidth = viewportWidth - totalFrozenColumnWidth;
   const nonFrozenRenderedColumnCount = getColumnCountForWidth(columns, availableWidth, colVisibleStartIdx);
   const colVisibleEndIdx = Math.min(columns.length, colVisibleStartIdx + nonFrozenRenderedColumnCount);
-  const colOverscanStartIdx = Math.max(0, colVisibleStartIdx - (scrollDirection === SCROLL_DIRECTION.LEFT ? overscanColumnCount : 2));
-  const colOverscanEndIdx = Math.min(columns.length, colVisibleEndIdx + (scrollDirection === SCROLL_DIRECTION.RIGHT ? overscanColumnCount : 2));
+  const colOverscanStartIdx = Math.max(0, colVisibleStartIdx - 2);
+  const colOverscanEndIdx = Math.min(columns.length, colVisibleEndIdx + 2);
 
   return { colVisibleStartIdx, colVisibleEndIdx, colOverscanStartIdx, colOverscanEndIdx };
-}
-
-export function getScrollDirection(prevScroll: ScrollPosition, nextScroll: ScrollPosition): SCROLL_DIRECTION {
-  if (nextScroll.scrollTop > prevScroll.scrollTop) return SCROLL_DIRECTION.DOWN;
-  if (nextScroll.scrollTop < prevScroll.scrollTop) return SCROLL_DIRECTION.UP;
-  if (nextScroll.scrollLeft > prevScroll.scrollLeft) return SCROLL_DIRECTION.RIGHT;
-  if (nextScroll.scrollLeft < prevScroll.scrollLeft) return SCROLL_DIRECTION.LEFT;
-  return SCROLL_DIRECTION.NONE;
 }


### PR DESCRIPTION
I think we had good intentions with it, but I don't think it's an impactful/worthwhile optimization to keep.

Our usage of `scrollDirection` was flawed as well as it's possible to scroll in both vertical and horizontal directions in one scroll event, so we would have to split it into two values.