### PR TITLE
Row components cleanup

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -238,14 +238,17 @@ function Canvas<R, K extends keyof R>({
   const summary = summaryRows && summaryRows.length > 0 && (
     <div ref={summaryRef} className="rdg-summary">
       {summaryRows.map((rowData, idx) => (
-        <SummaryRowRenderer<R, K>
+        <SummaryRowRenderer<R>
           key={idx}
           idx={idx}
-          rowData={rowData}
-          columnMetrics={columnMetrics}
+          row={rowData}
+          width={columnMetrics.totalColumnWidth + getScrollbarSize()}
+          height={rowHeight}
           viewportColumns={viewportColumns}
-          rowHeight={rowHeight}
+          isRowSelected={false}
+          lastFrozenColumnIndex={columnMetrics.lastFrozenColumnIndex}
           scrollLeft={nonStickyScrollLeft}
+          isSummaryRow
           eventBus={eventBus}
         />
       ))}

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -73,7 +73,7 @@ function Canvas<R, K extends keyof R>({
 }: CanvasProps<R, K>, ref: React.Ref<CanvasHandle>) {
   const [eventBus] = useState(() => new EventBus());
   const [scrollTop, setScrollTop] = useState(0);
-  const canvas = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
   const summaryRef = useRef<HTMLDivElement>(null);
   const lastSelectedRowIdx = useRef(-1);
 
@@ -110,7 +110,7 @@ function Canvas<R, K extends keyof R>({
   }
 
   function scrollToCell({ idx, rowIdx }: Partial<Position>) {
-    const { current } = canvas;
+    const { current } = canvasRef;
     if (!current) return;
 
     const { clientWidth, clientHeight, scrollLeft, scrollTop } = current;
@@ -141,7 +141,7 @@ function Canvas<R, K extends keyof R>({
   }
 
   function scrollToRow(rowIdx: number) {
-    const { current } = canvas;
+    const { current } = canvasRef;
     if (!current) return;
     current.scrollTop = rowIdx * rowHeight;
   }
@@ -260,7 +260,7 @@ function Canvas<R, K extends keyof R>({
       <div
         className="rdg-viewport"
         style={{ height: height - 2 - (summaryRows ? summaryRows.length * rowHeight + 2 : 0) }}
-        ref={canvas}
+        ref={canvasRef}
         onScroll={handleScroll}
         onKeyDown={props.onCanvasKeydown}
         onKeyUp={props.onCanvasKeyup}
@@ -277,7 +277,7 @@ function Canvas<R, K extends keyof R>({
           cellNavigationMode={props.cellNavigationMode}
           eventBus={eventBus}
           contextMenu={contextMenu}
-          canvasRef={canvas}
+          canvasRef={canvasRef}
           scrollLeft={scrollLeft}
           scrollTop={scrollTop}
           scrollToCell={scrollToCell}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -22,7 +22,7 @@ import {
   RowsContainerProps,
   RowExpandToggleEvent,
   SelectedRange,
-  IRowRendererProps,
+  RowRendererProps,
   ScrollPosition,
   Filters,
   FormatterProps
@@ -77,7 +77,7 @@ export interface DataGridProps<R, K extends keyof R> {
   /** The height of each row in pixels */
   rowHeight?: number;
   defaultFormatter?: React.ComponentType<FormatterProps<R>>;
-  rowRenderer?: React.ComponentType<IRowRendererProps<R>>;
+  rowRenderer?: React.ComponentType<RowRendererProps<R>>;
   rowGroupRenderer?: React.ComponentType;
   /** A function called for each rendered row that should return a plain key/value pair object */
   rows: readonly R[];

--- a/src/Row.test.tsx
+++ b/src/Row.test.tsx
@@ -5,19 +5,19 @@ import { shallow } from 'enzyme';
 import Row from './Row';
 import Cell from './Cell';
 import { createColumns } from './test/utils';
-import { IRowRendererProps } from './common/types';
+import { RowRendererProps } from './common/types';
 import EventBus from './EventBus';
 
 type RowType = any;
 
 describe('Row', () => {
-  function setup(props: IRowRendererProps<RowType>) {
+  function setup(props: RowRendererProps<RowType>) {
     const wrapper = shallow<typeof Row>(<Row {...props} />);
     const cells = wrapper.find(Cell);
     return { wrapper, cells };
   }
 
-  const requiredProperties: IRowRendererProps<RowType> = {
+  const requiredProperties: RowRendererProps<RowType> = {
     height: 30,
     width: 1000,
     viewportColumns: createColumns(50),

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import Cell from './Cell';
-import { IRowRendererProps } from './common/types';
+import { RowRendererProps } from './common/types';
 import { EventTypes } from './common/enums';
 
 export default function Row<R>({
@@ -21,7 +21,7 @@ export default function Row<R>({
   scrollLeft,
   viewportColumns,
   width
-}: IRowRendererProps<R>) {
+}: RowRendererProps<R>) {
   function handleDragEnter(e: React.DragEvent<HTMLDivElement>) {
     // Prevent default to allow drop
     e.preventDefault();

--- a/src/RowRenderer.tsx
+++ b/src/RowRenderer.tsx
@@ -3,7 +3,7 @@ import React, { memo } from 'react';
 import Row from './Row';
 import RowGroup from './RowGroup';
 import { CanvasProps } from './Canvas';
-import { IRowRendererProps, RowData } from './common/types';
+import { RowRendererProps, RowData } from './common/types';
 import EventBus from './EventBus';
 
 type SharedCanvasProps<R, K extends keyof R> = Pick<CanvasProps<R, K>,
@@ -18,7 +18,7 @@ type SharedCanvasProps<R, K extends keyof R> = Pick<CanvasProps<R, K>,
 | 'onRowExpandToggle'
 >;
 
-export interface RowRendererProps<R, K extends keyof R> extends SharedCanvasProps<R, K> {
+interface IRowRendererProps<R, K extends keyof R> extends SharedCanvasProps<R, K> {
   idx: number;
   rowData: R;
   scrollLeft: number | undefined;
@@ -39,9 +39,9 @@ function RowRenderer<R, K extends keyof R>({
   rowRenderer,
   scrollLeft,
   ...props
-}: RowRendererProps<R, K>) {
+}: IRowRendererProps<R, K>) {
   const { __metaData } = rowData as RowData;
-  const rendererProps: IRowRendererProps<R> = {
+  const rendererProps: RowRendererProps<R> = {
     idx,
     row: rowData,
     width: columnMetrics.totalColumnWidth,
@@ -75,7 +75,7 @@ function RowRenderer<R, K extends keyof R>({
     }
   }
 
-  return React.createElement<IRowRendererProps<R>>(rowRenderer || Row, rendererProps);
+  return React.createElement<RowRendererProps<R>>(rowRenderer || Row, rendererProps);
 }
 
-export default memo(RowRenderer) as <R, K extends keyof R>(props: RowRendererProps<R, K>) => JSX.Element;
+export default memo(RowRenderer) as <R, K extends keyof R>(props: IRowRendererProps<R, K>) => JSX.Element;

--- a/src/SummaryRowRenderer.tsx
+++ b/src/SummaryRowRenderer.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 
-import { IRowRendererProps } from './common/types';
+import { RowRendererProps } from './common/types';
 import Row from './Row';
 
-export default memo(Row) as <R>(props: IRowRendererProps<R>) => JSX.Element;
+export default memo(Row) as <R>(props: RowRendererProps<R>) => JSX.Element;

--- a/src/SummaryRowRenderer.tsx
+++ b/src/SummaryRowRenderer.tsx
@@ -1,42 +1,6 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 
+import { IRowRendererProps } from './common/types';
 import Row from './Row';
-import { RowRendererProps } from './RowRenderer';
-import { getScrollbarSize } from './utils';
 
-type SummaryRowRendererProps<R, K extends keyof R> = Pick<RowRendererProps<R, K>,
-| 'idx'
-| 'rowData'
-| 'columnMetrics'
-| 'viewportColumns'
-| 'rowHeight'
-| 'scrollLeft'
-| 'eventBus'
->;
-
-function SummaryRowRenderer<R, K extends keyof R>({
-  columnMetrics,
-  viewportColumns,
-  idx,
-  rowData,
-  rowHeight,
-  scrollLeft,
-  eventBus
-}: SummaryRowRendererProps<R, K>) {
-  return (
-    <Row<R>
-      idx={idx}
-      row={rowData}
-      width={columnMetrics.totalColumnWidth + getScrollbarSize()}
-      height={rowHeight}
-      viewportColumns={viewportColumns}
-      isRowSelected={false}
-      lastFrozenColumnIndex={columnMetrics.lastFrozenColumnIndex}
-      scrollLeft={scrollLeft}
-      isSummaryRow
-      eventBus={eventBus}
-    />
-  );
-}
-
-export default memo(SummaryRowRenderer) as <R, K extends keyof R>(props: SummaryRowRendererProps<R, K>) => JSX.Element;
+export default memo(Row) as <R>(props: IRowRendererProps<R>) => JSX.Element;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -140,7 +140,7 @@ export interface RowsContainerProps {
   children: React.ReactElement;
 }
 
-export interface IRowRendererProps<TRow> {
+export interface RowRendererProps<TRow> {
   height: number;
   width: number;
   viewportColumns: readonly CalculatedColumn<TRow>[];


### PR DESCRIPTION
- Remove  `SummaryRowRenderer` component and use memoized `Row` component instead
- Rename `IRowRendererProps` to `RowRendererProps`. This matches the convention 