### PR TITLE
Squeeze more performance out of Row.getCells

### DIFF
--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -137,7 +137,7 @@ export default class Cell<R> extends React.PureComponent<CellProps<R>> {
   }
 
   render() {
-    const { idx, rowIdx, column, value, tooltip, children, height, cellControls, expandableOptions, cellMetaData, rowData } = this.props;
+    const { idx, rowIdx, column, value, tooltip, children, cellControls, expandableOptions, cellMetaData, rowData } = this.props;
     if (column.hidden) {
       return null;
     }
@@ -153,7 +153,6 @@ export default class Cell<R> extends React.PureComponent<CellProps<R>> {
         value={value}
         tooltip={tooltip}
         expandableOptions={expandableOptions}
-        height={height}
         onDeleteSubRow={cellMetaData.onDeleteSubRow}
         cellControls={cellControls}
         isRowSelected={this.props.isRowSelected}

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -6,7 +6,6 @@ import CellActions from './Cell/CellActions';
 import CellExpand from './Cell/CellExpander';
 import CellContent from './Cell/CellContent';
 import { isFrozen } from './utils/columnUtils';
-import { isPositionStickySupported } from './utils';
 
 function getSubRowOptions<R>({ rowIdx, idx, rowData, expandableOptions: expandArgs }: CellProps<R>): SubRowOptions<R> {
   return { rowIdx, idx, rowData, expandArgs };
@@ -66,15 +65,15 @@ export default class Cell<R> extends React.PureComponent<CellProps<R>> {
   };
 
   getStyle(): React.CSSProperties {
-    const { column } = this.props;
+    const { column, scrollLeft } = this.props;
 
     const style: React.CSSProperties = {
       width: column.width,
       left: column.left
     };
 
-    if (!isPositionStickySupported() && isFrozen(column)) {
-      style.transform = `translateX(${this.props.scrollLeft}px)`;
+    if (scrollLeft !== undefined) {
+      style.transform = `translateX(${scrollLeft}px)`;
     }
 
     return style;
@@ -82,11 +81,13 @@ export default class Cell<R> extends React.PureComponent<CellProps<R>> {
 
   getCellClass() {
     const { column, tooltip, expandableOptions } = this.props;
+    const colIsFrozen = isFrozen(column);
     return classNames(
       column.cellClass,
       'rdg-cell',
       this.props.className, {
-        'rdg-cell-frozen': isFrozen(column),
+        'rdg-cell-frozen': colIsFrozen,
+        'rdg-cell-frozen-last': colIsFrozen && column.idx === this.props.lastFrozenColumnIndex,
         'has-tooltip': !!tooltip,
         'rdg-child-cell': expandableOptions && expandableOptions.subRowDetails && expandableOptions.treeDepth > 0
       }

--- a/packages/react-data-grid/src/Cell/CellContent.tsx
+++ b/packages/react-data-grid/src/Cell/CellContent.tsx
@@ -14,7 +14,6 @@ export type CellContentProps<R> = Pick<CellProps<R>,
 | 'value'
 | 'expandableOptions'
 | 'tooltip'
-| 'height'
 | 'cellControls'
 | 'isRowSelected'
 | 'onRowSelectionChange'
@@ -30,7 +29,6 @@ export default function CellContent<R>({
   value,
   tooltip,
   expandableOptions,
-  height,
   onDeleteSubRow,
   cellControls,
   isRowSelected,
@@ -54,7 +52,6 @@ export default function CellContent<R>({
   const cellDeleter = expandableOptions && treeDepth > 0 && isExpandCell && (
     <ChildRowDeleteButton
       treeDepth={treeDepth}
-      cellHeight={height}
       onDeleteSubRow={handleDeleteSubRow}
       isDeleteSubRowEnabled={!!onDeleteSubRow}
     />

--- a/packages/react-data-grid/src/ChildRowDeleteButton.tsx
+++ b/packages/react-data-grid/src/ChildRowDeleteButton.tsx
@@ -3,19 +3,16 @@ import { RemoveCircle } from '@material-ui/icons';
 
 export interface ChildRowDeleteButtonProps {
   treeDepth: number;
-  cellHeight: number;
   onDeleteSubRow(): void;
   isDeleteSubRowEnabled: boolean;
 }
 
-export default function ChildRowDeleteButton({ treeDepth, cellHeight, onDeleteSubRow, isDeleteSubRowEnabled }: ChildRowDeleteButtonProps) {
-  const left = treeDepth * 15;
-  const top = (cellHeight - 12) / 2;
+export default function ChildRowDeleteButton({ treeDepth, onDeleteSubRow, isDeleteSubRowEnabled }: ChildRowDeleteButtonProps) {
   return (
     <>
       <div className="rdg-child-row-action-cross" />
       {isDeleteSubRowEnabled && (
-        <div style={{ left, top }} className="rdg-child-row-btn" onClick={onDeleteSubRow}>
+        <div className="rdg-child-row-btn" style={{ left: treeDepth * 15 }} onClick={onDeleteSubRow}>
           <RemoveCircle />
         </div>
       )}

--- a/packages/react-data-grid/src/Header.tsx
+++ b/packages/react-data-grid/src/Header.tsx
@@ -97,6 +97,7 @@ export default forwardRef(function Header<R, K extends keyof R>(props: HeaderPro
         width={columnMetrics.totalColumnWidth + getScrollbarSize()}
         height={row.height}
         columns={columnMetrics.columns}
+        lastFrozenColumnIndex={columnMetrics.lastFrozenColumnIndex}
         draggableHeaderCell={props.draggableHeaderCell}
         filterable={row.filterable}
         onFilterChange={row.onFilterChange}

--- a/packages/react-data-grid/src/HeaderCell.tsx
+++ b/packages/react-data-grid/src/HeaderCell.tsx
@@ -13,6 +13,7 @@ function SimpleCellRenderer<R>({ column, rowType }: HeaderRowProps<R>) {
 interface Props<R> {
   renderer?: React.ReactElement | React.ComponentType<HeaderRowProps<R>>;
   column: CalculatedColumn<R>;
+  lastFrozenColumnIndex: number;
   rowType: HeaderRowType;
   height: number;
   onResize(column: CalculatedColumn<R>, width: number): void;
@@ -133,10 +134,12 @@ export default class HeaderCell<R> extends React.Component<Props<R>> {
 
   render() {
     const { column, rowType } = this.props;
+    const colIsFrozen = isFrozen(column);
 
     const className = classNames('rdg-cell', {
-      'rdg-header-cell-resizable': column.resizable,
-      'rdg-cell-frozen': isFrozen(column)
+      'rdg-cell-frozen': colIsFrozen,
+      'rdg-cell-frozen-last': colIsFrozen && column.idx === this.props.lastFrozenColumnIndex,
+      'rdg-header-cell-resizable': column.resizable
     }, this.props.className, column.cellClass);
 
     const cell = (

--- a/packages/react-data-grid/src/HeaderRow.tsx
+++ b/packages/react-data-grid/src/HeaderRow.tsx
@@ -23,6 +23,7 @@ export interface HeaderRowProps<R, K extends keyof R> extends SharedHeaderProps<
   width: number;
   height: number;
   columns: CalculatedColumn<R>[];
+  lastFrozenColumnIndex: number;
   onColumnResize(column: CalculatedColumn<R>, width: number): void;
   onColumnResizeEnd(): void;
   onAllRowsSelectionChange(checked: boolean): void;
@@ -91,22 +92,22 @@ export default class HeaderRow<R, K extends keyof R> extends React.Component<Hea
   }
 
   getCells() {
-    const cells = [];
-    const frozenCells = [];
-    const { columns, rowType } = this.props;
+    const cellElements = [];
+    const { columns, lastFrozenColumnIndex, rowType } = this.props;
     const setRef = !isPositionStickySupported();
 
     for (const column of columns) {
       const { key } = column;
       const renderer = key === 'select-row' && rowType === HeaderRowType.FILTER ? <div /> : this.getHeaderRenderer(column);
 
-      const cell = (
+      cellElements.push(
         <HeaderCell<R>
           key={key as string}
           ref={setRef
             ? node => node ? this.cells.set(key, node) : this.cells.delete(key)
             : undefined}
           column={column}
+          lastFrozenColumnIndex={lastFrozenColumnIndex}
           rowType={rowType}
           height={this.props.height}
           renderer={renderer}
@@ -118,15 +119,9 @@ export default class HeaderRow<R, K extends keyof R> extends React.Component<Hea
           draggableHeaderCell={this.props.draggableHeaderCell}
         />
       );
-
-      if (isFrozen(column)) {
-        frozenCells.push(cell);
-      } else {
-        cells.push(cell);
-      }
     }
 
-    return cells.concat(frozenCells);
+    return cellElements;
   }
 
   setScrollLeft(scrollLeft: number): void {

--- a/packages/react-data-grid/src/Row.tsx
+++ b/packages/react-data-grid/src/Row.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 
 import Cell from './Cell';
 import { isFrozen } from './utils/columnUtils';
-import { isPositionStickySupported } from './utils';
 import { IRowRendererProps } from './common/types';
 
 export default class Row<R> extends React.Component<IRowRendererProps<R>> {
@@ -36,41 +35,48 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
   getCells() {
     const {
       cellMetaData,
+      colOverscanEndIdx,
+      colOverscanStartIdx,
       columns,
       height,
       idx,
       isRowSelected,
+      lastFrozenColumnIndex,
       onRowSelectionChange,
       row,
       scrollLeft
     } = this.props;
     const Renderer = this.props.cellRenderer!;
-    const canSticky = isPositionStickySupported();
+    const cellElements = [];
 
-    // FIXME: do we need this, considering columnsMetrics should have these columns sorted already?
-    const frozenColumns = columns.slice(0, this.props.lastFrozenColumnIndex + 1);
-    const nonFrozenColumn = columns.slice(this.props.colOverscanStartIdx, this.props.colOverscanEndIdx + 1).filter(c => !isFrozen(c));
+    for (let colIdx = 0; colIdx <= colOverscanEndIdx; colIdx++) {
+      const column = columns[colIdx];
+      const colIsFrozen = isFrozen(column);
 
-    return nonFrozenColumn.concat(frozenColumns).map(column => {
+      if (colIdx < colOverscanStartIdx && !colIsFrozen) continue;
+
       const { key } = column;
 
-      return (
+      cellElements.push(
         <Renderer
-          key={`${key as keyof R}-${idx}`} // FIXME: fix key type
-          idx={column.idx}
+          key={key as string} // FIXME: fix key type
+          idx={colIdx}
           rowIdx={idx}
           height={height}
           column={column}
+          lastFrozenColumnIndex={lastFrozenColumnIndex}
           cellMetaData={cellMetaData}
-          value={this.getCellValue(key || String(column.idx) as keyof R) as R[keyof R]} // FIXME: fix types
+          value={this.getCellValue(key || String(colIdx) as keyof R) as R[keyof R]} // FIXME: fix types
           rowData={row}
           expandableOptions={this.getExpandableOptions(key)}
-          scrollLeft={!canSticky && isFrozen(column) ? scrollLeft : undefined}
+          scrollLeft={colIsFrozen && typeof scrollLeft === 'number' ? scrollLeft : undefined}
           isRowSelected={isRowSelected}
           onRowSelectionChange={onRowSelectionChange}
         />
       );
-    });
+    }
+
+    return cellElements;
   }
 
   getCellValue(key: keyof R) {

--- a/packages/react-data-grid/src/Row.tsx
+++ b/packages/react-data-grid/src/Row.tsx
@@ -9,9 +9,7 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
   static displayName = 'Row';
 
   static defaultProps = {
-    cellRenderer: Cell,
-    isSelected: false,
-    height: 35
+    cellRenderer: Cell
   };
 
   handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
@@ -38,7 +36,6 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
       colOverscanEndIdx,
       colOverscanStartIdx,
       columns,
-      height,
       idx,
       isRowSelected,
       lastFrozenColumnIndex,
@@ -62,7 +59,6 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
           key={key as string} // FIXME: fix key type
           idx={colIdx}
           rowIdx={idx}
-          height={height}
           column={column}
           lastFrozenColumnIndex={lastFrozenColumnIndex}
           cellMetaData={cellMetaData}

--- a/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
@@ -68,7 +68,7 @@ describe('Canvas Tests', () => {
       rowHeight: 25,
       rowsCount: 1,
       colVisibleStartIdx: 0,
-      colVisibleEndIdx: 1
+      colVisibleEndIdx: 0
     });
   });
 

--- a/packages/react-data-grid/src/__tests__/Cell.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.tsx
@@ -40,10 +40,10 @@ const testProps: CellProps<Row> = {
   rowIdx: 0,
   idx: 1,
   column: defaultColumn,
+  lastFrozenColumnIndex: -1,
   value: 'Wicklow',
   cellMetaData: testCellMetaData,
   rowData: { id: 1, description: 'Wicklow' },
-  height: 40,
   isRowSelected: false,
   onRowSelectionChange() {},
   scrollLeft: 0
@@ -86,8 +86,8 @@ describe('Cell Tests', () => {
     const requiredProperties: CellProps<Row> = {
       rowIdx: 18,
       idx: 19,
-      height: 60,
       column: helpers.columns[0],
+      lastFrozenColumnIndex: -1,
       value: 'requiredValue',
       cellMetaData: testCellMetaData,
       rowData: helpers.rowGetter(11),
@@ -119,8 +119,8 @@ describe('Cell Tests', () => {
       const props: CellProps<Row> = {
         rowIdx: 18,
         idx: 19,
-        height: 60,
         column: helpers.columns[0],
+        lastFrozenColumnIndex: -1,
         value: 'requiredValue',
         cellMetaData: testCellMetaData,
         rowData: helpers.rowGetter(11),

--- a/packages/react-data-grid/src/__tests__/ChildRowDeleteButton.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/ChildRowDeleteButton.spec.tsx
@@ -8,7 +8,6 @@ describe('ChildRowDeleteButton', () => {
     const onDeleteSubRow = jest.fn();
     return {
       treeDepth: 2,
-      cellHeight: 50,
       onDeleteSubRow,
       isDeleteSubRowEnabled: true
     };

--- a/packages/react-data-grid/src/__tests__/HeaderCell.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/HeaderCell.spec.tsx
@@ -23,6 +23,7 @@ describe('Header Cell Tests', () => {
         left: 300,
         ...columnProps
       },
+      lastFrozenColumnIndex: -1,
       rowType: HeaderRowType.HEADER,
       onResize: jest.fn(),
       onResizeEnd: jest.fn(),

--- a/packages/react-data-grid/src/__tests__/HeaderRow.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/HeaderRow.spec.tsx
@@ -12,6 +12,7 @@ describe('Header Row Unit Tests', () => {
   const defaultProps = {
     rowType: HeaderRowType.HEADER,
     columns: helpers.columns,
+    lastFrozenColumnIndex: -1,
     onColumnResize() { },
     onColumnResizeEnd() { },
     onSort: jest.fn(),
@@ -134,6 +135,7 @@ describe('Header Row Unit Tests', () => {
       width: 1000,
       height: 35,
       columns: helpers.columns,
+      lastFrozenColumnIndex: 1,
       onSort: jest.fn(),
       rowType: HeaderRowType.HEADER,
       allRowsSelected: false,

--- a/packages/react-data-grid/src/__tests__/Row.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Row.spec.tsx
@@ -80,13 +80,6 @@ describe('Row', () => {
         const renderedRange = colOverscanEndIdx - colOverscanStartIdx + 1;
         expect(cells.length).toBe(renderedRange);
       });
-
-      it('first frozen cell should be rendered after the unfrozen cells', () => {
-        const columns = lockColumns();
-        const { cells } = setup({ ...requiredProperties, columns, lastFrozenColumnIndex: LAST_LOCKED_CELL_IDX });
-        const firstFrozenColumn = columns.filter(c => c.frozen === true)[0];
-        expect(cells.at(cells.length - LAST_LOCKED_CELL_IDX - 1).props().column).toBe(firstFrozenColumn);
-      });
     });
 
     describe('When not using frozen columns', () => {

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -153,6 +153,7 @@ export interface CellRendererProps<TRow, TValue = unknown> {
   height: number;
   value: TValue;
   column: CalculatedColumn<TRow>;
+  lastFrozenColumnIndex: number;
   rowData: TRow;
   cellMetaData: CellMetaData<TRow>;
   scrollLeft: number | undefined;

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -150,7 +150,6 @@ export interface HeaderRowProps<TRow> {
 export interface CellRendererProps<TRow, TValue = unknown> {
   idx: number;
   rowIdx: number;
-  height: number;
   value: TValue;
   column: CalculatedColumn<TRow>;
   lastFrozenColumnIndex: number;

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -77,9 +77,9 @@ export function getHorizontalRangeToRender<R>({
   viewportWidth = viewportWidth > 0 ? viewportWidth + firstVisibleColumnHiddenWidth : totalColumnWidth;
   const availableWidth = viewportWidth - totalFrozenColumnWidth;
   const nonFrozenRenderedColumnCount = getColumnCountForWidth(columns, availableWidth, colVisibleStartIdx);
-  const colVisibleEndIdx = Math.min(columns.length, colVisibleStartIdx + nonFrozenRenderedColumnCount);
+  const colVisibleEndIdx = Math.min(columns.length - 1, colVisibleStartIdx + nonFrozenRenderedColumnCount);
   const colOverscanStartIdx = Math.max(0, colVisibleStartIdx - 1);
-  const colOverscanEndIdx = Math.min(columns.length, colVisibleEndIdx + 1);
+  const colOverscanEndIdx = Math.min(columns.length - 1, colVisibleEndIdx + 1);
 
   return { colVisibleStartIdx, colVisibleEndIdx, colOverscanStartIdx, colOverscanEndIdx };
 }

--- a/packages/react-data-grid/style/rdg-cell.less
+++ b/packages/react-data-grid/style/rdg-cell.less
@@ -20,16 +20,16 @@
     z-index: 3
   }
 
-  &:last-child {
-    box-shadow: 2px 0 5px -2px rgba(136, 136, 136, .3);
-  }
-
   @supports (position: sticky) or (position: -webkit-sticky) {
     & {
       position: -webkit-sticky;
       position: sticky;
     }
   }
+}
+
+.rdg-cell-frozen-last {
+  box-shadow: 2px 0 5px -2px rgba(136, 136, 136, .3);
 }
 
 /* cell which have tooltips need to have a higher z-index on hover so that the tooltip appears above the other cells*/

--- a/packages/react-data-grid/style/rdg-cell.less
+++ b/packages/react-data-grid/style/rdg-cell.less
@@ -148,24 +148,21 @@
     background: red;
 }
 .rdg-child-row-btn {
-   position: absolute;
-   cursor: pointer;
-   height: 12px;
-   width: 12px;
-   border:1px solid grey;
-   border-radius:14px;
-   z-index: 2;
-   background: white;
+  cursor: pointer;
+  position: absolute;
+  top: calc(50% - 6px);
+  height: 12px;
+  width: 12px;
+  z-index: 2;
+  background: white;
 }
 
 .rdg-child-row-btn .MuiSvgIcon-root {
   font-size: 16px;
   color: grey;
   position: absolute;
-  top: 50%;
-  left: 50%;
-  margin-top: -8px;
-  margin-left: -8px;
+  top: calc(50% - 8px);
+  left: calc(50% - 8px);
 
   &:hover {
     color: red;


### PR DESCRIPTION
- `Row.getCells()` is now less wasteful:
  - Before: `columns.slice` * 2 + `.filter()` + `.concat()` + `.map()` = we create 5 arrays, not super efficient
  - After: we create 1 array, and we only loop through the columns once, up to `colOverscanEndIdx`, that's better, and should put less stress on the gc.
- We now render frozen cells before the non-frozen cells.