### PR TITLE
Stricter rowRenderer/headerRenderer types

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -6,7 +6,6 @@ import React, {
   useMemo,
   createElement
 } from 'react';
-import { isValidElementType } from 'react-is';
 
 import HeaderRow from './HeaderRow';
 import FilterRow from './FilterRow';
@@ -24,7 +23,7 @@ import {
   RowExpandToggleEvent,
   RowGetter,
   SelectedRange,
-  IRowRendererProps,
+  CustomRowRendererProps,
   ScrollPosition,
   Filters,
   FormatterProps
@@ -79,7 +78,7 @@ export interface DataGridProps<R, K extends keyof R> {
   /** The height of each row in pixels */
   rowHeight?: number;
   defaultFormatter?: React.ComponentType<FormatterProps<unknown, R>>;
-  rowRenderer?: React.ReactElement | React.ComponentType<IRowRendererProps<R>>;
+  rowRenderer?: React.ComponentType<CustomRowRendererProps<R>>;
   rowGroupRenderer?: React.ComponentType;
   /** A function called for each rendered row that should return a plain key/value pair object */
   rowGetter: RowGetter<R>;
@@ -285,7 +284,7 @@ function DataGrid<R, K extends keyof R>({
               />
             )}
           </div>
-          {rowsCount === 0 && isValidElementType(props.emptyRowsView) ? createElement(props.emptyRowsView) : (
+          {rowsCount === 0 && props.emptyRowsView ? createElement(props.emptyRowsView) : (
             <Canvas<R, K>
               ref={ref}
               rowKey={rowKey}

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -1,8 +1,7 @@
-import React, { createElement, cloneElement } from 'react';
+import React, { createElement } from 'react';
 import classNames from 'classnames';
-import { isElement } from 'react-is';
 
-import { CalculatedColumn, HeaderRendererProps } from './common/types';
+import { CalculatedColumn } from './common/types';
 import { DEFINE_SORT } from './common/enums';
 import { HeaderRowProps } from './HeaderRow';
 import SortableHeaderCell from './common/cells/headerCells/SortableHeaderCell';
@@ -19,7 +18,6 @@ type SharedHeaderRowProps<R, K extends keyof R> = Pick<HeaderRowProps<R, K>,
 
 export interface HeaderCellProps<R, K extends keyof R> extends SharedHeaderRowProps<R, K> {
   column: CalculatedColumn<R>;
-  renderer?: React.ReactElement | React.ComponentType<HeaderRendererProps<R>>;
   lastFrozenColumnIndex: number;
   scrollLeft: number | undefined;
   onSort?(columnKey: keyof R, direction: DEFINE_SORT): void;
@@ -37,17 +35,8 @@ export default function HeaderCell<R, K extends keyof R>({
 }: HeaderCellProps<R, K>) {
   function getCell() {
     if (!column.headerRenderer) return column.name;
-    const renderer = column.headerRenderer;
 
-    if (isElement(renderer)) {
-      // TODO: is this needed?
-      // if it is a string, it's an HTML element, and column is not a valid property, so only pass height
-      if (typeof renderer.type === 'string') {
-        return cloneElement(renderer, { height });
-      }
-      return cloneElement(renderer, { column, height });
-    }
-    return createElement(renderer, { column, allRowsSelected, onAllRowsSelectionChange });
+    return createElement(column.headerRenderer, { column, allRowsSelected, onAllRowsSelectionChange });
   }
 
   let cell = getCell();
@@ -93,7 +82,7 @@ export default function HeaderCell<R, K extends keyof R>({
         column={column}
         onResize={props.onResize}
       >
-        {cell}
+        {cell as React.ReactElement<React.ComponentProps<'div'>>}
       </ResizableHeaderCell>
     );
   }

--- a/src/RowRenderer.tsx
+++ b/src/RowRenderer.tsx
@@ -1,10 +1,9 @@
 import React, { memo } from 'react';
-import { isElement } from 'react-is';
 
 import Row from './Row';
 import RowGroup from './RowGroup';
 import { CanvasProps } from './Canvas';
-import { IRowRendererProps, RowData } from './common/types';
+import { IRowRendererProps, CustomRowRendererProps, RowData } from './common/types';
 import EventBus from './EventBus';
 
 type SharedCanvasProps<R, K extends keyof R> = Pick<CanvasProps<R, K>,
@@ -64,22 +63,6 @@ function RowRenderer<R, K extends keyof R>({
     enableCellRangeSelection: props.enableCellRangeSelection
   };
 
-  function renderCustomRowRenderer() {
-    const { ref, ...otherProps } = rendererProps;
-    const CustomRowRenderer = rowRenderer!;
-    const customRowRendererProps = { ...otherProps, renderBaseRow: (p: IRowRendererProps<R>) => <Row ref={ref} {...p} /> };
-
-    if (isElement(CustomRowRenderer)) {
-      if (CustomRowRenderer.type === Row) {
-        // In the case where Row is specified as the custom render, ensure the correct ref is passed
-        return <Row<R> {...rendererProps} />;
-      }
-      return React.cloneElement(CustomRowRenderer, customRowRendererProps);
-    }
-
-    return <CustomRowRenderer {...customRowRendererProps} />;
-  }
-
   function renderGroupRow() {
     const { ref, columns, ...rowGroupProps } = rendererProps;
 
@@ -107,7 +90,11 @@ function RowRenderer<R, K extends keyof R>({
   }
 
   if (rowRenderer) {
-    return renderCustomRowRenderer();
+    const { ref, ...otherProps } = rendererProps;
+    return React.createElement<CustomRowRendererProps<R>>(rowRenderer, {
+      ...otherProps,
+      renderBaseRow: (p: IRowRendererProps<R>) => <Row ref={ref} {...p} />
+    });
   }
 
   return <Row<R> {...rendererProps} />;

--- a/src/__tests__/HeaderRow.spec.tsx
+++ b/src/__tests__/HeaderRow.spec.tsx
@@ -55,10 +55,9 @@ describe('Header Row Unit Tests', () => {
   });
 
   describe('When column has a headerRenderer', () => {
-    const CustomHeader = () => <div>Custom</div>;
     const customColumnIdx = 1;
     beforeEach(() => {
-      defaultProps.columns[customColumnIdx].headerRenderer = <CustomHeader />;
+      defaultProps.columns[customColumnIdx].headerRenderer = () => <div>Custom</div>;
     });
 
     it('should render custom column header', () => {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -37,7 +37,7 @@ interface ColumnValue<TRow, TField extends keyof TRow = keyof TRow> {
   editor?: React.ReactElement | React.ComponentType<EditorProps<TRow[TField], TRow>>;
   /** Header renderer for each header cell */
   // TODO: finalize API
-  headerRenderer?: React.ReactElement | React.ComponentType<HeaderRendererProps<TRow>>;
+  headerRenderer?: React.ComponentType<HeaderRendererProps<TRow>>;
   /** Component to be used to filter the data of the column */
   filterRenderer?: React.ComponentType<FilterRendererProps<TRow, any>>;
 }
@@ -165,6 +165,10 @@ export interface IRowRendererProps<TRow> {
   onRowClick?(rowIdx: number, rowData: TRow, column: CalculatedColumn<TRow>): void;
   onRowDoubleClick?(rowIdx: number, rowData: TRow, column: CalculatedColumn<TRow>): void;
   onRowExpandToggle?(event: RowExpandToggleEvent): void;
+}
+
+export interface CustomRowRendererProps<TRow> extends IRowRendererProps<TRow> {
+  renderBaseRow: React.FunctionComponent<IRowRendererProps<TRow>>;
 }
 
 export interface FilterRendererProps<TRow, TFilterValue = unknown> {


### PR DESCRIPTION
Would be nice if we could get rid of `react-is`.