### PR TITLE
Move Cell events in Row (POC)

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -24,48 +24,48 @@ function Cell<R>({
   rowIdx,
   scrollLeft,
   eventBus,
-  onRowClick,
-  onRowDoubleClick,
+  // onRowClick,
+  // onRowDoubleClick,
   enableCellRangeSelection
 }: CellProps<R>) {
   const position: Position = { idx, rowIdx };
 
-  function selectCell(openEditor?: boolean) {
-    eventBus.dispatch(EventTypes.SELECT_CELL, position, openEditor);
-  }
+  // function selectCell(openEditor?: boolean) {
+  //   eventBus.dispatch(EventTypes.SELECT_CELL, position, openEditor);
+  // }
 
-  function handleCellClick() {
-    selectCell();
-    onRowClick?.(rowIdx, rowData, column);
-  }
+  // function handleCellClick() {
+  //   selectCell();
+  //   onRowClick?.(rowIdx, rowData, column);
+  // }
 
-  function handleCellMouseDown() {
-    eventBus.dispatch(EventTypes.SELECT_START, position);
+  // function handleCellMouseDown() {
+  //   eventBus.dispatch(EventTypes.SELECT_START, position);
 
-    function handleWindowMouseUp() {
-      eventBus.dispatch(EventTypes.SELECT_END);
-      window.removeEventListener('mouseup', handleWindowMouseUp);
-    }
+  //   function handleWindowMouseUp() {
+  //     eventBus.dispatch(EventTypes.SELECT_END);
+  //     window.removeEventListener('mouseup', handleWindowMouseUp);
+  //   }
 
-    window.addEventListener('mouseup', handleWindowMouseUp);
-  }
+  //   window.addEventListener('mouseup', handleWindowMouseUp);
+  // }
+
+  // function handleCellContextMenu() {
+  //   selectCell();
+  // }
+
+  // function handleCellDoubleClick(e: React.MouseEvent<HTMLDivElement>) {
+  //   e.stopPropagation();
+  //   onRowDoubleClick?.(rowIdx, rowData, column);
+  //   selectCell(true);
+  // }
+
+  // function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+  //   e.preventDefault();
+  // }
 
   function handleCellMouseEnter() {
     eventBus.dispatch(EventTypes.SELECT_UPDATE, position);
-  }
-
-  function handleCellContextMenu() {
-    selectCell();
-  }
-
-  function handleCellDoubleClick(e: React.MouseEvent<HTMLDivElement>) {
-    e.stopPropagation();
-    onRowDoubleClick?.(rowIdx, rowData, column);
-    selectCell(true);
-  }
-
-  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
-    e.preventDefault();
   }
 
   function getEvents() {
@@ -73,14 +73,17 @@ function Cell<R>({
 
     const columnEvents = column.events;
     const allEvents: { [key: string]: Function } = {
-      onClick: handleCellClick,
-      onDoubleClick: handleCellDoubleClick,
-      onContextMenu: handleCellContextMenu,
-      onDragOver: handleDragOver
+      // onClick: handleCellClick,
+      // onDoubleClick: handleCellDoubleClick,
+      // onContextMenu: handleCellContextMenu,
+      // onDragOver: handleDragOver
     };
 
+    // if (enableCellRangeSelection) {
+    //   allEvents.onMouseDown = handleCellMouseDown;
+    // }
+
     if (enableCellRangeSelection) {
-      allEvents.onMouseDown = handleCellMouseDown;
       allEvents.onMouseEnter = handleCellMouseEnter;
     }
 
@@ -149,6 +152,7 @@ function Cell<R>({
 
   return (
     <div
+      data-idx={idx}
       className={className}
       style={style}
       {...getEvents()}

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import Cell from './Cell';
-import { IRowRendererProps } from './common/types';
+import { IRowRendererProps, Position } from './common/types';
 import { EventTypes } from './common/enums';
 
 export default class Row<R> extends React.Component<IRowRendererProps<R>> {
@@ -28,6 +28,44 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
     // The default in Firefox is to treat data in dataTransfer as a URL and perform navigation on it, even if the data type used is 'text'
     // To bypass this, we need to capture and prevent the drop event.
     e.preventDefault();
+  };
+
+  selectCell = (position: Position, openEditor?: boolean) => {
+    this.props.eventBus.dispatch(EventTypes.SELECT_CELL, position, openEditor);
+  };
+
+  getCellPosition = (e: React.MouseEvent<HTMLDivElement>): Position => {
+    const target = e.target as HTMLDivElement;
+    const closest = target.closest('.rdg-cell');
+    return { rowIdx: this.props.idx, idx: Number(closest?.getAttribute('data-idx') || 0) };
+  };
+
+  handleCellClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const position = this.getCellPosition(e);
+    this.selectCell(position);
+    this.props.onRowClick?.(this.props.idx, this.props.row, this.props.columns[position.idx]);
+  };
+
+  handleCellMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    this.props.eventBus.dispatch(EventTypes.SELECT_START, this.getCellPosition(e));
+
+    const handleWindowMouseUp = () => {
+      this.props.eventBus.dispatch(EventTypes.SELECT_END);
+      window.removeEventListener('mouseup', handleWindowMouseUp);
+    };
+
+    window.addEventListener('mouseup', handleWindowMouseUp);
+  };
+
+  handleCellContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+    this.selectCell(this.getCellPosition(e));
+  };
+
+  handleCellDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    const position = this.getCellPosition(e);
+    this.props.onRowDoubleClick?.(this.props.idx, this.props.row, this.props.columns[position.idx]);
+    this.selectCell(position, true);
   };
 
   getCells() {
@@ -82,8 +120,15 @@ export default class Row<R> extends React.Component<IRowRendererProps<R>> {
     const events = !isSummaryRow && {
       onDragEnter: this.handleDragEnter,
       onDragOver: this.handleDragOver,
-      onDrop: this.handleDrop
+      onDrop: this.handleDrop,
+      onClick: this.handleCellClick,
+      onDoubleClick: this.handleCellDoubleClick,
+      onContextMenu: this.handleCellContextMenu
     };
+
+    if (this.props.enableCellRangeSelection && events) {
+      (events as { [key: string]: Function }).onMouseDown = this.handleCellMouseDown;
+    }
 
     return (
       <div


### PR DESCRIPTION
1. Move the following events from `Cell` to `Row`
```
  onClick,
  onDoubleClick
  onContextMenu
  onDragOver
  onMouseDown
```
2. put data-idx in Cell div and use element.closest() to get the `.rdg-cell` to access the `idx`,
https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
3. Then we would know the position in Row level without binding the event in each Cell.

By doing so, for editable cells we could roughly save the following numbers of events binding (All features max width example, 1080P screen) `9 * 27 * 5 - 27 * 5 = 1080`

If this is the right way for a better performance, we could even move the common events 1 level above to `Canvas` by assiging `data-rowIdx` and `data-idx` to the cell. Then eventually for those common 5 events, we only need to bind to the Canvas once.

Events in Row
![image](https://user-images.githubusercontent.com/25043398/71759470-03515500-2e73-11ea-8093-089721029945.png)

Events in Cell
![image](https://user-images.githubusercontent.com/25043398/71759476-1a904280-2e73-11ea-8e59-ac85d13ef47d.png)
