### PR TITLE
Resize the all the cells when resizing a column

### DIFF
--- a/packages/react-data-grid/src/DataGrid.tsx
+++ b/packages/react-data-grid/src/DataGrid.tsx
@@ -245,14 +245,14 @@ function DataGrid<R, K extends keyof R>({
     return columnMetrics!.columns[idx];
   }
 
-  function handleColumnResize(idx: number, width: number) {
+  function handleColumnResize(column: CalculatedColumn<R>, width: number) {
     const newColumnWidths = new Map(columnWidths);
-    const columnKey = getColumn(idx).key;
-    newColumnWidths.set(columnKey, width);
+    width = Math.max(width, minColumnWidth);
+    newColumnWidths.set(column.key, width);
     setColumnWidths(newColumnWidths);
 
     if (props.onColumnResize) {
-      props.onColumnResize(idx, width);
+      props.onColumnResize(column.idx, width);
     }
   }
 
@@ -423,7 +423,6 @@ function DataGrid<R, K extends keyof R>({
             rowsCount={rowsCount}
             rowGetter={rowGetter}
             columnMetrics={columnMetrics}
-            defaultCellContentRenderer={defaultCellContentRenderer}
             onColumnResize={handleColumnResize}
             headerRows={headerRows}
             sortColumn={props.sortColumn}

--- a/packages/react-data-grid/src/HeaderCell.tsx
+++ b/packages/react-data-grid/src/HeaderCell.tsx
@@ -17,7 +17,6 @@ export interface HeaderCellProps<R> {
   rowType: HeaderRowType;
   height: number;
   onResize(column: CalculatedColumn<R>, width: number): void;
-  onResizeEnd(): void;
   onHeaderDrop?(): void;
   allRowsSelected: boolean;
   onAllRowsSelectionChange(checked: boolean): void;
@@ -47,7 +46,6 @@ export default class HeaderCell<R> extends React.Component<HeaderCellProps<R>> {
     const onMouseUp = () => {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
-      this.props.onResizeEnd();
     };
 
     event.preventDefault();
@@ -84,7 +82,6 @@ export default class HeaderCell<R> extends React.Component<HeaderCellProps<R>> {
       if (!touch) return;
       window.removeEventListener('touchmove', onTouchMove);
       window.removeEventListener('touchend', onTouchEnd);
-      this.props.onResizeEnd();
     };
 
     window.addEventListener('touchmove', onTouchMove);
@@ -92,12 +89,9 @@ export default class HeaderCell<R> extends React.Component<HeaderCellProps<R>> {
   };
 
   private onResize(x: number) {
-    const { onResize } = this.props;
-    if (onResize) {
-      const width = this.getWidthFromMouseEvent(x);
-      if (width > 0) {
-        onResize(this.props.column, width);
-      }
+    const width = this.getWidthFromMouseEvent(x);
+    if (width > 0) {
+      this.props.onResize(this.props.column, width);
     }
   }
 

--- a/packages/react-data-grid/src/HeaderRow.tsx
+++ b/packages/react-data-grid/src/HeaderRow.tsx
@@ -25,7 +25,6 @@ export interface HeaderRowProps<R, K extends keyof R> extends SharedHeaderProps<
   columns: CalculatedColumn<R>[];
   lastFrozenColumnIndex: number;
   onColumnResize(column: CalculatedColumn<R>, width: number): void;
-  onColumnResizeEnd(): void;
   onAllRowsSelectionChange(checked: boolean): void;
   filterable?: boolean;
   onFilterChange?(args: AddFilterEvent<R>): void;
@@ -112,7 +111,6 @@ export default class HeaderRow<R, K extends keyof R> extends React.Component<Hea
           height={this.props.height}
           renderer={renderer}
           onResize={this.props.onColumnResize}
-          onResizeEnd={this.props.onColumnResizeEnd}
           onHeaderDrop={this.props.onHeaderDrop}
           allRowsSelected={this.props.allRowsSelected}
           onAllRowsSelectionChange={this.props.onAllRowsSelectionChange}

--- a/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
@@ -52,7 +52,6 @@ const testProps: CanvasProps<Row, 'id'> = {
       left: 100,
       cellContentRenderer: valueCellContentRenderer
     }],
-    columnWidths: new Map(),
     lastFrozenColumnIndex: -1,
     totalColumnWidth: 0,
     viewportWidth: 1000

--- a/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Canvas.spec.tsx
@@ -54,7 +54,6 @@ const testProps: CanvasProps<Row, 'id'> = {
     }],
     columnWidths: new Map(),
     lastFrozenColumnIndex: -1,
-    minColumnWidth: 80,
     totalColumnWidth: 0,
     viewportWidth: 1000
   },

--- a/packages/react-data-grid/src/__tests__/Header.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Header.spec.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import Header, { HeaderProps } from '../Header';
-import HeaderRow from '../HeaderRow';
-import { valueCellContentRenderer } from '../Cell/cellContentRenderers';
+import HeaderRow, { HeaderRowProps } from '../HeaderRow';
 import helpers, { fakeCellMetaData, Row } from './GridPropHelpers';
 import * as utils from '../utils';
 import { HeaderRowType, DEFINE_SORT } from '../common/enums';
@@ -19,7 +18,6 @@ describe('Header Unit Tests', () => {
       allRowsSelected: false,
       columnMetrics: {
         columns: helpers.columns,
-        minColumnWidth: 80,
         totalColumnWidth: 2600,
         viewportWidth: 2600,
         lastFrozenColumnIndex: 0,
@@ -34,8 +32,7 @@ describe('Header Unit Tests', () => {
       onColumnResize: jest.fn(),
       onSort: () => null,
       onHeaderDrop() { },
-      draggableHeaderCell: () => null,
-      defaultCellContentRenderer: valueCellContentRenderer
+      draggableHeaderCell: () => null
     };
   }
 
@@ -56,11 +53,11 @@ describe('Header Unit Tests', () => {
   it('header row drag end should trigger onColumnResize callback', () => {
     const resizeColIdx = 1;
     const testProps = getProps();
-    const wrapper = shallow(<Header {...testProps} />);
-    wrapper.find(HeaderRow).props().onColumnResize(helpers.columns[resizeColIdx] as never, 200);
-    wrapper.find(HeaderRow).props().onColumnResizeEnd();
+    const wrapper = shallow(<Header<Row, 'id'> {...testProps} />);
+    const col = helpers.columns[resizeColIdx];
+    wrapper.find<HeaderRowProps<Row, 'id'>>(HeaderRow).props().onColumnResize(col, 200);
     expect(testProps.onColumnResize).toHaveBeenCalled();
-    expect(testProps.onColumnResize).toHaveBeenCalledWith(resizeColIdx, 200);
+    expect(testProps.onColumnResize).toHaveBeenCalledWith(col, 200);
   });
 
   describe('Rendering Header component', () => {
@@ -74,7 +71,6 @@ describe('Header Unit Tests', () => {
       allRowsSelected: false,
       columnMetrics: {
         columns: helpers.columns,
-        minColumnWidth: 81,
         totalColumnWidth: 2600,
         viewportWidth: 2600,
         lastFrozenColumnIndex: 0,
@@ -89,8 +85,7 @@ describe('Header Unit Tests', () => {
       onHeaderDrop() { },
       cellMetaData: fakeCellMetaData,
       draggableHeaderCell: () => null,
-      onColumnResize() { },
-      defaultCellContentRenderer: valueCellContentRenderer
+      onColumnResize() { }
     };
     const testAllProps: HeaderProps<Row, 'id'> = {
       rowKey: 'id',
@@ -99,7 +94,6 @@ describe('Header Unit Tests', () => {
       allRowsSelected: false,
       columnMetrics: {
         columns: helpers.columns,
-        minColumnWidth: 80,
         totalColumnWidth: 2600,
         viewportWidth: 2600,
         lastFrozenColumnIndex: 0,
@@ -117,8 +111,7 @@ describe('Header Unit Tests', () => {
       draggableHeaderCell: jest.fn(),
       getValidFilterValues: jest.fn(),
       cellMetaData: fakeCellMetaData,
-      onHeaderDrop() { },
-      defaultCellContentRenderer: valueCellContentRenderer
+      onHeaderDrop() { }
     };
     it('passes classname property', () => {
       const wrapper = renderComponent(testAllProps);

--- a/packages/react-data-grid/src/__tests__/Header.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/Header.spec.tsx
@@ -20,8 +20,7 @@ describe('Header Unit Tests', () => {
         columns: helpers.columns,
         totalColumnWidth: 2600,
         viewportWidth: 2600,
-        lastFrozenColumnIndex: 0,
-        columnWidths: new Map()
+        lastFrozenColumnIndex: 0
       },
       cellMetaData: fakeCellMetaData,
       headerRows: [{
@@ -73,8 +72,7 @@ describe('Header Unit Tests', () => {
         columns: helpers.columns,
         totalColumnWidth: 2600,
         viewportWidth: 2600,
-        lastFrozenColumnIndex: 0,
-        columnWidths: new Map()
+        lastFrozenColumnIndex: 0
       },
       headerRows: [{
         height: 51,
@@ -96,8 +94,7 @@ describe('Header Unit Tests', () => {
         columns: helpers.columns,
         totalColumnWidth: 2600,
         viewportWidth: 2600,
-        lastFrozenColumnIndex: 0,
-        columnWidths: new Map()
+        lastFrozenColumnIndex: 0
       },
       headerRows: [{
         height: 50,

--- a/packages/react-data-grid/src/__tests__/HeaderCell.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/HeaderCell.spec.tsx
@@ -28,7 +28,6 @@ describe('Header Cell Tests', () => {
       lastFrozenColumnIndex: -1,
       rowType: HeaderRowType.HEADER,
       onResize: jest.fn(),
-      onResizeEnd: jest.fn(),
       height: 50,
       onHeaderDrop() { },
       draggableHeaderCell: DraggableHeaderCell,
@@ -54,13 +53,6 @@ describe('Header Cell Tests', () => {
       wrapper.simulate('mousedown', { button: 0, clientX: 0 });
       window.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }));
       expect(props.onResize).toHaveBeenCalledWith(props.column, 200);
-    });
-
-    it('finish dragging should call onResizeEnd with no params', () => {
-      const { wrapper, props } = setup({}, { resizable: true });
-      wrapper.simulate('mousedown', { button: 0, clientX: 0 });
-      window.dispatchEvent(new MouseEvent('mouseup', { clientX: 250 }));
-      expect(props.onResizeEnd).toHaveBeenCalledWith();
     });
   });
 

--- a/packages/react-data-grid/src/__tests__/HeaderRow.spec.tsx
+++ b/packages/react-data-grid/src/__tests__/HeaderRow.spec.tsx
@@ -141,7 +141,6 @@ describe('Header Row Unit Tests', () => {
       allRowsSelected: false,
       onAllRowsSelectionChange() {},
       onColumnResize: jest.fn(),
-      onColumnResizeEnd: jest.fn(),
       onFilterChange() { },
       onHeaderDrop() { },
       draggableHeaderCell: () => <div />

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -60,7 +60,6 @@ export interface ColumnMetrics<TRow> {
   lastFrozenColumnIndex: number;
   viewportWidth: number;
   totalColumnWidth: number;
-  minColumnWidth: number;
   columnWidths: Map<keyof TRow, number>;
 }
 

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -60,7 +60,6 @@ export interface ColumnMetrics<TRow> {
   lastFrozenColumnIndex: number;
   viewportWidth: number;
   totalColumnWidth: number;
-  columnWidths: Map<keyof TRow, number>;
 }
 
 export interface RowData {

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
@@ -82,7 +82,6 @@ describe('viewportUtils', () => {
         columns,
         viewportWidth: 1000,
         totalColumnWidth: 200,
-        columnWidths: new Map(),
         lastFrozenColumnIndex: -1
       };
     }

--- a/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
+++ b/packages/react-data-grid/src/utils/__tests__/viewportUtils.spec.ts
@@ -83,7 +83,6 @@ describe('viewportUtils', () => {
         viewportWidth: 1000,
         totalColumnWidth: 200,
         columnWidths: new Map(),
-        minColumnWidth: 80,
         lastFrozenColumnIndex: -1
       };
     }

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -1,11 +1,13 @@
 import { Column, CalculatedColumn, ColumnMetrics, CellContentRenderer } from '../common/types';
 import { getScrollbarSize } from './domUtils';
 
-type Metrics<R> = Pick<ColumnMetrics<R>, 'viewportWidth' | 'columnWidths'> & {
+interface Metrics<R> {
   columns: Column<R>[];
+  columnWidths: Map<keyof R, number>;
   minColumnWidth: number;
+  viewportWidth: number;
   defaultCellContentRenderer: CellContentRenderer<R>;
-};
+}
 
 export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
   let left = 0;
@@ -42,7 +44,6 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
     columns: calculatedColumns,
     lastFrozenColumnIndex: frozenColumns.length - 1,
     totalColumnWidth: totalWidth,
-    columnWidths: metrics.columnWidths,
     viewportWidth: metrics.viewportWidth
   };
 }

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -1,8 +1,9 @@
 import { Column, CalculatedColumn, ColumnMetrics, CellContentRenderer } from '../common/types';
 import { getScrollbarSize } from './domUtils';
 
-type Metrics<R> = Pick<ColumnMetrics<R>, 'viewportWidth' | 'minColumnWidth' | 'columnWidths'> & {
+type Metrics<R> = Pick<ColumnMetrics<R>, 'viewportWidth' | 'columnWidths'> & {
   columns: Column<R>[];
+  minColumnWidth: number;
   defaultCellContentRenderer: CellContentRenderer<R>;
 };
 
@@ -41,7 +42,6 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
     columns: calculatedColumns,
     lastFrozenColumnIndex: frozenColumns.length - 1,
     totalColumnWidth: totalWidth,
-    minColumnWidth: metrics.minColumnWidth,
     columnWidths: metrics.columnWidths,
     viewportWidth: metrics.viewportWidth
   };


### PR DESCRIPTION
Since we've optimized rendering quite a bit, I think it's now safe to re-render the whole grid when resizing columns. 👍 