### PR TITLE
Wipe out Immutable.js support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -513,8 +513,7 @@ module.exports = {
       browser: true
     },
     globals: {
-      process: 'readable',
-      Immutable: 'readable'
+      process: 'readable'
     }
   }, {
     files: [

--- a/docs/ReactDataGrid.md
+++ b/docs/ReactDataGrid.md
@@ -16,7 +16,6 @@ Props
 ### `columns` (required)
 
 An array of objects representing each column on the grid.
-Can also be an ImmutableJS object
 
 **type:** arrayOf 
   | Name | Type | Required | Description

--- a/examples/demos/example11-immutable-data.js
+++ b/examples/demos/example11-immutable-data.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import ReactDataGrid from 'react-data-grid';
-import Immutable from 'immutable';
 import Wrapper from './Wrapper';
 
 export default class extends React.Component {
   constructor(props, context) {
     super(props, context);
     this._columns = this.createColumns();
-    this._rows = this.createRows();
 
-    this.state = { rows: new Immutable.fromJS(this._rows) };
+    this.state = { rows: this.createRows() };
   }
 
   getRandomDate = (start, end) => {
@@ -37,7 +35,7 @@ export default class extends React.Component {
   };
 
   rowGetter = (rowIdx) => {
-    return this.state.rows.get(rowIdx);
+    return this.state.rows[rowIdx];
   };
 
   render() {
@@ -47,7 +45,7 @@ export default class extends React.Component {
           enableCellSelect
           columns={this._columns}
           rowGetter={this.rowGetter}
-          rowsCount={this.state.rows.size}
+          rowsCount={this.state.rows.length}
           minHeight={1200}
         />
       </Wrapper>

--- a/examples/demos/example14-all-features-immutable.js
+++ b/examples/demos/example14-all-features-immutable.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDataGrid from 'react-data-grid';
 import { Editors, Toolbar, Menu, Formatters } from 'react-data-grid-addons';
-import Immutable from 'immutable';
 import faker from 'faker';
 import Wrapper from './Wrapper';
 import FakeObjectDataStore from './FakeObjectDataStore';
@@ -138,15 +137,15 @@ export default class extends React.Component {
   constructor(props) {
     super(props);
     const fakeRows = FakeObjectDataStore.createRows(100);
-    this.state = { rows: Immutable.fromJS(fakeRows) };
+    this.state = { rows: fakeRows };
   }
 
   handleGridRowsUpdated = (e) => {
     const { fromRow, toRow, updated } = e;
-    let rows = this.state.rows.slice();
+    const rows = [...this.state.rows];
 
     for (let i = fromRow; i <= toRow; i++) {
-      rows = rows.update(i, r => r.merge(updated));
+      rows[i] = { ...rows[i], ...updated };
     }
 
     if (this.props.handleCellDrag) {
@@ -163,20 +162,18 @@ export default class extends React.Component {
       lastName: ''
     };
 
-    let rows = this.state.rows.slice();
-    rows = rows.push(Immutable.fromJS(newRow));
-    this.setState({ rows });
+    this.setState({ rows: [...this.state.rows, newRow] });
   };
 
   getRowAt = (index) => {
     if (index < 0 || index > this.getSize()) {
       return undefined;
     }
-    return this.state.rows.get(index);
+    return this.state.rows[index];
   };
 
   getSize = () => {
-    return this.state.rows.size;
+    return this.state.rows.length;
   };
 
   render() {

--- a/examples/demos/example23-immutable-data-grouping.js
+++ b/examples/demos/example23-immutable-data-grouping.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ReactDataGrid from 'react-data-grid';
 import { ToolsPanel, Data, Draggable } from 'react-data-grid-addons';
 import faker from 'faker';
-import Immutable from 'immutable';
 import Wrapper from './Wrapper';
 
 const { AdvancedToolbar: Toolbar, GroupedColumnsPanel } = ToolsPanel;
@@ -45,8 +44,8 @@ class CustomToolbar extends React.Component {
 
 export default class extends React.Component {
   state = {
-    rows: new Immutable.fromJS(_rows),
-    cols: new Immutable.List(_cols),
+    rows: _rows,
+    cols: _cols,
     groupBy: [],
     expandedRows: {}
   };
@@ -57,11 +56,11 @@ export default class extends React.Component {
 
   getRowAt = (index) => {
     const rows = this.getRows();
-    return rows.get(index);
+    return rows[index];
   };
 
   getSize = () => {
-    return this.getRows().size;
+    return this.getRows().length;
   };
 
   onColumnGroupAdded = (colName) => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -53,7 +53,6 @@
     }
   </style>
   <script defer src="https://unpkg.com/core-js-bundle/minified.js"></script>
-  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.8.2/immutable.min.js"></script>
   <script defer src="./index.js"></script>
 </head>
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-sonarjs": "^0.4.0",
     "faker": "^4.1.0",
     "immutability-helper": "^3.0.1",
-    "immutable": "^3.8.2",
     "jest": "^24.9.0",
     "lerna": "^3.15.0",
     "less": "^3.10.3",

--- a/packages/react-data-grid-addons/src/data/RowFilterer.js
+++ b/packages/react-data-grid-addons/src/data/RowFilterer.js
@@ -1,8 +1,5 @@
-import { getMixedTypeValueRetriever } from '../utils';
-
 const filterRows = (filters, rows = []) => {
   return rows.filter(r => {
-    const retriever = getMixedTypeValueRetriever();
     let include = true;
     for (const columnKey in filters) {
       if (filters.hasOwnProperty(columnKey)) {
@@ -12,7 +9,7 @@ const filterRows = (filters, rows = []) => {
           include &= colFilter.filterValues(r, colFilter, columnKey);
         } else if (typeof colFilter.filterTerm === 'string') {
           // default filter action
-          const rowValue = retriever.getValue(r, columnKey);
+          const rowValue = r[columnKey];
           if (rowValue !== undefined && rowValue !== null) {
             if (rowValue.toString().toLowerCase().indexOf(colFilter.filterTerm.toLowerCase()) === -1) {
               include &= false;

--- a/packages/react-data-grid-addons/src/data/RowFilterer.js
+++ b/packages/react-data-grid-addons/src/data/RowFilterer.js
@@ -1,8 +1,8 @@
-import { isImmutableCollection, getMixedTypeValueRetriever } from '../utils';
+import { getMixedTypeValueRetriever } from '../utils';
 
 const filterRows = (filters, rows = []) => {
   return rows.filter(r => {
-    const retriever = getMixedTypeValueRetriever(isImmutableCollection(r));
+    const retriever = getMixedTypeValueRetriever();
     let include = true;
     for (const columnKey in filters) {
       if (filters.hasOwnProperty(columnKey)) {

--- a/packages/react-data-grid-addons/src/data/RowGrouper.js
+++ b/packages/react-data-grid-addons/src/data/RowGrouper.js
@@ -1,11 +1,10 @@
 import Resolver from './RowGrouperResolver';
-import { isImmutableCollection } from '../utils';
 
 class RowGrouper {
-  constructor(columns, expandedRows, isImmutable = false) {
+  constructor(columns, expandedRows) {
     this.columns = columns.slice(0);
     this.expandedRows = expandedRows;
-    this.resolver = new Resolver(isImmutable);
+    this.resolver = new Resolver();
   }
 
   isRowExpanded(columnName, name) {
@@ -46,7 +45,7 @@ class RowGrouper {
 }
 
 const groupRows = (rows, groupedColumns, expandedRows) => {
-  const rowGrouper = new RowGrouper(groupedColumns, expandedRows, isImmutableCollection(rows));
+  const rowGrouper = new RowGrouper(groupedColumns, expandedRows);
   return rowGrouper.groupRowsByColumn(rows, 0);
 };
 

--- a/packages/react-data-grid-addons/src/data/RowGrouper.js
+++ b/packages/react-data-grid-addons/src/data/RowGrouper.js
@@ -33,10 +33,10 @@ class RowGrouper {
       if (isExpanded) {
         nextColumnIndex = columnIndex + 1;
         if (this.columns.length > nextColumnIndex) {
-          dataviewRows = dataviewRows.concat(this.groupRowsByColumn(this.resolver.getRowObj(groupedRows, key), nextColumnIndex));
+          dataviewRows = dataviewRows.concat(this.groupRowsByColumn(groupedRows[key], nextColumnIndex));
           nextColumnIndex = columnIndex - 1;
         } else {
-          dataviewRows = dataviewRows.concat(this.resolver.getRowObj(groupedRows, key));
+          dataviewRows = dataviewRows.concat(groupedRows[key]);
         }
       }
     }

--- a/packages/react-data-grid-addons/src/data/RowGrouperResolver.js
+++ b/packages/react-data-grid-addons/src/data/RowGrouperResolver.js
@@ -1,11 +1,6 @@
 import groupBy from 'lodash/groupBy';
-import { getMixedTypeValueRetriever } from '../utils';
 
 export default class RowGrouperResolver {
-  constructor() {
-    this.getRowObj = getMixedTypeValueRetriever().getValue;
-  }
-
   initRowsCollection() {
     return [];
   }

--- a/packages/react-data-grid-addons/src/data/RowGrouperResolver.js
+++ b/packages/react-data-grid-addons/src/data/RowGrouperResolver.js
@@ -1,44 +1,24 @@
 import groupBy from 'lodash/groupBy';
-import { isImmutableMap, getMixedTypeValueRetriever } from '../utils';
+import { getMixedTypeValueRetriever } from '../utils';
 
 export default class RowGrouperResolver {
-  constructor(isImmutable) {
-    this.isImmutable = isImmutable;
-    this.getRowObj = getMixedTypeValueRetriever(isImmutable).getValue;
+  constructor() {
+    this.getRowObj = getMixedTypeValueRetriever().getValue;
   }
 
   initRowsCollection() {
-    return this.isImmutable ? new Immutable.List() : [];
+    return [];
   }
 
   getGroupedRows(rows, columnName) {
-    return this.isImmutable ? rows.groupBy(x => isImmutableMap(x) ? x.get(columnName) : x[columnName]) : groupBy(rows, columnName);
+    return groupBy(rows, columnName);
   }
 
   getGroupKeys(groupedRows) {
-    let getKeys = Object.keys;
-    if (this.isImmutable) {
-      getKeys = (col) => {
-        const keys = [];
-        const iterator = col.keys();
-        let item = iterator.next();
-
-        while (!item.done) {
-          keys.push(item.value);
-          item = iterator.next();
-        }
-        return keys;
-      };
-    }
-    return getKeys(groupedRows);
+    return Object.keys(groupedRows);
   }
 
   addHeaderRow(rowGroupHeader, dataviewRows) {
-    const rows = dataviewRows;
-    const dvRows = rows.push(rowGroupHeader);
-    if (this.isImmutable) {
-      return dvRows;
-    }
-    return rows;
+    return [...dataviewRows, rowGroupHeader];
   }
 }

--- a/packages/react-data-grid-addons/src/data/RowSorter.js
+++ b/packages/react-data-grid-addons/src/data/RowSorter.js
@@ -1,5 +1,3 @@
-import { getMixedTypeValueRetriever } from '../utils';
-
 export const comparer = (a, b) => {
   if (a > b) {
     return 1;
@@ -11,10 +9,9 @@ export const comparer = (a, b) => {
 };
 
 const sortRows = (rows, sortColumn, sortDirection) => {
-  const retriever = getMixedTypeValueRetriever();
   const sortDirectionSign = sortDirection === 'ASC' ? 1 : -1;
   const rowComparer = (a, b) => {
-    return sortDirectionSign * comparer(retriever.getValue(a, sortColumn), retriever.getValue(b, sortColumn));
+    return sortDirectionSign * comparer(a[sortColumn], b[sortColumn]);
   };
   if (sortDirection === 'NONE') {
     return rows;

--- a/packages/react-data-grid-addons/src/data/RowSorter.js
+++ b/packages/react-data-grid-addons/src/data/RowSorter.js
@@ -1,4 +1,4 @@
-import { getMixedTypeValueRetriever, isImmutableCollection } from '../utils';
+import { getMixedTypeValueRetriever } from '../utils';
 
 export const comparer = (a, b) => {
   if (a > b) {
@@ -11,7 +11,7 @@ export const comparer = (a, b) => {
 };
 
 const sortRows = (rows, sortColumn, sortDirection) => {
-  const retriever = getMixedTypeValueRetriever(isImmutableCollection(rows));
+  const retriever = getMixedTypeValueRetriever();
   const sortDirectionSign = sortDirection === 'ASC' ? 1 : -1;
   const rowComparer = (a, b) => {
     return sortDirectionSign * comparer(retriever.getValue(a, sortColumn), retriever.getValue(b, sortColumn));

--- a/packages/react-data-grid-addons/src/data/__tests__/RowFilterer.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/RowFilterer.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { fromJS } from 'immutable';
 import TestUtils from 'react-dom/test-utils';
 
 import filterRows from '../RowFilterer';
@@ -27,11 +26,6 @@ describe('Row Filterer', () => {
     expect(filterResult.length).toBe(1);
   });
 
-  it('It can filter an immutable js list of rows', () => {
-    const immutableList = fromJS(rows);
-    const filterResult = filterRows(filters, immutableList);
-    expect(filterResult.size).toBe(1);
-  });
   it('It can filter a normal array of rows with AutoCompleteFilter', () => {
     const filterResult = filterRows(acFilters, rows);
     expect(filterResult.length).toBe(2);

--- a/packages/react-data-grid-addons/src/data/__tests__/RowGrouper.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/RowGrouper.spec.js
@@ -1,5 +1,3 @@
-import Immutable from 'immutable';
-
 import groupRows from '../RowGrouper';
 
 const rows = [{ colOne: 'v1', colTwo: 'b1' },
@@ -19,12 +17,6 @@ describe('Row Grouper', () => {
     // we should have 5 elements -> 2 group headers + all of the original ones
     expect(groupingResult.length).toBe(5);
   });
-  it('It can group an immutable js list of rows (one grouping column)', () => {
-    const immutableList = Immutable.fromJS(rows);
-    const groupingResult = groupRows(immutableList, grpDetails.oneCol, grpDetails.expRows);
-
-    expect(groupingResult.size).toBe(5);
-  });
   it('It can group an array of rows (two grouping columns) - correct number of first nested header elements', () => {
     const groupingResult = groupRows(rows, grpDetails.multiCol, grpDetails.expRows);
 
@@ -36,27 +28,5 @@ describe('Row Grouper', () => {
     const groupingResult = groupRows(rows, grpDetails.multiCol, grpDetails.expRows);
 
     expect(groupingResult.length).toBe(8);
-  });
-  it('It can group an immutable js list of rows (two grouping columns)', () => {
-    const immutableList = Immutable.fromJS(rows);
-    const groupingResult = groupRows(immutableList, grpDetails.multiCol, grpDetails.expRows);
-
-    expect(groupingResult.size).toBe(8);
-  });
-  it('It can group an immutable js list of rows (two grouping columns) - correct number of first nested header elements', () => {
-    const immutableList = Immutable.fromJS(rows);
-    const groupingResult = groupRows(immutableList, grpDetails.multiCol, grpDetails.expRows);
-
-    expect(groupingResult
-      .slice(0, grpDetails.multiCol.length)
-      .every(x => x.__metaData)).toBe(true);
-  });
-  it('It can group an Immutable List (not list of immutable maps)', () => {
-    const immutableList = Immutable.List(rows);
-    const groupingResult = groupRows(immutableList, grpDetails.multiCol, grpDetails.expRows);
-
-    expect(groupingResult
-      .slice(0, grpDetails.multiCol.length)
-      .every(x => x.__metaData)).toBe(true);
   });
 });

--- a/packages/react-data-grid-addons/src/data/__tests__/RowSorter.spec.js
+++ b/packages/react-data-grid-addons/src/data/__tests__/RowSorter.spec.js
@@ -1,5 +1,3 @@
-import Immutable from 'immutable';
-
 import sortRows, { comparer } from '../RowSorter';
 
 describe('RowSorter', () => {
@@ -38,14 +36,6 @@ describe('RowSorter', () => {
       const rowsSorted = sortRows(rows, 'text', 'ASC');
       for (let i = 0; i < rowsSorted.length - 1; i++) {
         expect(rowsSorted[i].text <= rowsSorted[i + 1].text).toBe(true);
-      }
-    });
-
-    it('It can sort an immutable js list of rows', () => {
-      const immutableList = Immutable.fromJS(rows);
-      const rowsSorted = sortRows(immutableList, 'text', 'ASC');
-      for (let i = 0; i < rowsSorted.size - 1; i++) {
-        expect(rowsSorted.get(i).get('text') <= rowsSorted.get(i + 1).get('text')).toBe(true);
       }
     });
   });

--- a/packages/react-data-grid-addons/src/draggable/DragDropContainer.js
+++ b/packages/react-data-grid-addons/src/draggable/DragDropContainer.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import html5DragDropContext from '../shared/html5DragDropContext';
 import DraggableHeaderCell from './DraggableHeaderCell';
 import RowDragLayer from './RowDragLayer';
-import { isColumnsImmutable } from '../utils';
 
 class DraggableContainer extends Component {
   static propTypes = {
@@ -39,7 +38,7 @@ class DraggableContainer extends Component {
         <RowDragLayer
           selectedRows={grid.props.selectedRows}
           rows={rows}
-          columns={isColumnsImmutable(columns) ? columns.toArray() : columns}
+          columns={columns}
         />
       </div>
     );

--- a/packages/react-data-grid-addons/src/utils.ts
+++ b/packages/react-data-grid-addons/src/utils.ts
@@ -1,31 +1,13 @@
-import Immutable from 'immutable';
-
-export function isColumnsImmutable(columns: unknown): columns is Immutable.List<unknown> {
-  return Immutable.List.isList(columns);
-}
-
-export function isEmptyArray(obj: unknown): boolean {
-  return Array.isArray(obj) && obj.length === 0;
-}
-
-export function isFunction<T>(functionToCheck: T): boolean {
-  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+export function isEmptyArray(arr: readonly unknown[]): boolean {
+  return arr.length === 0;
 }
 
 export function isEmptyObject<T extends {}>(obj: T): boolean {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }
 
-export function isImmutableCollection<T>(objToVerify: T): boolean {
-  return Immutable.Iterable.isIterable(objToVerify);
-}
-
-export function getMixedTypeValueRetriever(isImmutable: boolean) {
+export function getMixedTypeValueRetriever() {
   return {
-    getValue: isImmutable
-      ? (immutable: Immutable.Map<string, unknown>, key: string) => immutable.get(key)
-      : <T>(item: T, key: keyof T): T[typeof key] => item[key]
+    getValue: <T>(item: T, key: keyof T): T[typeof key] => item[key]
   };
 }
-
-export const isImmutableMap = Immutable.Map.isMap;

--- a/packages/react-data-grid-addons/src/utils.ts
+++ b/packages/react-data-grid-addons/src/utils.ts
@@ -5,9 +5,3 @@ export function isEmptyArray(arr: readonly unknown[]): boolean {
 export function isEmptyObject<T extends {}>(obj: T): boolean {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }
-
-export function getMixedTypeValueRetriever() {
-  return {
-    getValue: <T>(item: T, key: keyof T): T[typeof key] => item[key]
-  };
-}

--- a/packages/react-data-grid/package.json
+++ b/packages/react-data-grid/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "immutable": "^3.8.2",
     "react-is": "^16.8.4",
     "shallowequal": "^1.1.0",
     "tslib": "^1.10.0"

--- a/packages/react-data-grid/src/ReactDataGrid.tsx
+++ b/packages/react-data-grid/src/ReactDataGrid.tsx
@@ -22,7 +22,7 @@ import {
   CellCopyPasteEvent,
   CellMetaData,
   CheckCellIsEditableEvent,
-  ColumnList,
+  Column,
   CommitEvent,
   GridRowsUpdatedEvent,
   HeaderRowData,
@@ -39,8 +39,8 @@ import {
 } from './common/types';
 
 export interface ReactDataGridProps<R extends {}> {
-  /** An array of objects representing each column on the grid. Can also be an ImmutableJS object */
-  columns: ColumnList<R>;
+  /** An array of objects representing each column on the grid */
+  columns: Column<R>[];
   /** The minimum width of the grid in pixels */
   minWidth?: number;
   /** The height of the header row in pixels */

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { KeyboardEvent, ReactNode } from 'react';
-import { List } from 'immutable';
 import { HeaderRowType, UpdateActions } from './enums';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -54,8 +53,6 @@ export type CalculatedColumn<TRow, TDependentValue = unknown, TField extends key
     width: number;
     left: number;
   };
-
-export type ColumnList<TRow> = Column<TRow>[] | List<Column<TRow>>;
 
 export interface ColumnMetrics<TRow> {
   columns: CalculatedColumn<TRow>[];

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -1,20 +1,15 @@
-import { Column, CalculatedColumn, ColumnList, ColumnMetrics } from '../common/types';
+import { Column, CalculatedColumn, ColumnMetrics } from '../common/types';
 import { getScrollbarSize } from './domUtils';
 
 type Metrics<R> = Pick<ColumnMetrics<R>, 'viewportWidth' | 'minColumnWidth' | 'columnWidths'> & {
-  columns: ColumnList<R>;
+  columns: Column<R>[];
 };
-
-function toArray<R>(columns: ColumnList<R>): Column<R>[] {
-  columns = Array.isArray(columns) ? columns : columns.toArray();
-  return columns.map(c => ({ ...c }));
-}
 
 export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
   let left = 0;
   let totalWidth = 0;
 
-  const columns = toArray(metrics.columns);
+  const columns = metrics.columns.map(c => ({ ...c }));
   setSpecifiedWidths(columns, metrics.columnWidths, metrics.viewportWidth, metrics.minColumnWidth);
 
   const allocatedWidths = columns.map(c => c.width || 0).reduce((acc, w) => acc + w, 0);

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -1,10 +1,7 @@
 import enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Immutable from 'immutable';
 
 enzyme.configure({
   adapter: new Adapter(),
   disableLifecycleMethods: true
 });
-
-window.Immutable = Immutable;


### PR DESCRIPTION
It can still be used by the users, but RDG has no use for it internally.