### PR TITLE
Remove support for getRowMetaData, dependentValues, rowMetaData

### DIFF
--- a/packages/react-data-grid-addons/src/draggable/RowDragLayer.js
+++ b/packages/react-data-grid-addons/src/draggable/RowDragLayer.js
@@ -68,8 +68,7 @@ class CustomDragLayer extends Component {
         if (item.hasOwnProperty(c.key)) {
           if (c.formatter) {
             const Formatter = c.formatter;
-            const dependentValues = typeof c.getRowMetaData === 'function' ? c.getRowMetaData(item, c) : {};
-            cells.push(<td key={`dragged-cell-${rowIdx}-${c.key}`} className="rdg-cell" style={{ padding: '5px' }}><Formatter dependentValues={dependentValues} value={item[c.key]} /></td>);
+            cells.push(<td key={`dragged-cell-${rowIdx}-${c.key}`} className="rdg-cell" style={{ padding: '5px' }}><Formatter value={item[c.key]} /></td>);
           } else {
             cells.push(<td key={`dragged-cell-${rowIdx}-${c.key}`} className="rdg-cell" style={{ padding: '5px' }}>{item[c.key]}</td>);
           }

--- a/packages/react-data-grid/src/Cell/CellContent.tsx
+++ b/packages/react-data-grid/src/Cell/CellContent.tsx
@@ -22,17 +22,6 @@ export default function CellContent<R>({
   const treeDepth = expandableOptions ? expandableOptions.treeDepth : 0;
   const style = expandableOptions && isExpandCell ? { marginLeft: expandableOptions.treeDepth * 30 } : undefined;
 
-  function getFormatterDependencies(row: R) {
-    // convention based method to get corresponding Id or Name of any Name or Id property
-    const { getRowMetaData } = column;
-    if (getRowMetaData) {
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('getRowMetaData for formatters is deprecated and will be removed in a future version of react-data-grid. Instead access row prop of formatter');
-      }
-      return getRowMetaData(row, column);
-    }
-  }
-
   function getFormatterProps() {
     return {
       value: rowData[column.key],
@@ -41,7 +30,6 @@ export default function CellContent<R>({
       row: rowData,
       isRowSelected,
       onRowSelectionChange,
-      dependentValues: getFormatterDependencies(rowData),
       isSummaryRow
     };
   }

--- a/packages/react-data-grid/src/Columns.tsx
+++ b/packages/react-data-grid/src/Columns.tsx
@@ -4,7 +4,7 @@ import { Column } from './common/types';
 
 // TODO: fix type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const SelectColumn: Column<any, any, any> = {
+export const SelectColumn: Column<any, any> = {
   key: 'select-row',
   name: '',
   width: 60,

--- a/packages/react-data-grid/src/common/editors/EditorContainer.tsx
+++ b/packages/react-data-grid/src/common/editors/EditorContainer.tsx
@@ -89,12 +89,11 @@ export default class EditorContainer<R, K extends keyof R> extends React.Compone
   };
 
   createEditor() {
-    type P = EditorProps<ValueType<R> | string, unknown, R>;
+    type P = EditorProps<ValueType<R> | string, R>;
     const editorProps: P & { ref: React.RefObject<Editor> } = {
       ref: this.editor,
       column: this.props.column,
       value: this.getInitialValue(),
-      rowMetaData: this.getRowMetaData(),
       rowData: this.props.rowData,
       height: this.props.height,
       onCommit: this.commit,
@@ -175,14 +174,6 @@ export default class EditorContainer<R, K extends keyof R> extends React.Compone
     const { isSelectOpen } = this.getEditor();
     return isSelectOpen ? isSelectOpen() : false;
   };
-
-  getRowMetaData() {
-    // clone row data so editor cannot actually change this
-    // convention based method to get corresponding Id or Name of any Name or Id property
-    if (this.props.column.getRowMetaData) {
-      return this.props.column.getRowMetaData(this.props.rowData, this.props.column);
-    }
-  }
 
   getEditor = () => {
     return this.editor.current!;

--- a/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.tsx
+++ b/packages/react-data-grid/src/common/editors/__tests__/SimpleTextEditor.spec.tsx
@@ -8,7 +8,7 @@ interface Row { text: string }
 
 describe('SimpleTextEditor', () => {
   describe('Basic tests', () => {
-    const fakeColumn: CalculatedColumn<Row, unknown, 'text'> = {
+    const fakeColumn: CalculatedColumn<Row, 'text'> = {
       idx: 0,
       key: 'text',
       name: 'name',

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -4,7 +4,7 @@ import { HeaderRowType, UpdateActions } from './enums';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow = keyof TRow> {
+interface ColumnValue<TRow, TField extends keyof TRow = keyof TRow> {
   /** The name of the column. By default it will be displayed in the header cell */
   name: string;
   /** A unique key to distinguish each column */
@@ -18,7 +18,7 @@ interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow
   };
   cellContentRenderer?: CellContentRenderer<TRow>;
   /** Formatter to be used to render the cell content */
-  formatter?: React.ReactElement | React.ComponentType<FormatterProps<TRow[TField], TDependentValue, TRow>>;
+  formatter?: React.ReactElement | React.ComponentType<FormatterProps<TRow[TField], TRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((rowData: TRow) => boolean);
   /** Enable dragging of a column */
@@ -34,21 +34,19 @@ interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow
   /** Sets the column sort order to be descending instead of ascending the first time the column is sorted */
   sortDescendingFirst?: boolean;
   /** Editor to be rendered when cell of column is being edited. If set, then the column is automatically set to be editable */
-  editor?: React.ReactElement | React.ComponentType<EditorProps<TRow[TField], TDependentValue, TRow>>;
+  editor?: React.ReactElement | React.ComponentType<EditorProps<TRow[TField], TRow>>;
   /** Header renderer for each header cell */
   // TODO: finalize API
   headerRenderer?: React.ReactElement | React.ComponentType<HeaderRowProps<TRow>>;
   /** Component to be used to filter the data of the column */
-  filterRenderer?: React.ComponentType<FilterRendererProps<TRow, TDependentValue>>;
-
-  getRowMetaData?(rowData: TRow, column: CalculatedColumn<TRow, TDependentValue>): TDependentValue;
+  filterRenderer?: React.ComponentType<FilterRendererProps<TRow>>;
 }
 
-export type Column<TRow, TDependentValue = unknown, TField extends keyof TRow = keyof TRow> =
-  TField extends keyof TRow ? ColumnValue<TRow, TDependentValue, TField> : never;
+export type Column<TRow, TField extends keyof TRow = keyof TRow> =
+  TField extends keyof TRow ? ColumnValue<TRow, TField> : never;
 
-export type CalculatedColumn<TRow, TDependentValue = unknown, TField extends keyof TRow = keyof TRow> =
-  Column<TRow, TDependentValue, TField> & {
+export type CalculatedColumn<TRow, TField extends keyof TRow = keyof TRow> =
+  Column<TRow, TField> & {
     idx: number;
     width: number;
     left: number;
@@ -117,21 +115,19 @@ export interface Editor<TValue = never> extends React.Component {
   readonly disableContainerStyles?: boolean;
 }
 
-export interface FormatterProps<TValue, TDependentValue = unknown, TRow = any> {
+export interface FormatterProps<TValue, TRow = any> {
   rowIdx: number;
   value: TValue;
-  column: CalculatedColumn<TRow, TDependentValue>;
+  column: CalculatedColumn<TRow>;
   row: TRow;
   isRowSelected: boolean;
   onRowSelectionChange(rowIdx: number, row: TRow, checked: boolean, isShiftClick: boolean): void;
-  dependentValues?: TDependentValue;
   isSummaryRow: boolean;
 }
 
-export interface EditorProps<TValue, TDependentValue = unknown, TRow = any> {
-  column: CalculatedColumn<TRow, TDependentValue>;
+export interface EditorProps<TValue, TRow = any> {
+  column: CalculatedColumn<TRow>;
   value: TValue;
-  rowMetaData?: TDependentValue;
   rowData: TRow;
   height: number;
   onCommit(args?: { key?: string }): void;


### PR DESCRIPTION
To be merged into `canary` once `canary` stabilizes and we merge it onto `next`.