### PR TITLE
Contributing links in README and templates Issue/Pr

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -41,7 +41,7 @@
 > 👋 Need general support? Not sure about how to use React itself, or how to get started with the Grid?
 > Please do not submit support request here. Instead see
 
-> https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
+> https://github.com/adazzle/react-data-grid/blob/master/docs/CONTRIBUTING.md
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 A few sentences describing the overall goals of the pull request's commits.
 
 **Please check if the PR fulfills these requirements**
-- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
+- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/docs/CONTRIBUTING.md
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Features
 Contributing
 ------------
 
-Please see [CONTRIBUTING](CONTRIBUTING.md)
+Please see [CONTRIBUTING](docs/CONTRIBUTING.md)
 
 Credits
 ------------


### PR DESCRIPTION
## Description
Contributing link was pointing nowhere. It nows point to /docs/contributing.md

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: fixed documentation
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
