### PR TITLE
Add support for custom cell content renderers

### DIFF
--- a/examples/demos/example01-basic.js
+++ b/examples/demos/example01-basic.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DataGrid from 'react-data-grid';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
 
 const columns = [
@@ -18,6 +18,7 @@ export default function() {
         rowGetter={i => rows[i]}
         rowsCount={3}
         minHeight={150}
+        defaultCellContentRenderer={valueCellContentRenderer}
       />
     </Wrapper>
   );

--- a/examples/demos/example02-resizable-cols.js
+++ b/examples/demos/example02-resizable-cols.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DataGrid from 'react-data-grid';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
 
 export default class extends React.Component {
@@ -82,6 +82,7 @@ export default class extends React.Component {
           rowsCount={this._rows.length}
           minHeight={500}
           minColumnWidth={120}
+          defaultCellContentRenderer={valueCellContentRenderer}
         />
       </Wrapper>
     );

--- a/examples/demos/example03-frozen-cols.js
+++ b/examples/demos/example03-frozen-cols.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DataGrid from 'react-data-grid';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
 
 export default class extends React.Component {
@@ -90,7 +90,8 @@ export default class extends React.Component {
           columns={this._columns}
           rowGetter={this.rowGetter}
           rowsCount={this._rows.length}
-          minHeight={500}
+          minHeight={600}
+          defaultCellContentRenderer={valueCellContentRenderer}
         />
       </Wrapper>
     );

--- a/examples/demos/example04-editable.js
+++ b/examples/demos/example04-editable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DataGrid from 'react-data-grid';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import update from 'immutability-helper';
 import Wrapper from './Wrapper';
 
@@ -93,6 +93,7 @@ export default class extends React.Component {
           rowsCount={this.state.rows.length}
           minHeight={500}
           onGridRowsUpdated={this.handleGridRowsUpdated}
+          defaultCellContentRenderer={valueCellContentRenderer}
         />
       </Wrapper>
     );

--- a/examples/demos/example05-custom-formatters.js
+++ b/examples/demos/example05-custom-formatters.js
@@ -28,9 +28,10 @@ export default class extends React.Component {
         key: 'complete',
         name: '% Complete',
         cellContentRenderer(props) {
+          const value = props.rowData.complete;
           return (
             <>
-              <progress max={100} value={props.value} /> {props.value}%
+              <progress max={100} value={value} /> {value}%
             </>
           );
         }

--- a/examples/demos/example05-custom-formatters.js
+++ b/examples/demos/example05-custom-formatters.js
@@ -1,25 +1,6 @@
 import React from 'react';
-import DataGrid from 'react-data-grid';
-import PropTypes from 'prop-types';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
-
-// Custom Formatter component
-class PercentCompleteFormatter extends React.Component {
-  static propTypes = {
-    value: PropTypes.number.isRequired
-  };
-
-  render() {
-    const percentComplete = `${this.props.value}%`;
-    return (
-      <div className="progress">
-        <div className="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style={{ width: percentComplete }}>
-          {percentComplete}
-        </div>
-      </div>
-    );
-  }
-}
 
 export default class extends React.Component {
   constructor(props, context) {
@@ -46,7 +27,13 @@ export default class extends React.Component {
       {
         key: 'complete',
         name: '% Complete',
-        formatter: PercentCompleteFormatter
+        cellContentRenderer(props) {
+          return (
+            <>
+              <progress max={100} value={props.value} /> {props.value}%
+            </>
+          );
+        }
       },
       {
         key: 'startDate',
@@ -94,6 +81,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this._rows.length}
           minHeight={500}
+          defaultCellContentRenderer={valueCellContentRenderer}
         />
       </Wrapper>
     );

--- a/examples/demos/example11-immutable-data.js
+++ b/examples/demos/example11-immutable-data.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DataGrid from 'react-data-grid';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
 
 export default class extends React.Component {
@@ -47,6 +47,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={1200}
+          defaultCellContentRenderer={valueCellContentRenderer}
         />
       </Wrapper>
     );

--- a/examples/demos/example31-isScrolling.js
+++ b/examples/demos/example31-isScrolling.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import DataGrid from 'react-data-grid';
+import DataGrid, { valueCellContentRenderer } from 'react-data-grid';
 import { AreaChart, Area } from 'Recharts';
 import Wrapper from './Wrapper';
 
@@ -53,7 +53,7 @@ const createColumns = (numberCols) => [...Array(numberCols).keys()].map(i => {
     name: `col${i}`
   };
   if (i === 3) {
-    column.formatter = ExpensiveFormatter;
+    column.cellContentRenderer = () => <ExpensiveFormatter />;
     column.width = 500;
   }
   return column;
@@ -81,6 +81,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={800}
+          defaultCellContentRenderer={valueCellContentRenderer}
         />
       </Wrapper>
     );

--- a/examples/demos/example32-summary-rows.js
+++ b/examples/demos/example32-summary-rows.js
@@ -1,22 +1,22 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import DataGrid, { SelectColumn } from 'react-data-grid';
+import DataGrid, { SelectColumn, valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
 
-function DecimalFormatter({ value, isSummaryRow, maximumFractionDigits }) {
-  const text = value.toLocaleString('en-US', maximumFractionDigits == null ? { maximumFractionDigits: 2 } : { maximumFractionDigits: 0 });
+function formatDecimal({ value, isSummaryRow, maximumFractionDigits = 2 }) {
+  const text = value.toLocaleString('en-US', { maximumFractionDigits });
   return isSummaryRow ? <strong>{text}</strong> : <div>{text}</div>;
 }
 
-function IntegerFormatter(props) {
-  return <DecimalFormatter {...props} maximumFractionDigits={0} />;
+function formatInteger(props) {
+  return formatDecimal({ ...props, maximumFractionDigits: 0 });
 }
 
-function TitleFormatter({ value, row: { selectedRowsCount }, isSummaryRow }) {
+function formatTitle({ value, rowData: { selectedRowsCount }, isSummaryRow }) {
   if (isSummaryRow) {
     return <strong>{ selectedRowsCount >= 0 ? `${selectedRowsCount} row${selectedRowsCount > 1 ? 's' : ''} selected` : 'Total'}</strong>;
   }
 
-  return <div>{value}</div>;
+  return value;
 }
 
 const columns = [
@@ -31,7 +31,7 @@ const columns = [
     name: 'Title',
     width: 200,
     frozen: true,
-    formatter: TitleFormatter
+    cellContentRenderer: formatTitle
   },
   {
     key: 'priority',
@@ -62,19 +62,19 @@ const columns = [
     key: 'cost',
     name: 'Resource cost (USD)',
     width: 200,
-    formatter: DecimalFormatter
+    cellContentRenderer: formatDecimal
   },
   {
     key: 'hours',
     name: '# of working hours',
     width: 200,
-    formatter: IntegerFormatter
+    cellContentRenderer: formatInteger
   },
   {
     key: 'issueCount',
     name: '# of issues',
     width: 200,
-    formatter: IntegerFormatter
+    cellContentRenderer: formatInteger
   }
 ];
 
@@ -149,6 +149,7 @@ export default function Example() {
         minHeight={700}
         selectedRows={selectedRowIndexes}
         onSelectedRowsChange={setSelectedRowIndexes}
+        defaultCellContentRenderer={valueCellContentRenderer}
       />
       <div
         style={{

--- a/examples/demos/example32-summary-rows.js
+++ b/examples/demos/example32-summary-rows.js
@@ -2,21 +2,23 @@ import React, { useCallback, useMemo, useState } from 'react';
 import DataGrid, { SelectColumn, valueCellContentRenderer } from 'react-data-grid';
 import Wrapper from './Wrapper';
 
-function formatDecimal({ value, isSummaryRow, maximumFractionDigits = 2 }) {
+function formatDecimal({ column, rowData, isSummaryRow, maximumFractionDigits = 2 }) {
+  const value = rowData[column.key];
   const text = value.toLocaleString('en-US', { maximumFractionDigits });
-  return isSummaryRow ? <strong>{text}</strong> : <div>{text}</div>;
+  return isSummaryRow ? <strong>{text}</strong> : text;
 }
 
 function formatInteger(props) {
   return formatDecimal({ ...props, maximumFractionDigits: 0 });
 }
 
-function formatTitle({ value, rowData: { selectedRowsCount }, isSummaryRow }) {
+function formatTitle({ column, rowData, isSummaryRow }) {
   if (isSummaryRow) {
+    const { selectedRowsCount } = rowData;
     return <strong>{ selectedRowsCount >= 0 ? `${selectedRowsCount} row${selectedRowsCount > 1 ? 's' : ''} selected` : 'Total'}</strong>;
   }
 
-  return value;
+  return rowData[column.key];
 }
 
 const columns = [

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -1,9 +1,7 @@
 import React, { memo } from 'react';
 import classNames from 'classnames';
 
-import CellActions from './Cell/CellActions';
 import CellContent from './Cell/CellContent';
-import CellExpand from './Cell/CellExpander';
 import { CellRendererProps, ColumnEventInfo } from './common/types';
 import { isFrozen } from './utils/columnUtils';
 
@@ -11,12 +9,9 @@ export interface CellProps<R> extends CellRendererProps<R> {
   children?: React.ReactNode;
   // TODO: Check if these props are required or not. These are most likely set by custom cell renderer
   className?: string;
-  tooltip?: string | null;
-  cellControls?: unknown;
 }
 
 function Cell<R>({
-  cellControls,
   cellMetaData,
   children,
   className,
@@ -30,7 +25,6 @@ function Cell<R>({
   rowData,
   rowIdx,
   scrollLeft,
-  tooltip,
   value = ''
 }: CellProps<R>) {
   function handleCellClick() {
@@ -58,12 +52,6 @@ function Cell<R>({
     cellMetaData.onCellDoubleClick({ idx, rowIdx });
   }
 
-  function handleCellExpand() {
-    if (cellMetaData.onCellExpand) {
-      cellMetaData.onCellExpand({ rowIdx, idx, rowData, expandArgs: expandableOptions });
-    }
-  }
-
   function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault();
   }
@@ -89,7 +77,6 @@ function Cell<R>({
       className, {
         'rdg-cell-frozen': colIsFrozen,
         'rdg-cell-frozen-last': colIsFrozen && column.idx === lastFrozenColumnIndex,
-        'has-tooltip': !!tooltip,
         'rdg-child-cell': expandableOptions && expandableOptions.subRowDetails && expandableOptions.treeDepth > 0
       }
     );
@@ -137,6 +124,7 @@ function Cell<R>({
     return allEvents;
   }
 
+  // FIXME: is this property used?
   if (column.hidden) {
     return null;
   }
@@ -151,6 +139,7 @@ function Cell<R>({
           idx={idx}
           rowIdx={rowIdx}
           column={column}
+          cellMetaData={cellMetaData}
           rowData={rowData}
           value={value}
           expandableOptions={expandableOptions}
@@ -162,45 +151,26 @@ function Cell<R>({
     );
   }
 
-  const cellContent = children || (
-    <CellContent<R>
-      idx={idx}
-      rowIdx={rowIdx}
-      column={column}
-      rowData={rowData}
-      value={value}
-      tooltip={tooltip}
-      expandableOptions={expandableOptions}
-      onDeleteSubRow={cellMetaData.onDeleteSubRow}
-      cellControls={cellControls}
-      isRowSelected={isRowSelected}
-      onRowSelectionChange={onRowSelectionChange}
-      isSummaryRow={isSummaryRow}
-    />
-  );
-
-  const cellExpander = expandableOptions && expandableOptions.canExpand && (
-    <CellExpand
-      expanded={expandableOptions.expanded}
-      onCellExpand={handleCellExpand}
-    />
-  );
-
   return (
     <div
       className={getCellClass()}
       style={getStyle()}
       {...getEvents()}
     >
-      {cellMetaData.getCellActions && (
-        <CellActions<R>
+      {children || (
+        <CellContent<R>
+          idx={idx}
+          rowIdx={rowIdx}
           column={column}
           rowData={rowData}
-          getCellActions={cellMetaData.getCellActions}
+          value={value}
+          cellMetaData={cellMetaData}
+          expandableOptions={expandableOptions}
+          isRowSelected={isRowSelected}
+          onRowSelectionChange={onRowSelectionChange}
+          isSummaryRow={isSummaryRow}
         />
       )}
-      {cellExpander}
-      {cellContent}
     </div>
   );
 }

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -23,8 +23,7 @@ function Cell<R>({
   onRowSelectionChange,
   rowData,
   rowIdx,
-  scrollLeft,
-  value = ''
+  scrollLeft
 }: CellProps<R>) {
   function handleCellClick() {
     cellMetaData.onCellClick({ idx, rowIdx });
@@ -141,7 +140,6 @@ function Cell<R>({
         rowIdx,
         rowData,
         column,
-        value,
         cellMetaData,
         expandableOptions,
         isRowSelected,

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -54,32 +54,6 @@ function Cell<R>({
     e.preventDefault();
   }
 
-  function getStyle(): React.CSSProperties {
-    const style: React.CSSProperties = {
-      width: column.width,
-      left: column.left
-    };
-
-    if (scrollLeft !== undefined) {
-      style.transform = `translateX(${scrollLeft}px)`;
-    }
-
-    return style;
-  }
-
-  function getCellClass() {
-    const colIsFrozen = isFrozen(column);
-    return classNames(
-      column.cellClass,
-      'rdg-cell',
-      className, {
-        'rdg-cell-frozen': colIsFrozen,
-        'rdg-cell-frozen-last': colIsFrozen && column.idx === lastFrozenColumnIndex,
-        'rdg-child-cell': expandableOptions && expandableOptions.subRowDetails && expandableOptions.treeDepth > 0
-      }
-    );
-  }
-
   function getEvents() {
     if (isSummaryRow) return null;
 
@@ -124,10 +98,30 @@ function Cell<R>({
     return allEvents;
   }
 
+  const colIsFrozen = isFrozen(column);
+  className = classNames(
+    column.cellClass,
+    'rdg-cell',
+    className, {
+      'rdg-cell-frozen': colIsFrozen,
+      'rdg-cell-frozen-last': colIsFrozen && column.idx === lastFrozenColumnIndex,
+      'rdg-child-cell': expandableOptions && expandableOptions.subRowDetails && expandableOptions.treeDepth > 0
+    }
+  );
+
+  const style: React.CSSProperties = {
+    width: column.width,
+    left: column.left
+  };
+
+  if (scrollLeft !== undefined) {
+    style.transform = `translateX(${scrollLeft}px)`;
+  }
+
   return (
     <div
-      className={getCellClass()}
-      style={getStyle()}
+      className={className}
+      style={style}
       {...getEvents()}
     >
       {children || column.cellContentRenderer({

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -124,11 +124,6 @@ function Cell<R>({
     return allEvents;
   }
 
-  // FIXME: is this property used?
-  if (column.hidden) {
-    return null;
-  }
-
   return (
     <div
       className={getCellClass()}

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -1,13 +1,12 @@
 import React, { memo } from 'react';
 import classNames from 'classnames';
 
-import CellContent from './Cell/CellContent';
 import { CellRendererProps, ColumnEventInfo } from './common/types';
 import { isFrozen } from './utils/columnUtils';
 
 export interface CellProps<R> extends CellRendererProps<R> {
-  children?: React.ReactNode;
   // TODO: Check if these props are required or not. These are most likely set by custom cell renderer
+  children?: React.ReactNode;
   className?: string;
 }
 
@@ -83,6 +82,8 @@ function Cell<R>({
   }
 
   function getEvents() {
+    if (isSummaryRow) return null;
+
     const columnEvents = column.events;
     const allEvents: { [key: string]: Function } = {
       onClick: handleCellClick,
@@ -129,48 +130,24 @@ function Cell<R>({
     return null;
   }
 
-  if (isSummaryRow) {
-    return (
-      <div
-        className={getCellClass()}
-        style={getStyle()}
-      >
-        <CellContent<R>
-          idx={idx}
-          rowIdx={rowIdx}
-          column={column}
-          cellMetaData={cellMetaData}
-          rowData={rowData}
-          value={value}
-          expandableOptions={expandableOptions}
-          isRowSelected={false}
-          onRowSelectionChange={onRowSelectionChange}
-          isSummaryRow
-        />
-      </div>
-    );
-  }
-
   return (
     <div
       className={getCellClass()}
       style={getStyle()}
       {...getEvents()}
     >
-      {children || (
-        <CellContent<R>
-          idx={idx}
-          rowIdx={rowIdx}
-          column={column}
-          rowData={rowData}
-          value={value}
-          cellMetaData={cellMetaData}
-          expandableOptions={expandableOptions}
-          isRowSelected={isRowSelected}
-          onRowSelectionChange={onRowSelectionChange}
-          isSummaryRow={isSummaryRow}
-        />
-      )}
+      {children || column.cellContentRenderer({
+        idx,
+        rowIdx,
+        rowData,
+        column,
+        value,
+        cellMetaData,
+        expandableOptions,
+        isRowSelected,
+        onRowSelectionChange,
+        isSummaryRow
+      })}
     </div>
   );
 }

--- a/packages/react-data-grid/src/Cell/CellActions.tsx
+++ b/packages/react-data-grid/src/Cell/CellActions.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import { CellMetaData } from '../common/types';
 import CellAction from './CellAction';
-import { CellProps } from '../Cell';
+import { CellMetaData, CellContentRendererProps } from '../common/types';
 
-type CellActionsProps<R> = Pick<CellProps<R>, 'column' | 'rowData'> & Pick<Required<CellMetaData<R>>, 'getCellActions'>;
+type CellActionsProps<R> = Pick<CellContentRendererProps<R>, 'column' | 'rowData'> & Pick<Required<CellMetaData<R>>, 'getCellActions'>;
 
 export default function CellActions<R>({ getCellActions, column, rowData }: CellActionsProps<R>) {
   const cellActionButtons = getCellActions(column, rowData);

--- a/packages/react-data-grid/src/Cell/CellContent.tsx
+++ b/packages/react-data-grid/src/Cell/CellContent.tsx
@@ -12,7 +12,6 @@ export default function CellContent<R>({
   rowIdx,
   column,
   rowData,
-  value,
   cellMetaData,
   expandableOptions,
   isRowSelected,
@@ -36,8 +35,7 @@ export default function CellContent<R>({
 
   function getFormatterProps() {
     return {
-      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      value: value as any, //FIXME: fix value type
+      value: rowData[column.key],
       column,
       rowIdx,
       row: rowData,
@@ -46,6 +44,22 @@ export default function CellContent<R>({
       dependentValues: getFormatterDependencies(rowData),
       isSummaryRow
     };
+  }
+
+  function getFormattedValue(formatter: typeof column['formatter']) {
+    if (formatter === undefined) {
+      return <SimpleCellFormatter value={rowData[column.key] as unknown as string} />;
+    }
+
+    if (isValidElementType(formatter)) {
+      return createElement<ReturnType<typeof getFormatterProps>>(formatter, getFormatterProps());
+    }
+
+    if (isElement(formatter)) {
+      return cloneElement(formatter, getFormatterProps());
+    }
+
+    return null;
   }
 
   function handleDeleteSubRow() {
@@ -64,8 +78,6 @@ export default function CellContent<R>({
       cellMetaData.onCellExpand({ rowIdx, idx, rowData, expandArgs: expandableOptions });
     }
   }
-
-  const { formatter } = column;
 
   return (
     <>
@@ -91,13 +103,7 @@ export default function CellContent<R>({
           />
         )}
         <div style={style}>
-          {formatter === undefined
-            ? <SimpleCellFormatter value={value as string} />
-            : isValidElementType(formatter)
-              ? createElement(formatter, getFormatterProps())
-              : isElement(formatter)
-                ? cloneElement(formatter, getFormatterProps())
-                : null}
+          {getFormattedValue(column.formatter)}
         </div>
       </div>
     </>

--- a/packages/react-data-grid/src/Cell/CellContent.tsx
+++ b/packages/react-data-grid/src/Cell/CellContent.tsx
@@ -5,20 +5,7 @@ import CellActions from './CellActions';
 import CellExpand from './CellExpander';
 import { SimpleCellFormatter } from '../formatters';
 import ChildRowDeleteButton from '../ChildRowDeleteButton';
-import { CellProps } from '../Cell';
-
-export type CellContentProps<R> = Pick<CellProps<R>,
-| 'idx'
-| 'rowIdx'
-| 'rowData'
-| 'column'
-| 'value'
-| 'cellMetaData'
-| 'expandableOptions'
-| 'isRowSelected'
-| 'onRowSelectionChange'
-| 'isSummaryRow'
->;
+import { CellContentRendererProps } from '../common/types';
 
 export default function CellContent<R>({
   idx,
@@ -31,7 +18,7 @@ export default function CellContent<R>({
   isRowSelected,
   isSummaryRow,
   onRowSelectionChange
-}: CellContentProps<R>) {
+}: CellContentRendererProps<R>) {
   const isExpandCell = expandableOptions ? expandableOptions.field === column.key : false;
   const treeDepth = expandableOptions ? expandableOptions.treeDepth : 0;
   const style = expandableOptions && isExpandCell ? { marginLeft: expandableOptions.treeDepth * 30 } : undefined;

--- a/packages/react-data-grid/src/Cell/cellContentRenderers.tsx
+++ b/packages/react-data-grid/src/Cell/cellContentRenderers.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CellContent from './CellContent';
+import { CellContentRendererProps } from '../common/types';
+
+export function legacyCellContentRenderer<R>(props: CellContentRendererProps<R>) {
+  return props.isSummaryRow
+    ? <CellContent<R> {...props} isRowSelected={false} />
+    : <CellContent<R> {...props} />;
+}
+
+export function valueCellContentRenderer<R>(props: CellContentRendererProps<R>) {
+  return props.value;
+}

--- a/packages/react-data-grid/src/Cell/cellContentRenderers.tsx
+++ b/packages/react-data-grid/src/Cell/cellContentRenderers.tsx
@@ -7,5 +7,5 @@ export function legacyCellContentRenderer<R>(props: CellContentRendererProps<R>)
 }
 
 export function valueCellContentRenderer<R>(props: CellContentRendererProps<R>) {
-  return props.value;
+  return props.rowData[props.column.key];
 }

--- a/packages/react-data-grid/src/Cell/cellContentRenderers.tsx
+++ b/packages/react-data-grid/src/Cell/cellContentRenderers.tsx
@@ -3,9 +3,7 @@ import CellContent from './CellContent';
 import { CellContentRendererProps } from '../common/types';
 
 export function legacyCellContentRenderer<R>(props: CellContentRendererProps<R>) {
-  return props.isSummaryRow
-    ? <CellContent<R> {...props} isRowSelected={false} />
-    : <CellContent<R> {...props} />;
+  return React.createElement<CellContentRendererProps<R>>(CellContent, props);
 }
 
 export function valueCellContentRenderer<R>(props: CellContentRendererProps<R>) {

--- a/packages/react-data-grid/src/Columns.tsx
+++ b/packages/react-data-grid/src/Columns.tsx
@@ -1,31 +1,29 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { legacyCellContentRenderer } from './Cell/cellContentRenderers';
 import SelectCellFormatter from './formatters/SelectCellFormatter';
-import {
-  Column,
-  FormatterProps,
-  HeaderRowProps
-} from './common/types';
+import { Column } from './common/types';
 
 // TODO: fix type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const SelectColumn: Column<any> = {
   key: 'select-row',
   name: '',
   width: 60,
   filterable: false,
   frozen: true,
-  cellContentRenderer: legacyCellContentRenderer,
-  headerRenderer: (props: HeaderRowProps<any>) => (
-    <SelectCellFormatter
-      value={props.allRowsSelected}
-      onChange={props.onAllRowsSelectionChange}
-    />
-  ),
-  formatter: (props: FormatterProps<boolean>) => props.isSummaryRow ? null : (
-    <SelectCellFormatter
-      value={props.isRowSelected}
-      onChange={(value, isShiftClick) => props.onRowSelectionChange(props.rowIdx, props.row, value, isShiftClick)}
-    />
-  )
+  headerRenderer(props) {
+    return (
+      <SelectCellFormatter
+        value={props.allRowsSelected}
+        onChange={props.onAllRowsSelectionChange}
+      />
+    );
+  },
+  cellContentRenderer(props) {
+    return props.isSummaryRow ? null : (
+      <SelectCellFormatter
+        value={props.isRowSelected}
+        onChange={(value, isShiftClick) => props.onRowSelectionChange(props.rowIdx, props.rowData, value, isShiftClick)}
+      />
+    );
+  }
 };

--- a/packages/react-data-grid/src/Columns.tsx
+++ b/packages/react-data-grid/src/Columns.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
+import { legacyCellContentRenderer } from './Cell/cellContentRenderers';
 import SelectCellFormatter from './formatters/SelectCellFormatter';
 import {
   Column,
@@ -14,6 +15,7 @@ export const SelectColumn: Column<any> = {
   width: 60,
   filterable: false,
   frozen: true,
+  cellContentRenderer: legacyCellContentRenderer,
   headerRenderer: (props: HeaderRowProps<any>) => (
     <SelectCellFormatter
       value={props.allRowsSelected}

--- a/packages/react-data-grid/src/DataGrid.tsx
+++ b/packages/react-data-grid/src/DataGrid.tsx
@@ -12,6 +12,7 @@ import { isValidElementType } from 'react-is';
 
 import Header, { HeaderHandle } from './Header';
 import Canvas from './Canvas';
+import { legacyCellContentRenderer } from './Cell/cellContentRenderers';
 import { getColumnMetrics } from './utils/columnUtils';
 import EventBus from './EventBus';
 import { CellNavigationMode, EventTypes, UpdateActions, HeaderRowType, DEFINE_SORT } from './common/enums';
@@ -23,6 +24,7 @@ import {
   CellMetaData,
   CheckCellIsEditableEvent,
   Column,
+  CellContentRenderer,
   CommitEvent,
   GridRowsUpdatedEvent,
   HeaderRowData,
@@ -89,6 +91,7 @@ export interface DataGridProps<R, K extends keyof R> {
   rowKey?: K;
   /** The height of each row in pixels */
   rowHeight?: number;
+  defaultCellContentRenderer?: CellContentRenderer<R>;
   rowRenderer?: React.ReactElement | React.ComponentType<IRowRendererProps<R>>;
   rowGroupRenderer?: React.ComponentType;
   /** A function called for each rendered row that should return a plain key/value pair object */
@@ -175,6 +178,7 @@ function DataGrid<R, K extends keyof R>({
   cellNavigationMode = CellNavigationMode.NONE,
   editorPortalTarget = document.body,
   renderBatchSize = 8,
+  defaultCellContentRenderer = legacyCellContentRenderer,
   columns,
   rowsCount,
   rowGetter,
@@ -199,9 +203,10 @@ function DataGrid<R, K extends keyof R>({
       columns,
       minColumnWidth,
       viewportWidth,
-      columnWidths
+      columnWidths,
+      defaultCellContentRenderer
     });
-  }, [columnWidths, columns, minColumnWidth, viewportWidth]);
+  }, [columnWidths, columns, defaultCellContentRenderer, minColumnWidth, viewportWidth]);
 
   useLayoutEffect(() => {
     // Do not calculate the width if minWidth is provided
@@ -418,6 +423,7 @@ function DataGrid<R, K extends keyof R>({
             rowsCount={rowsCount}
             rowGetter={rowGetter}
             columnMetrics={columnMetrics}
+            defaultCellContentRenderer={defaultCellContentRenderer}
             onColumnResize={handleColumnResize}
             headerRows={headerRows}
             sortColumn={props.sortColumn}

--- a/packages/react-data-grid/src/Header.tsx
+++ b/packages/react-data-grid/src/Header.tsx
@@ -18,6 +18,7 @@ type SharedDataGridProps<R, K extends keyof R> = Pick<DataGridProps<R, K>,
 | 'sortDirection'
 > & Required<Pick<DataGridProps<R, K>,
 | 'rowKey'
+| 'defaultCellContentRenderer'
 >>;
 
 export interface HeaderProps<R, K extends keyof R> extends SharedDataGridProps<R, K> {
@@ -45,12 +46,13 @@ export default forwardRef(function Header<R, K extends keyof R>(props: HeaderPro
 
     return getColumnMetrics({
       ...props.columnMetrics,
+      defaultCellContentRenderer: props.defaultCellContentRenderer,
       columnWidths: new Map([
         ...props.columnMetrics.columnWidths,
         [resizing.column.key, resizing.width]
       ])
     });
-  }, [props.columnMetrics, resizing]);
+  }, [props.columnMetrics, props.defaultCellContentRenderer, resizing]);
 
   useImperativeHandle(ref, () => ({
     setScrollLeft(scrollLeft: number): void {

--- a/packages/react-data-grid/src/HeaderCell.tsx
+++ b/packages/react-data-grid/src/HeaderCell.tsx
@@ -10,7 +10,7 @@ function SimpleCellRenderer<R>({ column, rowType }: HeaderRowProps<R>) {
   return <>{headerText}</>;
 }
 
-interface Props<R> {
+export interface HeaderCellProps<R> {
   renderer?: React.ReactElement | React.ComponentType<HeaderRowProps<R>>;
   column: CalculatedColumn<R>;
   lastFrozenColumnIndex: number;
@@ -25,7 +25,7 @@ interface Props<R> {
   className?: string;
 }
 
-export default class HeaderCell<R> extends React.Component<Props<R>> {
+export default class HeaderCell<R> extends React.Component<HeaderCellProps<R>> {
   private readonly cell = React.createRef<HTMLDivElement>();
 
   private onMouseDown = (event: React.MouseEvent) => {

--- a/packages/react-data-grid/src/Row.tsx
+++ b/packages/react-data-grid/src/Row.tsx
@@ -63,7 +63,6 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
           column={column}
           lastFrozenColumnIndex={lastFrozenColumnIndex}
           cellMetaData={cellMetaData}
-          value={this.getCellValue(key || String(colIdx) as keyof R) as R[keyof R]} // FIXME: fix types
           rowData={row}
           expandableOptions={this.getExpandableOptions(key)}
           scrollLeft={colIsFrozen && typeof scrollLeft === 'number' ? scrollLeft : undefined}
@@ -75,15 +74,6 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
     }
 
     return cellElements;
-  }
-
-  getCellValue(key: keyof R) {
-    const { isRowSelected, row } = this.props;
-    if (key === 'select-row') {
-      return isRowSelected;
-    }
-
-    return row[key];
   }
 
   getExpandableOptions(columnKey: keyof R) {

--- a/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
@@ -7,21 +7,21 @@ import EventBus from '../EventBus';
 import { CellNavigationMode } from '../common/enums';
 import { CalculatedColumn } from '../common/types';
 import RowComponent from '../Row';
+import { valueCellContentRenderer } from '../Cell/cellContentRenderers';
 
 interface Row {
-  id?: number;
-  row?: string;
-  __metaData?: unknown;
+  id: number;
+  row: string;
 }
 
 const noop = () => null;
 
-const testProps: CanvasProps<Row, 'row'> = {
-  rowKey: 'row',
+const testProps: CanvasProps<Row, 'id'> = {
+  rowKey: 'id',
   rowHeight: 25,
   height: 200,
   rowsCount: 1,
-  rowGetter() { return {}; },
+  rowGetter(id) { return { id, row: String(id) }; },
   cellMetaData: {
     rowKey: 'row',
     onCellClick() { },
@@ -44,7 +44,14 @@ const testProps: CanvasProps<Row, 'row'> = {
   editorPortalTarget: document.body,
   onScroll() {},
   columnMetrics: {
-    columns: [{ key: 'id', name: 'ID', idx: 0, width: 100, left: 100 }],
+    columns: [{
+      key: 'row',
+      name: 'ID',
+      idx: 0,
+      width: 100,
+      left: 100,
+      cellContentRenderer: valueCellContentRenderer
+    }],
     columnWidths: new Map(),
     lastFrozenColumnIndex: -1,
     minColumnWidth: 80,
@@ -56,8 +63,8 @@ const testProps: CanvasProps<Row, 'row'> = {
   onCanvasKeyup() {}
 };
 
-function renderComponent(extraProps?: Partial<CanvasProps<Row, 'row'>>) {
-  return mount(<Canvas<Row, 'row'> {...testProps} {...extraProps} />);
+function renderComponent(extraProps?: Partial<CanvasProps<Row, 'id'>>) {
+  return mount(<Canvas<Row, 'id'> {...testProps} {...extraProps} />);
 }
 
 describe('Canvas Tests', () => {
@@ -75,10 +82,10 @@ describe('Canvas Tests', () => {
   describe('Row Selection', () => {
     it('renders row selected', () => {
       const wrapper = renderComponent({
-        rowGetter() { return { row: 'one' }; },
+        rowGetter(id) { return { id, row: 'one' }; },
         rowsCount: 1,
-        rowKey: 'row',
-        selectedRows: new Set(['one'])
+        rowKey: 'id',
+        selectedRows: new Set([0])
       });
 
       expect(wrapper.find(RowComponent).props().isRowSelected).toBe(true);
@@ -86,15 +93,23 @@ describe('Canvas Tests', () => {
   });
 
   describe('Tree View', () => {
-    const COLUMNS: CalculatedColumn<Row>[] = [{ idx: 0, key: 'id', name: 'ID', width: 100, left: 100 }];
+    const COLUMNS: CalculatedColumn<Row>[] = [{
+      idx: 0,
+      key: 'id',
+      name: 'ID',
+      width: 100,
+      left: 100,
+      cellContentRenderer: valueCellContentRenderer
+    }];
 
     it('can render a custom renderer if __metadata property exists', () => {
       const EmptyChildRow = (props: unknown, rowIdx: number) => {
         return <div key={rowIdx} className="test-row-renderer" />;
       };
 
-      const rowGetter = () => ({
-        id: 0,
+      const rowGetter = (id: number) => ({
+        id,
+        row: String(id),
         __metaData: {
           isGroup: false,
           treeDepth: 0,

--- a/packages/react-data-grid/src/__tests__/Cell.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Cell.spec.tsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import Cell, { CellProps } from '../Cell';
 import helpers, { Row } from './GridPropHelpers';
 import CellAction from '../Cell/CellAction';
+import { legacyCellContentRenderer } from '../Cell/cellContentRenderers';
 import { SimpleCellFormatter } from '../formatters';
 import { CalculatedColumn, CellMetaData } from '../common/types';
 
@@ -34,14 +35,20 @@ const expandableOptions = {
   }
 };
 
-const defaultColumn: CalculatedColumn<Row> = { idx: 0, key: 'description', name: 'Desciption', width: 100, left: 0 };
+const defaultColumn: CalculatedColumn<Row> = {
+  idx: 0,
+  key: 'description',
+  name: 'Desciption',
+  width: 100,
+  left: 0,
+  cellContentRenderer: legacyCellContentRenderer
+};
 
 const testProps: CellProps<Row> = {
   rowIdx: 0,
   idx: 1,
   column: defaultColumn,
   lastFrozenColumnIndex: -1,
-  value: 'Wicklow',
   cellMetaData: testCellMetaData,
   rowData: { id: 1, description: 'Wicklow' },
   isRowSelected: false,
@@ -89,7 +96,6 @@ describe('Cell Tests', () => {
       idx: 19,
       column: helpers.columns[0],
       lastFrozenColumnIndex: -1,
-      value: 'requiredValue',
       cellMetaData: testCellMetaData,
       rowData: helpers.rowGetter(11),
       expandableOptions,
@@ -123,7 +129,6 @@ describe('Cell Tests', () => {
         idx: 19,
         column: helpers.columns[0],
         lastFrozenColumnIndex: -1,
-        value: 'requiredValue',
         cellMetaData: testCellMetaData,
         rowData: helpers.rowGetter(11),
         expandableOptions,
@@ -153,7 +158,7 @@ describe('Cell Tests', () => {
 
         const renderedCellActions = wrapper.find(CellAction);
 
-        expect(renderedCellActions.length).toBe(1);
+        expect(renderedCellActions).toHaveLength(1);
         expect(renderedCellActions.props()).toEqual({
           ...action,
           isFirst: true
@@ -164,10 +169,7 @@ describe('Cell Tests', () => {
     describe('when getCellActions is not in cellMetadata', () => {
       it('should not render any CellActions', () => {
         const { wrapper } = setup();
-
-        const renderedCellActions = wrapper.find(CellAction);
-
-        expect(renderedCellActions.length).toBe(0);
+        expect(wrapper.find(CellAction)).toHaveLength(0);
       });
     });
   });

--- a/packages/react-data-grid/src/__tests__/GridPropHelpers.ts
+++ b/packages/react-data-grid/src/__tests__/GridPropHelpers.ts
@@ -1,3 +1,4 @@
+import { valueCellContentRenderer, legacyCellContentRenderer } from '../Cell/cellContentRenderers';
 import { CalculatedColumn, CellMetaData } from '../common/types';
 
 export interface Row {
@@ -12,19 +13,22 @@ const columns: CalculatedColumn<Row>[] = [{
   key: 'id',
   name: 'ID',
   width: 100,
-  left: 0
+  left: 0,
+  cellContentRenderer: legacyCellContentRenderer
 }, {
   idx: 1,
   key: 'title',
   name: 'Title',
   width: 100,
-  left: 100
+  left: 100,
+  cellContentRenderer: valueCellContentRenderer
 }, {
   idx: 2,
   key: 'count',
   name: 'Count',
   width: 100,
-  left: 200
+  left: 200,
+  cellContentRenderer: valueCellContentRenderer
 }];
 
 const _rows: Row[] = [];

--- a/packages/react-data-grid/src/__tests__/Header.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Header.spec.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 
 import Header, { HeaderProps } from '../Header';
 import HeaderRow from '../HeaderRow';
+import { valueCellContentRenderer } from '../Cell/cellContentRenderers';
 import helpers, { fakeCellMetaData, Row } from './GridPropHelpers';
 import * as utils from '../utils';
 import { HeaderRowType, DEFINE_SORT } from '../common/enums';
@@ -33,7 +34,8 @@ describe('Header Unit Tests', () => {
       onColumnResize: jest.fn(),
       onSort: () => null,
       onHeaderDrop() { },
-      draggableHeaderCell: () => null
+      draggableHeaderCell: () => null,
+      defaultCellContentRenderer: valueCellContentRenderer
     };
   }
 
@@ -87,7 +89,8 @@ describe('Header Unit Tests', () => {
       onHeaderDrop() { },
       cellMetaData: fakeCellMetaData,
       draggableHeaderCell: () => null,
-      onColumnResize() { }
+      onColumnResize() { },
+      defaultCellContentRenderer: valueCellContentRenderer
     };
     const testAllProps: HeaderProps<Row, 'id'> = {
       rowKey: 'id',
@@ -114,7 +117,8 @@ describe('Header Unit Tests', () => {
       draggableHeaderCell: jest.fn(),
       getValidFilterValues: jest.fn(),
       cellMetaData: fakeCellMetaData,
-      onHeaderDrop() { }
+      onHeaderDrop() { },
+      defaultCellContentRenderer: valueCellContentRenderer
     };
     it('passes classname property', () => {
       const wrapper = renderComponent(testAllProps);

--- a/packages/react-data-grid/src/__tests__/HeaderCell.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/HeaderCell.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import HeaderCell from '../HeaderCell';
+import HeaderCell, { HeaderCellProps } from '../HeaderCell';
+import { valueCellContentRenderer } from '../Cell/cellContentRenderers';
 import { HeaderRowType } from '../common/enums';
 
 interface Row {
@@ -14,13 +15,14 @@ describe('Header Cell Tests', () => {
   }
 
   function setup(overrideProps = {}, columnProps = {}) {
-    const props = {
+    const props: HeaderCellProps<Row> = {
       column: {
         idx: 0,
         key: 'bla',
         name: 'bla',
         width: 150,
         left: 300,
+        cellContentRenderer: valueCellContentRenderer,
         ...columnProps
       },
       lastFrozenColumnIndex: -1,
@@ -28,14 +30,13 @@ describe('Header Cell Tests', () => {
       onResize: jest.fn(),
       onResizeEnd: jest.fn(),
       height: 50,
-      name: 'bla',
       onHeaderDrop() { },
       draggableHeaderCell: DraggableHeaderCell,
       allRowsSelected: false,
       onAllRowsSelectionChange() {},
       ...overrideProps
     };
-    const wrapper = mount<HeaderCell<Row>>(<HeaderCell {...props} />);
+    const wrapper = mount<HeaderCell<Row>>(<HeaderCell<Row> {...props} />);
     return { wrapper, props };
   }
 

--- a/packages/react-data-grid/src/__tests__/utils/index.ts
+++ b/packages/react-data-grid/src/__tests__/utils/index.ts
@@ -1,6 +1,7 @@
+import { valueCellContentRenderer } from '../../Cell/cellContentRenderers';
 import { CalculatedColumn } from '../../common/types';
 
-function createColumn(index: number): CalculatedColumn<{ [key: string]: unknown }> {
+function createColumn(index: number): CalculatedColumn<{ [key: string]: React.ReactNode }> {
   const key = `Column${index}`;
   return {
     key,
@@ -8,11 +9,12 @@ function createColumn(index: number): CalculatedColumn<{ [key: string]: unknown 
     editable: true,
     idx: index,
     width: 100,
-    left: 100 * index
+    left: 100 * index,
+    cellContentRenderer: valueCellContentRenderer
   };
 }
 
-export const createColumns = (count: number): CalculatedColumn<{ [key: string]: unknown }>[] =>
+export const createColumns = (count: number): CalculatedColumn<{ [key: string]: React.ReactNode }>[] =>
   Array(count).fill(null).map((_, i) => createColumn(i));
 
 export const sel = (id: string): string => `[data-test="${id}"]`;

--- a/packages/react-data-grid/src/common/cells/headerCells/__tests__/SortableHeaderCell.spec.tsx
+++ b/packages/react-data-grid/src/common/cells/headerCells/__tests__/SortableHeaderCell.spec.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import SortableHeaderCell, { Props } from '../SortableHeaderCell';
 import { HeaderRowType, DEFINE_SORT } from '../../../enums';
 import { Column } from '../../../types';
+import { valueCellContentRenderer } from '../../../../Cell/cellContentRenderers';
 
 interface Row { col1: string }
 
@@ -15,6 +16,7 @@ describe('<SortableHeaderCell/>', () => {
         key: 'col1',
         width: 100,
         left: 0,
+        cellContentRenderer: valueCellContentRenderer,
         ...overrideColumn
       },
       rowType: HeaderRowType.HEADER,

--- a/packages/react-data-grid/src/common/editors/__tests__/EditorContainer.spec.tsx
+++ b/packages/react-data-grid/src/common/editors/__tests__/EditorContainer.spec.tsx
@@ -4,6 +4,7 @@ import { mount, MountRendererProps } from 'enzyme';
 
 import EditorContainer, { Props } from '../EditorContainer';
 import SimpleTextEditor from '../SimpleTextEditor';
+import { valueCellContentRenderer } from '../../../Cell/cellContentRenderers';
 import { CalculatedColumn, EditorProps } from '../../types';
 
 interface Row {
@@ -39,7 +40,8 @@ const fakeColumn: CalculatedColumn<Row> = {
   name: 'col1',
   key: 'col1',
   width: 100,
-  left: 0
+  left: 0,
+  cellContentRenderer: valueCellContentRenderer
 };
 
 const setup = (extraProps?: Partial<Props<Row, 'id'>>, opts?: MountRendererProps) => {

--- a/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.tsx
+++ b/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import SimpleTextEditor from '../SimpleTextEditor';
+import { valueCellContentRenderer } from '../../../Cell/cellContentRenderers';
 import { CalculatedColumn } from '../../types';
 
 interface Row { text: string }
@@ -12,7 +13,8 @@ describe('SimpleTextEditor', () => {
       key: 'text',
       name: 'name',
       width: 0,
-      left: 0
+      left: 0,
+      cellContentRenderer: valueCellContentRenderer
     };
     function fakeBlurCb() { return true; }
 

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -150,10 +150,9 @@ export interface HeaderRowProps<TRow> {
   onAllRowsSelectionChange(checked: boolean): void;
 }
 
-export interface CellRendererProps<TRow, TValue = unknown> {
+export interface CellRendererProps<TRow> {
   idx: number;
   rowIdx: number;
-  value: TValue;
   column: CalculatedColumn<TRow>;
   lastFrozenColumnIndex: number;
   rowData: TRow;
@@ -172,7 +171,6 @@ export type CellContentRendererProps<TRow> = Pick<CellRendererProps<TRow>,
 | 'rowIdx'
 | 'rowData'
 | 'column'
-| 'value'
 | 'cellMetaData'
 | 'expandableOptions'
 | 'isRowSelected'

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -17,6 +17,7 @@ interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow
   events?: {
     [key: string]: undefined | ((e: Event, info: ColumnEventInfo<TRow>) => void);
   };
+  cellContentRenderer?: CellContentRenderer<TRow>;
   /** Formatter to be used to render the cell content */
   formatter?: React.ReactElement | React.ComponentType<FormatterProps<TRow[TField], TDependentValue, TRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
@@ -52,6 +53,7 @@ export type CalculatedColumn<TRow, TDependentValue = unknown, TField extends key
     idx: number;
     width: number;
     left: number;
+    cellContentRenderer: CellContentRenderer<TRow>;
   };
 
 export interface ColumnMetrics<TRow> {
@@ -162,6 +164,21 @@ export interface CellRendererProps<TRow, TValue = unknown> {
   isRowSelected: boolean;
   onRowSelectionChange(rowIdx: number, row: TRow, checked: boolean, isShiftClick: boolean): void;
 }
+
+export type CellContentRenderer<TRow> = (props: CellContentRendererProps<TRow>) => React.ReactChild;
+
+export type CellContentRendererProps<TRow> = Pick<CellRendererProps<TRow>,
+| 'idx'
+| 'rowIdx'
+| 'rowData'
+| 'column'
+| 'value'
+| 'cellMetaData'
+| 'expandableOptions'
+| 'isRowSelected'
+| 'onRowSelectionChange'
+| 'isSummaryRow'
+>;
 
 export interface RowsContainerProps {
   id: string;

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -11,7 +11,6 @@ interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow
   key: TField;
   /** Column width. If not specified, it will be determined automatically based on grid width and specified widths of other columns*/
   width?: number;
-  hidden?: boolean;
   cellClass?: string;
   /** By adding an event object with callbacks for the native react events you can bind events to a specific column. That will not break the default behaviour of the grid and will run only for the specified column */
   events?: {

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -165,7 +165,7 @@ export interface CellRendererProps<TRow, TValue = unknown> {
   onRowSelectionChange(rowIdx: number, row: TRow, checked: boolean, isShiftClick: boolean): void;
 }
 
-export type CellContentRenderer<TRow> = (props: CellContentRendererProps<TRow>) => React.ReactChild;
+export type CellContentRenderer<TRow> = (props: CellContentRendererProps<TRow>) => React.ReactNode;
 
 export type CellContentRendererProps<TRow> = Pick<CellRendererProps<TRow>,
 | 'idx'

--- a/packages/react-data-grid/src/index.ts
+++ b/packages/react-data-grid/src/index.ts
@@ -3,6 +3,7 @@ export { default as Cell } from './Cell';
 export { default as Row } from './Row';
 export { default as HeaderCell } from './HeaderCell';
 export * from './Columns';
+export * from './Cell/cellContentRenderers';
 export * from './formatters';
 export * from './common/editors';
 export * from './common/enums';

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
@@ -18,7 +18,7 @@ const ROWS_COUNT = 5;
 const columns = createColumns(NUMBER_OF_COLUMNS);
 
 interface Row {
-  [key: string]: unknown;
+  [key: string]: React.ReactNode;
 }
 
 describe('<InteractionMasks/>', () => {

--- a/packages/react-data-grid/src/utils/__tests__/columnMetrics.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/columnMetrics.spec.ts
@@ -1,4 +1,5 @@
 import { getColumnMetrics } from '../columnUtils';
+import { valueCellContentRenderer } from '../../Cell/cellContentRenderers';
 import { Column } from '../../common/types';
 
 interface Row {
@@ -28,7 +29,13 @@ describe('Column Metrics Tests', () => {
 
       it('should set the unset column widths based on the total width', () => {
         const columns = getInitialColumns();
-        const metrics = getColumnMetrics({ columns, viewportWidth, minColumnWidth: 50, columnWidths: new Map() });
+        const metrics = getColumnMetrics({
+          columns,
+          viewportWidth,
+          minColumnWidth: 50,
+          columnWidths: new Map(),
+          defaultCellContentRenderer: valueCellContentRenderer
+        });
 
         expect(metrics.columns[0].width).toEqual(60);
         expect(metrics.columns[1].width).toEqual(120);
@@ -37,7 +44,13 @@ describe('Column Metrics Tests', () => {
 
       it('should set the column left based on the column widths', () => {
         const columns = getInitialColumns();
-        const metrics = getColumnMetrics({ columns, viewportWidth, minColumnWidth: 50, columnWidths: new Map() });
+        const metrics = getColumnMetrics({
+          columns,
+          viewportWidth,
+          minColumnWidth: 50,
+          columnWidths: new Map(),
+          defaultCellContentRenderer: valueCellContentRenderer
+        });
 
         expect(metrics.columns[0].left).toEqual(0);
         expect(metrics.columns[1].left).toEqual(columns[0].width);
@@ -50,7 +63,13 @@ describe('Column Metrics Tests', () => {
         const thirdFrozenColumn: Column<Row> = { key: 'frozenColumn3', name: 'frozenColumn3', frozen: true };
         const columns = [...getInitialColumns(), secondFrozenColumn, thirdFrozenColumn];
         columns.splice(2, 0, firstFrozenColumn);
-        const metrics = getColumnMetrics({ columns, viewportWidth, minColumnWidth: 50, columnWidths: new Map() });
+        const metrics = getColumnMetrics({
+          columns,
+          viewportWidth,
+          minColumnWidth: 50,
+          columnWidths: new Map(),
+          defaultCellContentRenderer: valueCellContentRenderer
+        });
         expect(metrics.columns[0]).toMatchObject(firstFrozenColumn);
         expect(metrics.columns[1]).toMatchObject(secondFrozenColumn);
         expect(metrics.columns[2]).toMatchObject(thirdFrozenColumn);

--- a/packages/react-data-grid/src/utils/__tests__/columnUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/columnUtils.spec.ts
@@ -1,4 +1,5 @@
 import { canEdit } from '../columnUtils';
+import { valueCellContentRenderer } from '../../Cell/cellContentRenderers';
 import { CalculatedColumn, Omit } from '../../common/types';
 
 interface Row {
@@ -16,7 +17,8 @@ describe('ColumnUtils tests', () => {
       left: 460,
       name: 'Adserver Placement Type',
       resizable: true,
-      width: 150
+      width: 150,
+      cellContentRenderer: valueCellContentRenderer
     };
 
     return {

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
@@ -3,10 +3,11 @@ import {
   getHorizontalRangeToRender,
   HorizontalRangeToRenderParams
 } from '../viewportUtils';
+import { valueCellContentRenderer } from '../../Cell/cellContentRenderers';
 import { ColumnMetrics } from '../../common/types';
 
 interface Row {
-  [key: string]: unknown;
+  [key: string]: React.ReactNode;
 }
 
 interface VerticalRangeToRenderParams {
@@ -69,7 +70,14 @@ describe('viewportUtils', () => {
 
   describe('getHorizontalRangeToRender', () => {
     function getColumnMetrics(): ColumnMetrics<Row> {
-      const columns = [...Array(500).keys()].map(i => ({ idx: i, key: `col${i}`, name: `col${i}`, width: 100, left: i * 100 }));
+      const columns = [...Array(500).keys()].map(i => ({
+        idx: i,
+        key: `col${i}`,
+        name: `col${i}`,
+        width: 100,
+        left: i * 100,
+        cellContentRenderer: valueCellContentRenderer
+      }));
       return {
         columns,
         viewportWidth: 1000,

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -1,8 +1,9 @@
-import { Column, CalculatedColumn, ColumnMetrics } from '../common/types';
+import { Column, CalculatedColumn, ColumnMetrics, CellContentRenderer } from '../common/types';
 import { getScrollbarSize } from './domUtils';
 
 type Metrics<R> = Pick<ColumnMetrics<R>, 'viewportWidth' | 'minColumnWidth' | 'columnWidths'> & {
   columns: Column<R>[];
+  defaultCellContentRenderer: CellContentRenderer<R>;
 };
 
 export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
@@ -24,7 +25,8 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
       ...column,
       idx: 0,
       width,
-      left
+      left,
+      cellContentRenderer: column.cellContentRenderer || metrics.defaultCellContentRenderer
     };
     totalWidth += width;
     left += width;

--- a/packages/react-data-grid/style/rdg-cell.less
+++ b/packages/react-data-grid/style/rdg-cell.less
@@ -16,10 +16,6 @@
   /* Should have a higher value than 1 to show in front of cell masks */
   z-index: 2;
 
-  &.has-tooltip:hover {
-    z-index: 3
-  }
-
   @supports (position: sticky) or (position: -webkit-sticky) {
     & {
       position: -webkit-sticky;
@@ -30,11 +26,6 @@
 
 .rdg-cell-frozen-last {
   box-shadow: 2px 0 5px -2px rgba(136, 136, 136, .3);
-}
-
-/* cell which have tooltips need to have a higher z-index on hover so that the tooltip appears above the other cells*/
-.rdg-cell.has-tooltip:hover {
-  z-index: 1;
 }
 
 .react-contextmenu--visible {
@@ -74,39 +65,6 @@
 
 .rdg-cell-value .btn-sm {
   padding: 0;
-}
-
-.rdg-cell-tooltip .rdg-cell-tooltip-text {
-    white-space: normal;
-    visibility: hidden;
-    width: 150px;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: absolute;
-    top: 50%;
-    bottom: initial;
-    left: 50%;
-    margin-top: 15px;
-    margin-left: -75px
-}
-
-.rdg-cell-tooltip:hover .rdg-cell-tooltip-text {
-    visibility: visible;
-    opacity: 0.8;
-}
-
-.rdg-cell-tooltip .rdg-cell-tooltip-text::after {
-    content: " ";
-    position: absolute;
-    bottom: 100%;  /* At the top of the tooltip */
-    left: 50%;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent black transparent;
 }
 
 .rdg-cell-expand {


### PR DESCRIPTION
- Main info in here: https://gist.github.com/MayhemYDG/090298c3c2d94324cb332c33d82fdcfb
- Custom cell content rendering is an opt-in feature, so it shouldn't break anything.
- Removed handling the `value` in `Row`/`Cell`, it's now handled within cell content renderers, which makes types a bit easier to deal with.
- Removed `cellControls` prop from `Cell`, which doesn't seem to be an actually used feature
- Removed `tooltip` prop from `Cell`, custom cell content renderers should just implement this themselves. We can add it back if needed.
- I want to remove the `children` prop from `Cell` as well, I think it's only used for custom cell renderers that wrap `Cell`. WDYT?