### PR TITLE
Fix columns metrics columns generating logic, improve performance

### DIFF
--- a/examples/demos/example13-all-features.js
+++ b/examples/demos/example13-all-features.js
@@ -21,7 +21,8 @@ export default class extends React.Component {
         key: 'id',
         name: 'ID',
         width: 80,
-        resizable: true
+        resizable: true,
+        frozen: true
       },
       {
         key: 'avatar',
@@ -48,14 +49,16 @@ export default class extends React.Component {
         name: 'First Name',
         editable: true,
         width: 200,
-        resizable: true
+        resizable: true,
+        frozen: true
       },
       {
         key: 'lastName',
         name: 'Last Name',
         editable: true,
         width: 200,
-        resizable: true
+        resizable: true,
+        frozen: true
       },
       {
         key: 'email',

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -8,14 +8,12 @@ type Metrics<R> = Pick<ColumnMetrics<R>, 'viewportWidth' | 'minColumnWidth' | 'c
 export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
   let left = 0;
   let totalWidth = 0;
-  let allocatedWidths = 0;
 
   const frozenColumns: Column<R>[] = [];
   const nonFrozenColumns: Column<R>[] = [];
 
   for (const metricsColumn of metrics.columns) {
     const column = { ...metricsColumn };
-    allocatedWidths += column.width || 0;
 
     if (isFrozen(column)) {
       frozenColumns.push(column);
@@ -27,6 +25,7 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
   const columns = [...frozenColumns, ...nonFrozenColumns];
   setSpecifiedWidths(columns, metrics.columnWidths, metrics.viewportWidth, metrics.minColumnWidth);
 
+  const allocatedWidths = columns.reduce((acc, c) => acc + (c.width || 0), 0);
   const unallocatedWidth = metrics.viewportWidth - allocatedWidths - getScrollbarSize();
 
   setRemainingWidths(columns, unallocatedWidth, metrics.minColumnWidth);

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -18,9 +18,9 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
     allocatedWidths += column.width || 0;
 
     if (isFrozen(column)) {
-      frozenColumns.push({ ...column });
+      frozenColumns.push(column);
     } else {
-      nonFrozenColumns.push({ ...column });
+      nonFrozenColumns.push(column);
     }
   }
 

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -9,20 +9,20 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
   let left = 0;
   let totalWidth = 0;
 
-  const frozenColumns: Column<R>[] = [];
-  const nonFrozenColumns: Column<R>[] = [];
+  let lastFrozenColumnIndex = -1;
+  const columns: Column<R>[] = [];
 
   for (const metricsColumn of metrics.columns) {
     const column = { ...metricsColumn };
 
     if (isFrozen(column)) {
-      frozenColumns.push(column);
+      lastFrozenColumnIndex++;
+      columns.splice(lastFrozenColumnIndex, 0, column);
     } else {
-      nonFrozenColumns.push(column);
+      columns.push(column);
     }
   }
 
-  const columns = [...frozenColumns, ...nonFrozenColumns];
   setSpecifiedWidths(columns, metrics.columnWidths, metrics.viewportWidth, metrics.minColumnWidth);
 
   const allocatedWidths = columns.reduce((acc, c) => acc + (c.width || 0), 0);
@@ -46,7 +46,7 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
 
   return {
     columns: calculatedColumns,
-    lastFrozenColumnIndex: frozenColumns.length - 1,
+    lastFrozenColumnIndex,
     totalColumnWidth: totalWidth,
     minColumnWidth: metrics.minColumnWidth,
     columnWidths: metrics.columnWidths,

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -40,7 +40,7 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
 
   const calculatedColumns: CalculatedColumn<R>[] = columns.map((column, idx) => {
     // Every column should have a valid width as this stage
-    const width = column.width || unallocatedColumnWidth;
+    const width = column.width === undefined ? unallocatedColumnWidth : column.width;
     const newColumn: CalculatedColumn<R> = {
       ...column,
       idx,


### PR DESCRIPTION
`column.left` was calculated based on obsoleted columns order when `isFrozne` column is applied, We should sort the columns first and then calculate it. This PR is only for fixing, no performance updates, as I believe after moving the code around we could save some more loops.