### PR TITLE
[canary] Horizontal scroll calculation after removing columns breaks the dataGrid

### DIFF
--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.tsx
@@ -734,7 +734,7 @@ describe('<InteractionMasks/>', () => {
   });
 
   describe('Drag functionality', () => {
-    const setupDrag = (rowIdx: number = 2) => {
+    const setupDrag = (rowIdx = 2) => {
       const selectedPosition = { idx: 1, rowIdx };
       const rows = [
         { Column1: '1' },

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -59,7 +59,12 @@ export function getHorizontalRangeToRender<R>({
   const { columns, totalColumnWidth, lastFrozenColumnIndex } = columnMetrics;
   let { viewportWidth } = columnMetrics;
 
-  let remainingScroll = scrollLeft;
+  // Get valid left scroll position.
+  // When we're scrolled all the way to the right and we remove columns, the scrollLeft value will be outdated,
+  // and greater than what's possible, so we need to handle that case here.
+  let remainingScroll = scrollLeft + viewportWidth > totalColumnWidth
+    ? totalColumnWidth - viewportWidth
+    : scrollLeft;
   let columnIndex = Math.max(lastFrozenColumnIndex, 0);
   let hiddenColumnsWidth = 0;
   while (remainingScroll >= 0 && columnIndex < columns.length) {

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -65,15 +65,16 @@ export function getHorizontalRangeToRender<R>({
   let remainingScroll = scrollLeft + viewportWidth > totalColumnWidth
     ? totalColumnWidth - viewportWidth
     : scrollLeft;
-  let columnIndex = Math.max(lastFrozenColumnIndex, 0);
+
+  let columnIndex = lastFrozenColumnIndex;
   let hiddenColumnsWidth = 0;
-  while (remainingScroll >= 0 && columnIndex < columns.length) {
+  while (remainingScroll >= 0 && columnIndex < columns.length - 1) {
+    columnIndex++;
     const { width = 0 } = columns[columnIndex];
     remainingScroll -= width;
     if (remainingScroll >= 0) {
       hiddenColumnsWidth += width;
     }
-    columnIndex++;
   }
   const colVisibleStartIdx = Math.max(columnIndex, 0);
 
@@ -82,8 +83,6 @@ export function getHorizontalRangeToRender<R>({
   if (viewportWidth > 0) {
     const firstVisibleColumnHiddenWidth = scrollLeft - hiddenColumnsWidth;
     viewportWidth += firstVisibleColumnHiddenWidth;
-  } else if (remainingScroll > totalColumnWidth) {
-    viewportWidth = scrollLeft - totalColumnWidth;
   } else {
     viewportWidth = totalColumnWidth;
   }

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -60,7 +60,7 @@ export function getHorizontalRangeToRender<R>({
   let { viewportWidth } = columnMetrics;
 
   let remainingScroll = scrollLeft;
-  let columnIndex = lastFrozenColumnIndex;
+  let columnIndex = Math.max(lastFrozenColumnIndex, 0);
   let hiddenColumnsWidth = 0;
   while (remainingScroll >= 0 && columnIndex < columns.length) {
     const { width = 0 } = columns[columnIndex];

--- a/packages/react-data-grid/src/utils/viewportUtils.ts
+++ b/packages/react-data-grid/src/utils/viewportUtils.ts
@@ -63,18 +63,26 @@ export function getHorizontalRangeToRender<R>({
   let columnIndex = lastFrozenColumnIndex;
   let hiddenColumnsWidth = 0;
   while (remainingScroll >= 0 && columnIndex < columns.length) {
-    columnIndex++;
-    const column = columns[columnIndex];
-    remainingScroll -= column.width;
+    const { width = 0 } = columns[columnIndex];
+    remainingScroll -= width;
     if (remainingScroll >= 0) {
-      hiddenColumnsWidth += column.width;
+      hiddenColumnsWidth += width;
     }
+    columnIndex++;
   }
   const colVisibleStartIdx = Math.max(columnIndex, 0);
-  const firstVisibleColumnHiddenWidth = scrollLeft - hiddenColumnsWidth;
 
   const totalFrozenColumnWidth = getTotalFrozenColumnWidth(columns, lastFrozenColumnIndex);
-  viewportWidth = viewportWidth > 0 ? viewportWidth + firstVisibleColumnHiddenWidth : totalColumnWidth;
+
+  if (viewportWidth > 0) {
+    const firstVisibleColumnHiddenWidth = scrollLeft - hiddenColumnsWidth;
+    viewportWidth += firstVisibleColumnHiddenWidth;
+  } else if (remainingScroll > totalColumnWidth) {
+    viewportWidth = scrollLeft - totalColumnWidth;
+  } else {
+    viewportWidth = totalColumnWidth;
+  }
+
   const availableWidth = viewportWidth - totalFrozenColumnWidth;
   const nonFrozenRenderedColumnCount = getColumnCountForWidth(columns, availableWidth, colVisibleStartIdx);
   const colVisibleEndIdx = Math.min(columns.length - 1, colVisibleStartIdx + nonFrozenRenderedColumnCount);


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Having 30 columns and the horizontal scroll bar at the far right, then removing some (keep 10 of those) the method getHorizontalRangeToRender tries to move the horizontal scrollbar to the proper column index but fails because there is always a remaining scroll value after substracting the width of each column. it fails trying to get a invalid column index of the column array. columns[10] index = 10. 


**What is the new behavior?**
moved the columnIndex incrementer at the end of the while loop so the condition in the while loop will actually be validated.

```
  while (remainingScroll >= 0 && columnIndex < columns.length) {
    const { width = 0 } = columns[columnIndex];
    remainingScroll -= width;
    if (remainingScroll >= 0) {
      hiddenColumnsWidth += width;
    }
    columnIndex++; <------
  }
```


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
