### PR TITLE
Fix dragging issue

### DIFF
--- a/packages/react-data-grid/src/masks/InteractionMasks.tsx
+++ b/packages/react-data-grid/src/masks/InteractionMasks.tsx
@@ -600,10 +600,8 @@ export default class InteractionMasks<R> extends React.Component<InteractionMask
     const column = columns[draggedPosition.idx];
     const value = getSelectedCellValue({ selectedPosition: draggedPosition, columns, rowGetter });
     const cellKey = column.key;
-    const fromRow = rowIdx;
-    const toRow = overRowIdx;
 
-    onGridRowsUpdated(cellKey, fromRow, toRow, { [cellKey]: value }, UpdateActions.CELL_DRAG);
+    onGridRowsUpdated(cellKey, rowIdx, overRowIdx, { [cellKey]: value }, UpdateActions.CELL_DRAG);
 
     this.setState({
       draggedPosition: null

--- a/packages/react-data-grid/src/masks/InteractionMasks.tsx
+++ b/packages/react-data-grid/src/masks/InteractionMasks.tsx
@@ -600,8 +600,8 @@ export default class InteractionMasks<R> extends React.Component<InteractionMask
     const column = columns[draggedPosition.idx];
     const value = getSelectedCellValue({ selectedPosition: draggedPosition, columns, rowGetter });
     const cellKey = column.key;
-    const fromRow = rowIdx < overRowIdx ? rowIdx : overRowIdx;
-    const toRow = rowIdx > overRowIdx ? rowIdx : overRowIdx;
+    const fromRow = rowIdx;
+    const toRow = overRowIdx;
 
     onGridRowsUpdated(cellKey, fromRow, toRow, { [cellKey]: value }, UpdateActions.CELL_DRAG);
 

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
@@ -738,15 +738,17 @@ describe('<InteractionMasks/>', () => {
   });
 
   describe('Drag functionality', () => {
-    const setupDrag = () => {
-      const selectedPosition = { idx: 1, rowIdx: 2 };
+    const setupDrag = (overrideProps?: any) => {
+      const selectedPosition = { idx: 1, rowIdx: 2, ...overrideProps };
       const rows = [
         { Column1: '1' },
         { Column1: '2' },
-        { Column1: '3' }
+        { Column1: '3' },
+        { Column1: '4' },
+        { Column1: '5' }
       ];
       return setup({
-        rowGetter: (rowIdx) => rowIdx < 3 ? rows[rowIdx] : rowGetter()
+        rowGetter: (rowIdx) => rowIdx < 5 ? rows[rowIdx] : rowGetter()
       }, { selectedPosition });
     };
 
@@ -768,7 +770,7 @@ describe('<InteractionMasks/>', () => {
       expect(setData).toHaveBeenCalled();
     });
 
-    it('should update the dragged over cells on drag end', () => {
+    it('should update the dragged over cells on downwards drag end', () => {
       const { wrapper, props } = setupDrag();
       const setData = jest.fn();
       wrapper.find(DragHandle).simulate('dragstart', {
@@ -779,6 +781,19 @@ describe('<InteractionMasks/>', () => {
       wrapper.find(DragHandle).simulate('dragEnd');
 
       expect(props.onGridRowsUpdated).toHaveBeenCalledWith('Column1', 2, 6, { Column1: '3' }, UpdateActions.CELL_DRAG);
+    });
+
+    it('should update the dragged over cells on upwards drag end', () => {
+      const { wrapper, props } = setupDrag({ rowIdx: 4 });
+      const setData = jest.fn();
+      wrapper.find(DragHandle).simulate('dragstart', {
+        target: { className: 'test' },
+        dataTransfer: { setData }
+      });
+      props.eventBus.dispatch(EventTypes.DRAG_ENTER, 0);
+      wrapper.find(DragHandle).simulate('dragEnd');
+
+      expect(props.onGridRowsUpdated).toHaveBeenCalledWith('Column1', 4, 0, { Column1: '5' }, UpdateActions.CELL_DRAG);
     });
   });
 

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
@@ -738,8 +738,8 @@ describe('<InteractionMasks/>', () => {
   });
 
   describe('Drag functionality', () => {
-    const setupDrag = (overrideProps?: any) => {
-      const selectedPosition = { idx: 1, rowIdx: 2, ...overrideProps };
+    const setupDrag = (rowIdx: number = 2) => {
+      const selectedPosition = { idx: 1, rowIdx };
       const rows = [
         { Column1: '1' },
         { Column1: '2' },
@@ -784,7 +784,7 @@ describe('<InteractionMasks/>', () => {
     });
 
     it('should update the dragged over cells on upwards drag end', () => {
-      const { wrapper, props } = setupDrag({ rowIdx: 4 });
+      const { wrapper, props } = setupDrag(4);
       const setData = jest.fn();
       wrapper.find(DragHandle).simulate('dragstart', {
         target: { className: 'test' },


### PR DESCRIPTION
When dragging upwards the `fromRow` and `toRow` are set incorrectly.

- [x] Assign correct values to `fromRow` and `toRow` when dragging upwards