### PR TITLE
[canary] new prop for column 'minWidth' and SelectColumn always use `width` prop

### DIFF
--- a/examples/demos/example02-resizable-cols.js
+++ b/examples/demos/example02-resizable-cols.js
@@ -11,12 +11,13 @@ export default class extends React.Component {
         key: 'id',
         name: 'ID',
         resizable: true,
-        width: 40
+        minWidth: 40
       },
       {
         key: 'task',
         name: 'Title',
-        resizable: true
+        resizable: true,
+        minWidth: 80
       },
       {
         key: 'priority',
@@ -26,7 +27,8 @@ export default class extends React.Component {
       {
         key: 'issueType',
         name: 'Issue Type',
-        resizable: true
+        resizable: true,
+        width: 150
       },
       {
         key: 'complete',

--- a/examples/demos/example13-all-features.js
+++ b/examples/demos/example13-all-features.js
@@ -22,6 +22,7 @@ export default class extends React.Component {
         key: 'id',
         name: 'ID',
         width: 80,
+        minWidth: 60,
         resizable: true,
         frozen: true
       },
@@ -29,6 +30,7 @@ export default class extends React.Component {
         key: 'avatar',
         name: 'Avatar',
         width: 60,
+        minWidth: 60,
         formatter: ImageFormatter,
         resizable: true,
         headerRenderer: <ImageFormatter value={faker.image.cats()} />
@@ -38,6 +40,7 @@ export default class extends React.Component {
         name: 'Title',
         editor: <DropDownEditor options={titles} />,
         width: 200,
+        minWidth: 50,
         resizable: true,
         events: {
           onClick: (ev, { idx, rowIdx }) => {
@@ -65,28 +68,28 @@ export default class extends React.Component {
         key: 'email',
         name: 'Email',
         editable: true,
-        width: 200,
+        minWidth: 250,
         resizable: true
       },
       {
         key: 'street',
         name: 'Street',
         editable: true,
-        width: 200,
+        minWidth: 200,
         resizable: true
       },
       {
         key: 'zipCode',
         name: 'ZipCode',
         editable: true,
-        width: 200,
+        minWidth: 80,
         resizable: true
       },
       {
         key: 'date',
         name: 'Date',
         editable: true,
-        width: 200,
+        minWidth: 100,
         resizable: true
       },
       {
@@ -125,7 +128,7 @@ export default class extends React.Component {
     };
   }
 
-  createRows = numberOfRows => {
+  createRows = (numberOfRows) => {
     const rows = [];
     for (let i = 0; i < numberOfRows; i++) {
       rows[i] = this.createFakeRowObjectData(i);
@@ -133,7 +136,7 @@ export default class extends React.Component {
     return rows;
   };
 
-  createFakeRowObjectData = index => {
+  createFakeRowObjectData = (index) => {
     return {
       id: `id_${index}`,
       avatar: faker.image.avatar(),
@@ -177,7 +180,7 @@ export default class extends React.Component {
     this.setState({ rows });
   };
 
-  getRowAt = index => {
+  getRowAt = (index) => {
     if (index < 0 || index > this.getSize()) {
       return undefined;
     }
@@ -189,7 +192,7 @@ export default class extends React.Component {
     return this.state.rows.length;
   };
 
-  onSelectedRowsChange = selectedRows => {
+  onSelectedRowsChange = (selectedRows) => {
     this.setState({ selectedRows });
   };
 

--- a/packages/react-data-grid/src/DataGrid.tsx
+++ b/packages/react-data-grid/src/DataGrid.tsx
@@ -13,7 +13,7 @@ import { isValidElementType } from 'react-is';
 import Header, { HeaderHandle } from './Header';
 import Canvas from './Canvas';
 import { legacyCellContentRenderer } from './Cell/cellContentRenderers';
-import { getColumnMetrics, getWidth } from './utils/columnUtils';
+import { getColumnMetrics } from './utils/columnUtils';
 import EventBus from './EventBus';
 import { CellNavigationMode, EventTypes, UpdateActions, HeaderRowType, DEFINE_SORT } from './common/enums';
 import {
@@ -247,7 +247,7 @@ function DataGrid<R, K extends keyof R>({
 
   function handleColumnResize(column: CalculatedColumn<R>, width: number) {
     const newColumnWidths = new Map(columnWidths);
-    const minWidth = getWidth(viewportWidth, column.minWidth, minColumnWidth) as number;
+    const minWidth = typeof column.minWidth === 'number' ? column.minWidth : minColumnWidth;
     width = Math.max(width, minWidth);
     newColumnWidths.set(column.key, width);
     setColumnWidths(newColumnWidths);

--- a/packages/react-data-grid/src/DataGrid.tsx
+++ b/packages/react-data-grid/src/DataGrid.tsx
@@ -13,7 +13,7 @@ import { isValidElementType } from 'react-is';
 import Header, { HeaderHandle } from './Header';
 import Canvas from './Canvas';
 import { legacyCellContentRenderer } from './Cell/cellContentRenderers';
-import { getColumnMetrics } from './utils/columnUtils';
+import { getColumnMetrics, getWidth } from './utils/columnUtils';
 import EventBus from './EventBus';
 import { CellNavigationMode, EventTypes, UpdateActions, HeaderRowType, DEFINE_SORT } from './common/enums';
 import {
@@ -247,7 +247,8 @@ function DataGrid<R, K extends keyof R>({
 
   function handleColumnResize(column: CalculatedColumn<R>, width: number) {
     const newColumnWidths = new Map(columnWidths);
-    width = Math.max(width, minColumnWidth);
+    const minWidth = getWidth(viewportWidth, column.minWidth, minColumnWidth) as number;
+    width = Math.max(width, minWidth);
     newColumnWidths.set(column.key, width);
     setColumnWidths(newColumnWidths);
 

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -11,7 +11,7 @@ interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow
   key: TField;
   /** Column widths. If not specified, it will be determined automatically based on grid width and specified widths of other columns*/
   width?: number | string;
-  minWidth?: number | string;
+  minWidth?: number;
   cellClass?: string;
   /** By adding an event object with callbacks for the native react events you can bind events to a specific column. That will not break the default behaviour of the grid and will run only for the specified column */
   events?: {

--- a/packages/react-data-grid/src/utils/columnUtils.ts
+++ b/packages/react-data-grid/src/utils/columnUtils.ts
@@ -65,15 +65,8 @@ export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {
   };
 }
 
-function getWidthFromViewport(
-  minWidth: string,
-  viewportWidth: number
-): number {
-  return Math.floor((viewportWidth * parseInt(minWidth, 10)) / 100);
-}
-
 // get column width, fallback on defaultWidth when width is undefined
-export function getWidth(
+function getWidth(
   viewportWidth: number,
   minWidth?: number | string,
   defaultWidth?: number
@@ -81,7 +74,7 @@ export function getWidth(
   switch (typeof minWidth) {
     case 'string':
       return /^\d+%$/.test(minWidth)
-        ? getWidthFromViewport(minWidth, viewportWidth)
+        ? Math.floor((viewportWidth * parseInt(minWidth, 10)) / 100)
         : defaultWidth;
     case 'number':
       return minWidth;
@@ -97,7 +90,7 @@ function getSpecifiedWidth<R>(
   defaultMinColumnWidth: number
 ): number | void {
   // get column min width from grid or column prop, fallback on defaultMinColumnWidth if undefined
-  const minWidth = getWidth(viewportWidth, column.minWidth, defaultMinColumnWidth) as number;
+  const minWidth = typeof column.minWidth === 'number' ? column.minWidth : defaultMinColumnWidth;
   const width = getWidth(viewportWidth, column.width);
 
   // SelectColumn must always use width prop when defined

--- a/packages/react-data-grid/style/rdg-core.less
+++ b/packages/react-data-grid/style/rdg-core.less
@@ -6,13 +6,14 @@
   position: relative;
   z-index: 0;
   border: 1px solid @borderColor;
+  box-sizing: border-box;
   .user-select();
   font-size: 14px;
 
   *,
   *::before,
   *::after {
-    box-sizing: border-box;
+    box-sizing: inherit;
   }
 }
 


### PR DESCRIPTION
> * Column new prop: minWidth
> 
> * Grid prop minColumnWidth is ignored if column has its prop minWidth specified, then it uses minWidth/width highest value
> 
> * SelectColumn can now have a width specified to stay fixed when minColumnWidth is specified
> 
> * updated all-features-13 which was already using SelectColumn to demo the added feature


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
- #1816 Can't specify a width to SelectColumn
- Can't specifiy a minWidth to individual column
- minColumnWidth affects SelectColumn and breaks the UI


**What is the new behavior?**
- SelectColumn width can be overwritten
- Column have a new prop : minWidth


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
![image](https://user-images.githubusercontent.com/23088305/68419740-d7626d80-0168-11ea-9cd7-91b9bb367555.png)

close issue #1816 
