### PR TITLE
Remove FormatterProps.value

### DIFF
--- a/examples/demos/example13-all-features.tsx
+++ b/examples/demos/example13-all-features.tsx
@@ -75,11 +75,9 @@ export default function AllFeaturesExample(): JSX.Element {
       key: 'avatar',
       name: 'Avatar',
       width: 40,
-      formatter: ImageFormatter,
       resizable: true,
-      headerRenderer() {
-        return <ImageFormatter value={faker.image.cats()} />;
-      }
+      headerRenderer: () => <ImageFormatter value={faker.image.cats()} />,
+      formatter: ({ row }) => <ImageFormatter value={row.avatar} />
     },
     {
       key: 'title',

--- a/examples/demos/example25-tree-view.tsx
+++ b/examples/demos/example25-tree-view.tsx
@@ -107,7 +107,7 @@ export default function() {
       {
         key: 'format',
         name: 'format',
-        formatter({ value, row }) {
+        formatter({ row }) {
           const hasChildren = row.children !== undefined;
           const style = !hasChildren ? { marginLeft: 30 } : undefined;
           return (
@@ -126,7 +126,7 @@ export default function() {
                   />
                 )}
                 <div style={style}>
-                  {value}
+                  {row.format}
                 </div>
               </div>
             </>

--- a/examples/demos/example27-cell-actions.tsx
+++ b/examples/demos/example27-cell-actions.tsx
@@ -47,14 +47,14 @@ const columns: Column<Row>[] = [
     key: 'avatar',
     name: 'Avatar',
     width: 60,
-    formatter: ImageFormatter
+    formatter: ({ row }) => <ImageFormatter value={row.avatar} />
   },
   {
     key: 'county',
     name: 'County',
     width: 200,
     cellClass: 'rdg-cell-action',
-    formatter({ row, value }) {
+    formatter({ row }) {
       if (row.id === 'id_0') {
         const actions = [
           {
@@ -80,13 +80,13 @@ const columns: Column<Row>[] = [
           <>
             <CellActionsFormatter actions={actions} />
             <div>
-              {value}
+              {row.county}
             </div>
           </>
         );
       }
 
-      return <>{value}</>;
+      return <>{row.county}</>;
     }
   },
   {

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -137,17 +137,14 @@ function Cell<R>({
   }
 
   if (!children) {
-    const { formatter } = column;
-    const formatterProps = {
-      value: rowData[column.key],
+    children = createElement(column.formatter, {
       column,
       rowIdx,
       row: rowData,
       isRowSelected,
       onRowSelectionChange,
       isSummaryRow
-    };
-    children = createElement<typeof formatterProps>(formatter, formatterProps);
+    });
   }
 
   return (

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -77,7 +77,7 @@ export interface DataGridProps<R, K extends keyof R> {
   rowKey?: K;
   /** The height of each row in pixels */
   rowHeight?: number;
-  defaultFormatter?: React.ComponentType<FormatterProps<unknown, R>>;
+  defaultFormatter?: React.ComponentType<FormatterProps<R>>;
   rowRenderer?: React.ComponentType<IRowRendererProps<R>>;
   rowGroupRenderer?: React.ComponentType;
   /** A function called for each rendered row that should return a plain key/value pair object */

--- a/src/__tests__/Cell.spec.tsx
+++ b/src/__tests__/Cell.spec.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import Cell, { CellProps } from '../Cell';
 import helpers, { Row } from './GridPropHelpers';
 import { SimpleCellFormatter } from '../formatters';
-import { CalculatedColumn } from '../common/types';
+import { CalculatedColumn, FormatterProps } from '../common/types';
 import EventBus from '../EventBus';
 
 const defaultColumn: CalculatedColumn<Row> = {
@@ -37,11 +37,11 @@ describe('Cell Tests', () => {
   it('should render a SimpleCellFormatter with value', () => {
     const wrapper = renderComponent();
     const formatter = wrapper.find(SimpleCellFormatter);
-    expect(formatter.props().value).toEqual('Wicklow');
+    expect(formatter.props().row[defaultColumn.key]).toEqual('Wicklow');
   });
 
   it('should render a custom formatter when specified on column', () => {
-    const CustomFormatter = () => <div>Custom</div>;
+    const CustomFormatter = (props: FormatterProps) => <div>{props.row[props.column.key]}</div>;
 
     const column = {
       ...defaultColumn,
@@ -50,7 +50,7 @@ describe('Cell Tests', () => {
 
     const wrapper = renderComponent({ column });
     const formatterInstance = wrapper.find(CustomFormatter);
-    expect(formatterInstance.prop('value')).toEqual('Wicklow');
+    expect(formatterInstance.prop('row')[column.key]).toEqual('Wicklow');
   });
 
   it('should render children when those are passed', () => {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -18,7 +18,7 @@ interface ColumnValue<TRow, TField extends keyof TRow = keyof TRow> {
     [key: string]: undefined | ((e: Event, info: ColumnEventInfo<TRow>) => void);
   };
   /** Formatter to be used to render the cell content */
-  formatter?: React.ComponentType<FormatterProps<TRow[TField], TRow>>;
+  formatter?: React.ComponentType<FormatterProps<TRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((rowData: TRow) => boolean);
   /** Enable dragging of a column */
@@ -50,7 +50,7 @@ export type CalculatedColumn<TRow, TField extends keyof TRow = keyof TRow> =
     idx: number;
     width: number;
     left: number;
-    formatter: React.ComponentType<FormatterProps<any, TRow>>;
+    formatter: React.ComponentType<FormatterProps<TRow>>;
   };
 
 export interface ColumnMetrics<TRow> {
@@ -100,9 +100,8 @@ export interface Editor<TValue = never> {
   readonly disableContainerStyles?: boolean;
 }
 
-export interface FormatterProps<TValue, TRow = any> {
+export interface FormatterProps<TRow = any> {
   rowIdx: number;
-  value: TValue;
   column: CalculatedColumn<TRow>;
   row: TRow;
   isRowSelected: boolean;

--- a/src/formatters/SimpleCellFormatter.tsx
+++ b/src/formatters/SimpleCellFormatter.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
+import { FormatterProps } from '../common/types';
 
-export interface SimpleCellFormatterProps {
-  value?: string | number | boolean;
-}
-
-export function SimpleCellFormatter({ value }: SimpleCellFormatterProps) {
+export function SimpleCellFormatter({ row, column }: FormatterProps) {
+  const value = row[column.key];
   return <span title={String(value)}>{value}</span>;
 }

--- a/src/formatters/ValueFormatter.tsx
+++ b/src/formatters/ValueFormatter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormatterProps } from '../common/types';
 
-export function ValueFormatter<R>(props: FormatterProps<unknown, R>) {
+export function ValueFormatter<R>(props: FormatterProps<R>) {
   return <>{props.row[props.column.key]}</>;
 }

--- a/src/utils/columnUtils.ts
+++ b/src/utils/columnUtils.ts
@@ -6,7 +6,7 @@ interface Metrics<R> {
   columnWidths: Map<keyof R, number>;
   minColumnWidth: number;
   viewportWidth: number;
-  defaultFormatter: React.ComponentType<FormatterProps<unknown, R>>;
+  defaultFormatter: React.ComponentType<FormatterProps<R>>;
 }
 
 export function getColumnMetrics<R>(metrics: Metrics<R>): ColumnMetrics<R> {


### PR DESCRIPTION
I'd like to see if it makes sense to decouple `row` from `column.key`, as we might not always have a perfect 1:1 mapping between the data we want to display, and the actual data.

For example:

| a  | b | sum (a + b) |
| - | - | - |
| 2  | 3  | 5 |

Removing `value` from formatters is a first step, the second one is in editors. then maybe we can make `column.key` a simple `string` type.
WDYT?