### PR TITLE
Support for copying and pasting ranges of cells

### DIFF
--- a/examples/components/ExampleList.js
+++ b/examples/components/ExampleList.js
@@ -38,6 +38,7 @@ export default class ExampleList extends React.Component {
         <li><Link to="/examples/descendingFirstSortable">Descending First Sortable Example</Link></li>
         <li><Link to="/examples/selection-range-events">Selection Range Events Example</Link></li>
         <li><Link to="/examples/isScrolling">IsScrolling Example</Link></li>
+        <li><Link to="/examples/range-copy-paste">Range Copy &amp; Paste Example</Link></li>
       </ul>
     );
   }

--- a/examples/components/Examples.js
+++ b/examples/components/Examples.js
@@ -37,6 +37,7 @@ import ScrollToRowIndex from '../scripts/example28-scroll-to-row-index';
 import DescendingFirstSortable from '../scripts/example29-descendingFirstSortable';
 import SelectionRangeEvents from '../scripts/example30-selection-range-events';
 import IsScrolling from '../scripts/example31-isScrolling';
+import RangeCopyPaste from '../scripts/example32-range-copy-paste';
 
 export default function Examples({ match }) {
   return (
@@ -87,6 +88,7 @@ export default function Examples({ match }) {
               <Route path="/examples/descendingFirstSortable" component={DescendingFirstSortable} />
               <Route path="/examples/selection-range-events" component={SelectionRangeEvents} />
               <Route path="/examples/isScrolling" component={IsScrolling} />
+              <Route path="/examples/range-copy-paste" component={RangeCopyPaste} />
               <Redirect from={`${match.url}`} to={`${match.url}/all-features`} />
             </Switch>
           </div>

--- a/examples/scripts/example32-range-copy-paste.js
+++ b/examples/scripts/example32-range-copy-paste.js
@@ -94,7 +94,9 @@ class Example extends React.Component {
 
 const exampleDescription = (
   <p>
-    TODO
+    This example shows that copying and pasting a range of cells works as you would expect.
+    To implement this behavior, make your columns editable per the <a href="#/examples/editable">Editable Example</a>
+    {' '} and add the <code>cellRangeSelection</code> property to the component.
   </p>
 );
 

--- a/examples/scripts/example32-range-copy-paste.js
+++ b/examples/scripts/example32-range-copy-paste.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import ReactDataGrid from 'react-data-grid';
+import faker from 'faker';
+import update from 'immutability-helper';
+
+import exampleWrapper from '../components/exampleWrapper';
+
+class Example extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this._columns = [
+      {
+        key: 'id',
+        name: 'ID',
+        width: 80
+      },
+      {
+        key: 'title',
+        name: 'Title',
+        editable: true
+      },
+      {
+        key: 'currency',
+        name: 'Currency',
+        editable: true
+      },
+      {
+        key: 'color',
+        name: 'Color',
+        editable: true
+      },
+      {
+        key: 'description',
+        name: 'Description',
+        editable: true
+      },
+      {
+        key: 'count',
+        name: 'Count',
+        editable: true
+      }
+    ];
+
+    this.state = { rows: this.createRows(1000) };
+  }
+
+  createRows = () => {
+    const rows = [];
+    for (let i = 1; i < 1000; i++) {
+      rows.push({
+        id: i,
+        title: `Title ${i}`,
+        count: i * 1000,
+        color: faker.commerce.color(),
+        currency: faker.finance.currencyCode(),
+        description: faker.lorem.words(5),
+        isSelected: false
+      });
+    }
+
+    return rows;
+  };
+
+  rowGetter = (i) => {
+    return this.state.rows[i];
+  };
+
+  handleGridRowsUpdated = ({ fromRow, toRow, updated }) => {
+    const rows = this.state.rows.slice();
+
+    for (let i = fromRow; i <= toRow; i++) {
+      const rowToUpdate = rows[i];
+      const updatedRow = update(rowToUpdate, { $merge: updated });
+      rows[i] = updatedRow;
+    }
+
+    this.setState({ rows });
+  };
+
+  render() {
+    return (
+      <ReactDataGrid
+        enableCellSelect
+        cellRangeSelection
+        columns={this._columns}
+        rowGetter={this.rowGetter}
+        rowsCount={this.state.rows.length}
+        minHeight={500}
+        onGridRowsUpdated={this.handleGridRowsUpdated}
+      />
+    );
+  }
+}
+
+const exampleDescription = (
+  <p>
+    TODO
+  </p>
+);
+
+export default exampleWrapper({
+  WrappedComponent: Example,
+  exampleName: 'Range Copy and Paste',
+  exampleDescription,
+  examplePath: './scripts/example32-range-copy-paste.js'
+  // TODO: Playground link
+});

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -29,12 +29,6 @@
       "contributing": {
         "title": "Contributing"
       },
-      "doc4": {
-        "title": "Other Document"
-      },
-      "doc5": {
-        "title": "Fifth Document"
-      },
       "examples/advanced-filtering": {
         "title": "Advanced Filtering"
       },
@@ -151,14 +145,14 @@
       "Docs": "Docs",
       "Examples": "Examples",
       "Blog": "Blog",
-      "V5.0.4": "V5.0.4"
+      "V7.0.0-alpha.20": "V7.0.0-alpha.20"
     },
     "categories": {
       "Getting Started": "Getting Started",
       "API": "API",
       "Contributing": "Contributing",
-      "Changelog": "Changelog",
       "Migrations": "Migrations",
+      "Changelog": "Changelog",
       "Examples": "Examples"
     }
   },


### PR DESCRIPTION
## Description
This branch adds support for copying and pasting cell contents for ranges of cells using the system clipboard. The reason for adding this is that this is expected behavior when coming from Excel or Google Sheets -- when copying a range, the values should be copied as a TSV (tab-separated values), and pasting in a TSV should paste the right values into the right cells.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Cmd-C/V use some sort of internal clipboard and you cannot copy data from react-data-grid into another application.

**What is the new behavior?**

Cmd-C/V works as one would expect.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

- This uses the [ClipboardEvent API](https://caniuse.com/#feat=mdn-api_clipboardevent), which seems to be [well supported](https://caniuse.com/#feat=mdn-api_clipboardevent).
- There's still a problem where hitting Cmd-C/Cmd-V anywhere on the page activates the grid's copy and paste. This might be a bug, but I also noticed that using the arrow keys anywhere on the page is captures, so a larger fix might be to implement some sort of "is the grid focused" check.
