### PR TITLE
Remove getRowTop/getRowHeight

### DIFF
--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -44,7 +44,7 @@ export interface CanvasProps<R> extends SharedDataGridProps<R> {
 }
 
 interface RendererProps<R> extends Pick<CanvasProps<R>, 'cellMetaData' | 'onRowSelectionChange'> {
-  ref(row: RowRenderer | null): void;
+  ref(row: (RowRenderer & React.Component<RowRendererProps<R>>) | null): void;
   key: number;
   idx: number;
   columns: CalculatedColumn<R>[];
@@ -90,7 +90,7 @@ export default function Canvas<R>({
   const canvas = useRef<HTMLDivElement>(null);
   const interactionMasks = useRef<InteractionMasks<R>>(null);
   const prevScrollToRowIndex = useRef<number | undefined>();
-  const [rows] = useState(() => new Map<number, RowRenderer>());
+  const [rows] = useState(() => new Map<number, RowRenderer & React.Component<RowRendererProps<R>>>());
   const clientHeight = getClientHeight();
 
   const [rowOverscanStartIdx, rowOverscanEndIdx] = getVerticalRangeToRender(

--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -44,7 +44,7 @@ export interface CanvasProps<R> extends SharedDataGridProps<R> {
 }
 
 interface RendererProps<R> extends Pick<CanvasProps<R>, 'cellMetaData' | 'onRowSelectionChange'> {
-  ref(row: (RowRenderer<R> & React.Component<RowRendererProps<R>>) | null): void;
+  ref(row: RowRenderer | null): void;
   key: number;
   idx: number;
   columns: CalculatedColumn<R>[];
@@ -90,7 +90,7 @@ export default function Canvas<R>({
   const canvas = useRef<HTMLDivElement>(null);
   const interactionMasks = useRef<InteractionMasks<R>>(null);
   const prevScrollToRowIndex = useRef<number | undefined>();
-  const [rows] = useState(() => new Map<number, RowRenderer<R> & React.Component<RowRendererProps<R>>>());
+  const [rows] = useState(() => new Map<number, RowRenderer>());
   const clientHeight = getClientHeight();
 
   const { rowOverscanStartIdx, rowOverscanEndIdx } = useMemo(() => {

--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -239,27 +239,6 @@ export default function Canvas<R>({
     });
   }
 
-  function getRowTop(rowIdx: number) {
-    const row = rows.get(rowIdx);
-    if (row && row.getRowTop) {
-      return row.getRowTop();
-    }
-    return rowHeight * rowIdx;
-  }
-
-  function getRowHeight(rowIdx: number) {
-    const row = rows.get(rowIdx);
-    if (row && row.getRowHeight) {
-      return row.getRowHeight();
-    }
-    return rowHeight;
-  }
-
-  function getRowColumns(rowIdx: number) {
-    const row = rows.get(rowIdx);
-    return row && row.props ? row.props.columns : columnMetrics.columns;
-  }
-
   function renderCustomRowRenderer(rowProps: RendererProps<R>) {
     const { ref, ...otherProps } = rowProps;
     const CustomRowRenderer = rowRenderer!;
@@ -325,9 +304,6 @@ export default function Canvas<R>({
         onHitRightBoundary={handleHitColummBoundary}
         scrollLeft={scrollLeft}
         scrollTop={scrollTop}
-        getRowHeight={getRowHeight}
-        getRowTop={getRowTop}
-        getRowColumns={getRowColumns}
         editorPortalTarget={editorPortalTarget}
         {...interactionMasksMetaData}
       />

--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -237,6 +237,11 @@ export default function Canvas<R>({
     });
   }
 
+  function getRowColumns(rowIdx: number) {
+    const row = rows.get(rowIdx);
+    return row && row.props ? row.props.columns : columnMetrics.columns;
+  }
+
   function renderCustomRowRenderer(rowProps: RendererProps<R>) {
     const { ref, ...otherProps } = rowProps;
     const CustomRowRenderer = rowRenderer!;
@@ -302,6 +307,7 @@ export default function Canvas<R>({
         onHitRightBoundary={handleHitColummBoundary}
         scrollLeft={scrollLeft}
         scrollTop={scrollTop}
+        getRowColumns={getRowColumns}
         editorPortalTarget={editorPortalTarget}
         {...interactionMasksMetaData}
       />

--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -93,13 +93,13 @@ export default function Canvas<R>({
   const [rows] = useState(() => new Map<number, RowRenderer>());
   const clientHeight = getClientHeight();
 
-  const [rowOverscanStartIdx, rowOverscanEndIdx] = getVerticalRangeToRender({
-    height: clientHeight,
+  const [rowOverscanStartIdx, rowOverscanEndIdx] = getVerticalRangeToRender(
+    clientHeight,
     rowHeight,
     scrollTop,
     rowsCount,
     renderBatchSize
-  });
+  );
 
   const { colOverscanStartIdx, colOverscanEndIdx, colVisibleStartIdx, colVisibleEndIdx } = useMemo(() => {
     return getHorizontalRangeToRender({

--- a/packages/react-data-grid/src/Canvas.tsx
+++ b/packages/react-data-grid/src/Canvas.tsx
@@ -93,15 +93,13 @@ export default function Canvas<R>({
   const [rows] = useState(() => new Map<number, RowRenderer>());
   const clientHeight = getClientHeight();
 
-  const { rowOverscanStartIdx, rowOverscanEndIdx } = useMemo(() => {
-    return getVerticalRangeToRender({
-      height: clientHeight,
-      rowHeight,
-      scrollTop,
-      rowsCount,
-      renderBatchSize
-    });
-  }, [clientHeight, renderBatchSize, rowHeight, rowsCount, scrollTop]);
+  const [rowOverscanStartIdx, rowOverscanEndIdx] = getVerticalRangeToRender({
+    height: clientHeight,
+    rowHeight,
+    scrollTop,
+    rowsCount,
+    renderBatchSize
+  });
 
   const { colOverscanStartIdx, colOverscanEndIdx, colVisibleStartIdx, colVisibleEndIdx } = useMemo(() => {
     return getHorizontalRangeToRender({

--- a/packages/react-data-grid/src/Row.tsx
+++ b/packages/react-data-grid/src/Row.tsx
@@ -6,7 +6,7 @@ import Cell from './Cell';
 import { isFrozen } from './utils/columnUtils';
 import { RowRenderer, RowRendererProps, CellRenderer, CellRendererProps, CalculatedColumn } from './common/types';
 
-export default class Row<R> extends React.Component<RowRendererProps<R>> implements RowRenderer<R> {
+export default class Row<R> extends React.Component<RowRendererProps<R>> implements RowRenderer {
   static displayName = 'Row';
 
   static defaultProps = {
@@ -52,7 +52,7 @@ export default class Row<R> extends React.Component<RowRendererProps<R>> impleme
       ref: (cell) => cell ? this.cells.set(key, cell) : this.cells.delete(key),
       idx: column.idx,
       rowIdx: idx,
-      height: this.getRowHeight(),
+      height: this.props.height,
       column,
       cellMetaData,
       value: this.getCellValue(key || String(column.idx) as keyof R) as R[keyof R], // FIXME: fix types
@@ -72,16 +72,6 @@ export default class Row<R> extends React.Component<RowRendererProps<R>> impleme
     const frozenColumns = columns.slice(0, lastFrozenColumnIndex + 1);
     const nonFrozenColumn = columns.slice(colOverscanStartIdx, colOverscanEndIdx + 1).filter(c => !isFrozen(c));
     return nonFrozenColumn.concat(frozenColumns).map(c => this.getCell(c));
-  }
-
-  getRowTop(): number {
-    const { current } = this.row;
-    if (!current) return 0;
-    return current.getBoundingClientRect().top - current.parentElement!.getBoundingClientRect().top;
-  }
-
-  getRowHeight(): number {
-    return this.props.height;
   }
 
   getCellValue(key: keyof R) {
@@ -129,7 +119,7 @@ export default class Row<R> extends React.Component<RowRendererProps<R>> impleme
       <div
         ref={this.row}
         className={className}
-        style={{ height: this.getRowHeight() }}
+        style={{ height: this.props.height }}
         onDragEnter={this.handleDragEnter}
         onDragOver={this.handleDragOver}
         onDrop={this.handleDrop}

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -241,10 +241,8 @@ export interface CellRenderer {
   setScrollLeft(scrollLeft: number): void;
 }
 
-export interface RowRenderer<TRow> {
+export interface RowRenderer {
   setScrollLeft(scrollLeft: number): void;
-  getRowTop?(): number;
-  getRowHeight?(): number;
 }
 
 export interface ScrollPosition {

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
@@ -50,6 +50,7 @@ describe('<InteractionMasks/>', () => {
       enableCellAutoFocus: false,
       cellNavigationMode: CellNavigationMode.NONE,
       eventBus: new EventBus(),
+      getRowColumns: () => columns,
       editorPortalTarget: document.body,
       scrollLeft: 0,
       scrollTop: 0,

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
@@ -50,9 +50,6 @@ describe('<InteractionMasks/>', () => {
       enableCellAutoFocus: false,
       cellNavigationMode: CellNavigationMode.NONE,
       eventBus: new EventBus(),
-      getRowColumns: () => columns,
-      getRowHeight: () => 50,
-      getRowTop: () => 0,
       editorPortalTarget: document.body,
       scrollLeft: 0,
       scrollTop: 0,
@@ -124,7 +121,7 @@ describe('<InteractionMasks/>', () => {
           }
         });
         expect(wrapper.find(SelectionMask).length).toBe(1);
-        expect(wrapper.find(SelectionMask).props()).toEqual({ height: 50, left: 0, top: 0, width: 100, zIndex: 1 });
+        expect(wrapper.find(SelectionMask).props()).toEqual({ height: 30, left: 0, top: 0, width: 100, zIndex: 1 });
       });
     });
   });
@@ -712,7 +709,7 @@ describe('<InteractionMasks/>', () => {
     it('should render a CopyMask component when a cell is copied', () => {
       const { wrapper } = setupCopy();
       pressKey(wrapper, 'c', { keyCode: KeyCodes.c, ctrlKey: true });
-      expect(wrapper.find(CopyMask).props()).toEqual({ height: 50, left: 100, top: 0, width: 100, zIndex: 1 });
+      expect(wrapper.find(CopyMask).props()).toEqual({ height: 30, left: 100, top: 60, width: 100, zIndex: 1 });
     });
 
     it('should remove the CopyMask component on escape', () => {

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
@@ -1,6 +1,5 @@
 import {
   getVerticalRangeToRender,
-  VerticalRangeToRenderParams,
   getHorizontalRangeToRender,
   HorizontalRangeToRenderParams
 } from '../viewportUtils';
@@ -10,17 +9,24 @@ interface Row {
   [key: string]: unknown;
 }
 
+interface VerticalRangeToRenderParams {
+  height: number;
+  rowHeight: number;
+  scrollTop: number;
+  rowsCount: number;
+  renderBatchSize: number;
+}
+
 describe('viewportUtils', () => {
   describe('getVerticalRangeToRender', () => {
-    function getRange<K extends keyof VerticalRangeToRenderParams>(overrides: Pick<VerticalRangeToRenderParams, K>) {
-      return getVerticalRangeToRender({
-        height: 500,
-        rowHeight: 50,
-        scrollTop: 200,
-        rowsCount: 1000,
-        renderBatchSize: 8,
-        ...overrides
-      });
+    function getRange({
+      height = 500,
+      rowHeight = 50,
+      scrollTop = 200,
+      rowsCount = 1000,
+      renderBatchSize = 8
+    }: Partial<VerticalRangeToRenderParams>) {
+      return getVerticalRangeToRender(height, rowHeight, scrollTop, rowsCount, renderBatchSize);
     }
 
     it('should use rowHeight to calculate the range', () => {

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
@@ -24,70 +24,40 @@ describe('viewportUtils', () => {
     }
 
     it('should use rowHeight to calculate the range', () => {
-      expect(getRange({ rowHeight: 50 })).toEqual({
-        rowOverscanStartIdx: 0,
-        rowOverscanEndIdx: 24
-      });
+      expect(getRange({ rowHeight: 50 })).toEqual([0, 24]);
     });
 
     it('should use height to calculate the range', () => {
-      expect(getRange({ height: 250 })).toEqual({
-        rowOverscanStartIdx: 0,
-        rowOverscanEndIdx: 16
-      });
+      expect(getRange({ height: 250 })).toEqual([0, 16]);
     });
 
     it('should use scrollTop to calculate the range', () => {
-      expect(getRange({ scrollTop: 500 })).toEqual({
-        rowOverscanStartIdx: 0,
-        rowOverscanEndIdx: 24
-      });
+      expect(getRange({ scrollTop: 500 })).toEqual([0, 24]);
     });
 
     it('should use rowsCount to calculate the range', () => {
-      expect(getRange({ rowsCount: 5, scrollTop: 0 })).toEqual({
-        rowOverscanStartIdx: 0,
-        rowOverscanEndIdx: 4
-      });
+      expect(getRange({ rowsCount: 5, scrollTop: 0 })).toEqual([0, 4]);
     });
 
     it('should use renderBatchSize to calculate the range', () => {
-      expect(getRange({ renderBatchSize: 4, scrollTop: 0 })).toEqual({
-        rowOverscanStartIdx: 0,
-        rowOverscanEndIdx: 16
-      });
-      expect(getRange({ renderBatchSize: 4, scrollTop: 50 * 1000 - 500 /* max scroll top */ })).toEqual({
-        rowOverscanStartIdx: 984,
-        rowOverscanEndIdx: 999
-      });
-      expect(getRange({ renderBatchSize: 4, scrollTop: 2350 })).toEqual({
-        rowOverscanStartIdx: 40,
-        rowOverscanEndIdx: 64
-      });
-      expect(getRange({ renderBatchSize: 12, scrollTop: 2350 })).toEqual({
-        rowOverscanStartIdx: 36,
-        rowOverscanEndIdx: 72
-      });
-      expect(getRange({ renderBatchSize: 12, scrollTop: 2550 })).toEqual({
-        rowOverscanStartIdx: 36,
-        rowOverscanEndIdx: 72
-      });
-      expect(getRange({ renderBatchSize: 12, scrollTop: 2850 })).toEqual({
-        rowOverscanStartIdx: 48,
-        rowOverscanEndIdx: 72
-      });
-      expect(getRange({ renderBatchSize: 12, scrollTop: 2950 })).toEqual({
-        rowOverscanStartIdx: 48,
-        rowOverscanEndIdx: 84
-      });
-      expect(getRange({ renderBatchSize: 12, scrollTop: 2950, height: 200 })).toEqual({
-        rowOverscanStartIdx: 48,
-        rowOverscanEndIdx: 72
-      });
-      expect(getRange({ renderBatchSize: 12, scrollTop: 2950, height: 800 })).toEqual({
-        rowOverscanStartIdx: 48,
-        rowOverscanEndIdx: 84
-      });
+      expect(getRange({ renderBatchSize: 4, scrollTop: 0 }))
+        .toEqual([0, 16]);
+      expect(getRange({ renderBatchSize: 4, scrollTop: 50 * 1000 - 500 /* max scroll top */ }))
+        .toEqual([984, 999]);
+      expect(getRange({ renderBatchSize: 4, scrollTop: 2350 }))
+        .toEqual([40, 64]);
+      expect(getRange({ renderBatchSize: 12, scrollTop: 2350 }))
+        .toEqual([36, 72]);
+      expect(getRange({ renderBatchSize: 12, scrollTop: 2550 }))
+        .toEqual([36, 72]);
+      expect(getRange({ renderBatchSize: 12, scrollTop: 2850 }))
+        .toEqual([48, 72]);
+      expect(getRange({ renderBatchSize: 12, scrollTop: 2950 }))
+        .toEqual([48, 84]);
+      expect(getRange({ renderBatchSize: 12, scrollTop: 2950, height: 200 }))
+        .toEqual([48, 72]);
+      expect(getRange({ renderBatchSize: 12, scrollTop: 2950, height: 800 }))
+        .toEqual([48, 84]);
     });
   });
 

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -24,21 +24,13 @@ function getColumnCountForWidth<R>(columns: CalculatedColumn<R>[], initialWidth:
   return count;
 }
 
-export interface VerticalRangeToRenderParams {
-  height: number;
-  rowHeight: number;
-  scrollTop: number;
-  rowsCount: number;
-  renderBatchSize: number;
-}
-
-export function getVerticalRangeToRender({
-  height,
-  rowHeight,
-  scrollTop,
-  rowsCount,
-  renderBatchSize
-}: VerticalRangeToRenderParams) {
+export function getVerticalRangeToRender(
+  height: number,
+  rowHeight: number,
+  scrollTop: number,
+  rowsCount: number,
+  renderBatchSize: number
+) {
   const overscanThreshold = 4;
   const rowVisibleStartIdx = Math.floor(scrollTop / rowHeight);
   const rowVisibleEndIdx = Math.min(rowsCount - 1, Math.floor((scrollTop + height) / rowHeight));

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -32,25 +32,20 @@ export interface VerticalRangeToRenderParams {
   renderBatchSize: number;
 }
 
-export interface VerticalRangeToRender {
-  rowOverscanStartIdx: number;
-  rowOverscanEndIdx: number;
-}
-
 export function getVerticalRangeToRender({
   height,
   rowHeight,
   scrollTop,
   rowsCount,
   renderBatchSize
-}: VerticalRangeToRenderParams): VerticalRangeToRender {
+}: VerticalRangeToRenderParams) {
   const overscanThreshold = 4;
   const rowVisibleStartIdx = Math.floor(scrollTop / rowHeight);
   const rowVisibleEndIdx = Math.min(rowsCount - 1, Math.floor((scrollTop + height) / rowHeight));
   const rowOverscanStartIdx = Math.max(0, Math.floor((rowVisibleStartIdx - overscanThreshold) / renderBatchSize) * renderBatchSize);
   const rowOverscanEndIdx = Math.min(rowsCount - 1, Math.ceil((rowVisibleEndIdx + overscanThreshold) / renderBatchSize) * renderBatchSize);
 
-  return { rowOverscanStartIdx, rowOverscanEndIdx };
+  return [rowOverscanStartIdx, rowOverscanEndIdx] as const;
 }
 
 export interface HorizontalRangeToRender {


### PR DESCRIPTION
I don't think we have a need for `row.getRowTop()` or `row.getRowHeight()`? Or `row.props.columns`?

We really need a utils file with all the maths to get grid/row/cell positions/dimensions, we have a bunch of duplicate logic all around for that.

I've also removed `useMemo` for `getVerticalRangeToRender`, all it does is a handful of basic arithmetics, so it's probably faster to just run it all the time rather than loop through the `useMemo` dependencies.