### PR TITLE
Rearrange props

### DIFF
--- a/packages/react-data-grid-addons/src/__tests__/Grid.test.js
+++ b/packages/react-data-grid-addons/src/__tests__/Grid.test.js
@@ -30,7 +30,7 @@ describe('Grid', () => {
       rowsCount: rows.length,
       minWidth: 300,
       onCellCopyPaste() {},
-      onGridSort() {},
+      onSort() {},
       onAddFilter() {},
       rowKey: 'id',
       ...extraProps
@@ -59,24 +59,24 @@ describe('Grid', () => {
     describe('for defaults props', () => {
       it('uses the appropriate default for the header row height', () => {
         const { wrapper } = setup({ enableHeaderFilters: true });
-        expect(wrapper.find('HeaderRow').prop('height')).toEqual(35);
+        expect(wrapper.find('HeaderRow').prop('height')).toStrictEqual(35);
       });
 
       it('uses the appropriate default for the header filter row height', () => {
         const { wrapper } = setup({ enableHeaderFilters: true });
-        expect(wrapper.find('FilterRow').prop('height')).toEqual(45);
+        expect(wrapper.find('FilterRow').prop('height')).toStrictEqual(45);
       });
     });
 
     describe('for a given row height prop', () => {
       it('passes the grid row height to the header row when no height to the specific header row is provided', () => {
         const { wrapper } = setup({ enableHeaderFilters: true, rowHeight: 40 });
-        expect(wrapper.find('HeaderRow').prop('height')).toEqual(40);
+        expect(wrapper.find('HeaderRow').prop('height')).toStrictEqual(40);
       });
 
       it('uses the default prop height for the filter row when none is provided', () => {
         const { wrapper } = setup({ enableHeaderFilters: true, rowHeight: 40 });
-        expect(wrapper.find('FilterRow').prop('height')).toEqual(45);
+        expect(wrapper.find('FilterRow').prop('height')).toStrictEqual(45);
       });
     });
 
@@ -91,11 +91,11 @@ describe('Grid', () => {
       }
 
       it('passes the correct height to the header row', () => {
-        expect(innerSetup().wrapper.find('HeaderRow').prop('height')).toEqual(50);
+        expect(innerSetup().wrapper.find('HeaderRow').prop('height')).toStrictEqual(50);
       });
 
       it('passes the correct height to the header filter row', () => {
-        expect(innerSetup().wrapper.find('FilterRow').prop('height')).toEqual(60);
+        expect(innerSetup().wrapper.find('FilterRow').prop('height')).toStrictEqual(60);
       });
     });
   });
@@ -105,7 +105,7 @@ describe('Grid', () => {
       it('should set the width of the table', () => {
         const { wrapper } = setup();
         wrapper.setProps({ minWidth: 900 });
-        expect(wrapper.find('.rdg-root').props().style.width).toEqual(900);
+        expect(wrapper.find('.rdg-root').props().style.width).toStrictEqual(900);
       });
     });
   });

--- a/src/Canvas.test.tsx
+++ b/src/Canvas.test.tsx
@@ -20,7 +20,7 @@ const testProps: CanvasProps<Row, 'id'> = {
   rowHeight: 25,
   height: 200,
   rows: [{ id: 0, row: '0' }],
-  onGridRowsUpdated: noop,
+  onRowUpdate: noop,
   enableCellSelect: true,
   enableCellAutoFocus: false,
   enableCellCopyPaste: true,

--- a/src/Canvas.test.tsx
+++ b/src/Canvas.test.tsx
@@ -20,7 +20,7 @@ const testProps: CanvasProps<Row, 'id'> = {
   rowHeight: 25,
   height: 200,
   rows: [{ id: 0, row: '0' }],
-  onRowUpdate: noop,
+  onRowsUpdate: noop,
   enableCellSelect: true,
   enableCellAutoFocus: false,
   enableCellCopyPaste: true,

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -34,7 +34,7 @@ type SharedDataGridProps<R, K extends keyof R> = Pick<DataGridProps<R, K>,
 | 'cellNavigationMode'
 | 'editorPortalTarget'
 | 'renderBatchSize'
-| 'onGridRowsUpdated'
+| 'onRowUpdate'
 >>;
 
 export interface CanvasProps<R, K extends keyof R> extends SharedDataGridProps<R, K> {
@@ -283,7 +283,7 @@ function Canvas<R, K extends keyof R>({
           scrollToCell={scrollToCell}
           editorPortalTarget={props.editorPortalTarget}
           onCheckCellIsEditable={props.onCheckCellIsEditable}
-          onGridRowsUpdated={props.onGridRowsUpdated}
+          onRowUpdate={props.onRowUpdate}
           onSelectedCellChange={props.onSelectedCellChange}
           onSelectedCellRangeChange={props.onSelectedCellRangeChange}
         />

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -14,7 +14,7 @@ type SharedDataGridProps<R, K extends keyof R> = Pick<DataGridProps<R, K>,
 | 'rowRenderer'
 | 'rowGroupRenderer'
 | 'contextMenu'
-| 'RowsContainer'
+| 'rowsContainer'
 | 'selectedRows'
 | 'summaryRows'
 | 'onCheckCellIsEditable'
@@ -65,7 +65,7 @@ function Canvas<R, K extends keyof R>({
   rows,
   rowHeight,
   rowKey,
-  RowsContainer,
+  rowsContainer: RowsContainer,
   summaryRows,
   selectedRows,
   onSelectedRowsChange,

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -34,7 +34,7 @@ type SharedDataGridProps<R, K extends keyof R> = Pick<DataGridProps<R, K>,
 | 'cellNavigationMode'
 | 'editorPortalTarget'
 | 'renderBatchSize'
-| 'onRowUpdate'
+| 'onRowsUpdate'
 >>;
 
 export interface CanvasProps<R, K extends keyof R> extends SharedDataGridProps<R, K> {
@@ -283,7 +283,7 @@ function Canvas<R, K extends keyof R>({
           scrollToCell={scrollToCell}
           editorPortalTarget={props.editorPortalTarget}
           onCheckCellIsEditable={props.onCheckCellIsEditable}
-          onRowUpdate={props.onRowUpdate}
+          onRowsUpdate={props.onRowsUpdate}
           onSelectedCellChange={props.onSelectedCellChange}
           onSelectedCellRangeChange={props.onSelectedCellRangeChange}
         />

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -31,34 +31,20 @@ import {
 export { DataGridHandle };
 
 export interface DataGridProps<R, K extends keyof R> {
+  /**
+   * Grid and data Props
+   */
   /** An array of objects representing each column on the grid */
   columns: readonly Column<R>[];
-  /** The minimum width of the grid in pixels */
-  minWidth?: number;
-  /** The height of the header row in pixels */
-  headerRowHeight?: number;
-  /** The height of the header filter row in pixels */
-  headerFiltersHeight?: number;
-  /** Toggles whether filters row is displayed or not */
-  enableHeaderFilters?: boolean;
-  /** Minimum column width in pixels */
-  minColumnWidth?: number;
-  /** Function called whenever row is clicked */
-  onRowClick?(rowIdx: number, rowData: R, column: CalculatedColumn<R>): void;
-  /** Function called whenever row is double clicked */
-  onRowDoubleClick?(rowIdx: number, rowData: R, column: CalculatedColumn<R>): void;
-
-  filters?: Filters<R>;
-  onFiltersChange?(filters: Filters<R>): void;
-  /** Function called whenever keyboard key is released */
-  onGridKeyUp?(event: React.KeyboardEvent<HTMLDivElement>): void;
-  /** Function called whenever keyboard key is pressed down */
-  onGridKeyDown?(event: React.KeyboardEvent<HTMLDivElement>): void;
-
-  selectedRows?: ReadonlySet<R[K]>;
-  /** Function called whenever row selection is changed */
-  onSelectedRowsChange?(selectedRows: Set<R[K]>): void;
-
+  /** A function called for each rendered row that should return a plain key/value pair object */
+  rows: readonly R[];
+  /**
+   * Rows to be pinned at the bottom of the rows view for summary, the vertical scroll bar will not scroll these rows.
+   * Bottom horizontal scroll bar can move the row left / right. Or a customized row renderer can be used to disabled the scrolling support.
+   */
+  summaryRows?: readonly R[];
+  /** The primary key property of each row */
+  rowKey?: K;
   /**
    * Callback called whenever row data is updated
    * When editing is enabled, this callback will be called for the following scenarios
@@ -68,23 +54,81 @@ export interface DataGridProps<R, K extends keyof R> {
    * 4. Update all cells under a given cell by double clicking the cell's fill handle.
    */
   onGridRowsUpdated?<E extends GridRowsUpdatedEvent<R>>(event: E): void;
-  /** Called when a column is resized */
-  onColumnResize?(idx: number, width: number): void;
 
-  /** Grid Props */
-  /** The primary key property of each row */
-  rowKey?: K;
+  /**
+   * Dimensions props
+   */
+  /** The width of the grid in pixels */
+  width?: number;
+  /** The height of the grid in pixels */
+  height?: number;
+  /** Minimum column width in pixels */
+  minColumnWidth?: number;
   /** The height of each row in pixels */
   rowHeight?: number;
+  /** The height of the header row in pixels */
+  headerRowHeight?: number;
+  /** The height of the header filter row in pixels */
+  headerFiltersHeight?: number;
+
+  /**
+   * Feature props
+   */
+  /** Set of selected row keys */
+  selectedRows?: ReadonlySet<R[K]>;
+  /** Function called whenever row selection is changed */
+  onSelectedRowsChange?(selectedRows: Set<R[K]>): void;
+  /** The key of the column which is currently being sorted */
+  sortColumn?: keyof R;
+  /** The direction to sort the sortColumn*/
+  sortDirection?: DEFINE_SORT;
+  /** Function called whenever grid is sorted*/
+  onGridSort?(columnKey: keyof R, direction: DEFINE_SORT): void;
+  filters?: Filters<R>;
+  onFiltersChange?(filters: Filters<R>): void;
+
+  /**
+   * Custom renderers
+   */
   defaultFormatter?: React.ComponentType<FormatterProps<R>>;
   rowRenderer?: React.ComponentType<RowRendererProps<R>>;
   rowGroupRenderer?: React.ComponentType;
-  /** A function called for each rendered row that should return a plain key/value pair object */
-  rows: readonly R[];
-  /** The minimum height of the grid in pixels */
-  minHeight?: number;
-  /** Component used to render a context menu. react-data-grid-addons provides a default context menu which may be used*/
+  emptyRowsView?: React.ComponentType<{}>;
+  rowsContainer?: React.ComponentType<RowsContainerProps>;
+  /** Component used to render a draggable header cell */
+  draggableHeaderCell?: React.ComponentType<{ column: CalculatedColumn<R>; onHeaderDrop(): void }>;
+  /** Component used to render a context menu. */
   contextMenu?: React.ReactElement;
+
+  /**
+   * Event props
+   */
+  /** Function called whenever a row is clicked */
+  onRowClick?(rowIdx: number, rowData: R, column: CalculatedColumn<R>): void;
+  /** Function called whenever a row is double clicked */
+  onRowDoubleClick?(rowIdx: number, rowData: R, column: CalculatedColumn<R>): void;
+  /** Function called whenever a key is pressed down */
+  onGridKeyDown?(event: React.KeyboardEvent<HTMLDivElement>): void;
+  /** Function called whenever a key is released */
+  onGridKeyUp?(event: React.KeyboardEvent<HTMLDivElement>): void;
+  /** Called when the grid is scrolled */
+  onScroll?(scrollPosition: ScrollPosition): void;
+  /** Called when a column is resized */
+  onColumnResize?(idx: number, width: number): void;
+  onHeaderDrop?(): void;
+  onRowExpandToggle?(event: RowExpandToggleEvent): void;
+  /** Function called whenever selected cell is changed */
+  onSelectedCellChange?(position: Position): void;
+  /** Function called whenever selected cell range is changed */
+  onSelectedCellRangeChange?(selectedRange: SelectedRange): void;
+  /** called before cell is set active, returns a boolean to determine whether cell is editable */
+  onCheckCellIsEditable?(event: CheckCellIsEditableEvent<R>): boolean;
+
+  /**
+   * Toggles and modes
+   */
+  /** Toggles whether filters row is displayed or not */
+  enableHeaderFilters?: boolean;
   /** Used to toggle whether cells can be selected or not */
   enableCellSelect?: boolean;
   /** Toggles whether cells should be autofocused */
@@ -92,34 +136,12 @@ export interface DataGridProps<R, K extends keyof R> {
   enableCellCopyPaste?: boolean;
   enableCellDragAndDrop?: boolean;
   cellNavigationMode?: CellNavigationMode;
+
+  /**
+   * Miscellaneous
+   */
   /** The node where the editor portal should mount. */
   editorPortalTarget?: Element;
-  /** The key of the column which is currently being sorted */
-  sortColumn?: keyof R;
-  /** The direction to sort the sortColumn*/
-  sortDirection?: DEFINE_SORT;
-  /** Function called whenever grid is sorted*/
-  onGridSort?(columnKey: keyof R, direction: DEFINE_SORT): void;
-  /** Called when the grid is scrolled */
-  onScroll?(scrollPosition: ScrollPosition): void;
-  /** Component used to render a draggable header cell */
-  draggableHeaderCell?: React.ComponentType<{ column: CalculatedColumn<R>; onHeaderDrop(): void }>;
-  RowsContainer?: React.ComponentType<RowsContainerProps>;
-  emptyRowsView?: React.ComponentType<{}>;
-  onHeaderDrop?(): void;
-  onRowExpandToggle?(event: RowExpandToggleEvent): void;
-
-  /** Function called whenever selected cell is changed */
-  onSelectedCellChange?(position: Position): void;
-  /** Function called whenever selected cell range is changed */
-  onSelectedCellRangeChange?(selectedRange: SelectedRange): void;
-  /** called before cell is set active, returns a boolean to determine whether cell is editable */
-  onCheckCellIsEditable?(event: CheckCellIsEditableEvent<R>): boolean;
-  /**
-   * Rows to be pinned at the bottom of the rows view for summary, the vertical scroll bar will not scroll these rows.
-   * Bottom horizontal scroll bar can move the row left / right. Or a customized row renderer can be used to disabled the scrolling support.
-   */
-  summaryRows?: readonly R[];
   /** Control how big render row batches will be. */
   renderBatchSize?: number;
 }
@@ -137,8 +159,8 @@ function DataGrid<R, K extends keyof R>({
   headerRowHeight = rowHeight,
   headerFiltersHeight = 45,
   minColumnWidth = 80,
-  minHeight = 350,
-  minWidth: width,
+  height = 350,
+  width,
   enableCellAutoFocus = true,
   enableCellSelect = false,
   enableHeaderFilters = false,
@@ -196,7 +218,7 @@ function DataGrid<R, K extends keyof R>({
   }, [colOverscanEndIdx, colOverscanStartIdx, columnMetrics]);
 
   useLayoutEffect(() => {
-    // Do not calculate the width if minWidth is provided
+    // Do not calculate the width if width is provided
     if (width) return;
     function onResize() {
       // Immediately re-render when the component is mounted to get valid columnMetrics.
@@ -286,7 +308,7 @@ function DataGrid<R, K extends keyof R>({
               columnMetrics={columnMetrics}
               viewportColumns={viewportColumns}
               onScroll={handleScroll}
-              height={minHeight - rowOffsetHeight}
+              height={height - rowOffsetHeight}
               contextMenu={props.contextMenu}
               rowGroupRenderer={props.rowGroupRenderer}
               enableCellSelect={enableCellSelect}
@@ -295,7 +317,7 @@ function DataGrid<R, K extends keyof R>({
               enableCellDragAndDrop={enableCellDragAndDrop}
               cellNavigationMode={cellNavigationMode}
               scrollLeft={scrollLeft}
-              RowsContainer={props.RowsContainer}
+              rowsContainer={props.rowsContainer}
               editorPortalTarget={editorPortalTarget}
               onCanvasKeydown={props.onGridKeyDown}
               onCanvasKeyup={props.onGridKeyUp}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -53,7 +53,7 @@ export interface DataGridProps<R, K extends keyof R> {
    * 3. Update multiple cells by dragging the fill handle of a cell up or down to a destination cell.
    * 4. Update all cells under a given cell by double clicking the cell's fill handle.
    */
-  onRowUpdate?<E extends RowUpdateEvent<R>>(event: E): void;
+  onRowsUpdate?<E extends RowUpdateEvent<R>>(event: E): void;
 
   /**
    * Dimensions props
@@ -250,7 +250,7 @@ function DataGrid<R, K extends keyof R>({
   }
 
   function handleRowUpdate(event: RowUpdateEvent<R>) {
-    props.onRowUpdate?.(event);
+    props.onRowsUpdate?.(event);
   }
 
   const rowOffsetHeight = headerRowHeight + (enableHeaderFilters ? headerFiltersHeight : 0);
@@ -324,7 +324,7 @@ function DataGrid<R, K extends keyof R>({
               renderBatchSize={renderBatchSize}
               summaryRows={props.summaryRows}
               onCheckCellIsEditable={props.onCheckCellIsEditable}
-              onRowUpdate={handleRowUpdate}
+              onRowsUpdate={handleRowUpdate}
               onSelectedCellChange={props.onSelectedCellChange}
               onSelectedCellRangeChange={props.onSelectedCellRangeChange}
               onRowClick={props.onRowClick}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -17,7 +17,7 @@ import {
   CalculatedColumn,
   CheckCellIsEditableEvent,
   Column,
-  GridRowsUpdatedEvent,
+  RowUpdateEvent,
   Position,
   RowsContainerProps,
   RowExpandToggleEvent,
@@ -53,7 +53,7 @@ export interface DataGridProps<R, K extends keyof R> {
    * 3. Update multiple cells by dragging the fill handle of a cell up or down to a destination cell.
    * 4. Update all cells under a given cell by double clicking the cell's fill handle.
    */
-  onGridRowsUpdated?<E extends GridRowsUpdatedEvent<R>>(event: E): void;
+  onRowUpdate?<E extends RowUpdateEvent<R>>(event: E): void;
 
   /**
    * Dimensions props
@@ -83,7 +83,7 @@ export interface DataGridProps<R, K extends keyof R> {
   /** The direction to sort the sortColumn*/
   sortDirection?: DEFINE_SORT;
   /** Function called whenever grid is sorted*/
-  onGridSort?(columnKey: keyof R, direction: DEFINE_SORT): void;
+  onSort?(columnKey: keyof R, direction: DEFINE_SORT): void;
   filters?: Filters<R>;
   onFiltersChange?(filters: Filters<R>): void;
 
@@ -249,8 +249,8 @@ function DataGrid<R, K extends keyof R>({
     props.onScroll?.(scrollPosition);
   }
 
-  function handleGridRowsUpdated(event: GridRowsUpdatedEvent<R>) {
-    props.onGridRowsUpdated?.(event);
+  function handleRowUpdate(event: RowUpdateEvent<R>) {
+    props.onRowUpdate?.(event);
   }
 
   const rowOffsetHeight = headerRowHeight + (enableHeaderFilters ? headerFiltersHeight : 0);
@@ -281,7 +281,7 @@ function DataGrid<R, K extends keyof R>({
               onSelectedRowsChange={onSelectedRowsChange}
               sortColumn={props.sortColumn}
               sortDirection={props.sortDirection}
-              onGridSort={props.onGridSort}
+              onSort={props.onSort}
               scrollLeft={nonStickyScrollLeft}
             />
             {enableHeaderFilters && (
@@ -324,7 +324,7 @@ function DataGrid<R, K extends keyof R>({
               renderBatchSize={renderBatchSize}
               summaryRows={props.summaryRows}
               onCheckCellIsEditable={props.onCheckCellIsEditable}
-              onGridRowsUpdated={handleGridRowsUpdated}
+              onRowUpdate={handleRowUpdate}
               onSelectedCellChange={props.onSelectedCellChange}
               onSelectedCellRangeChange={props.onSelectedCellRangeChange}
               onRowClick={props.onRowClick}

--- a/src/FilterRow.tsx
+++ b/src/FilterRow.tsx
@@ -36,7 +36,7 @@ export default function FilterRow<R, K extends keyof R>({
   return (
     <div
       className="rdg-header-row"
-      style={{ width, height }}
+      style={{ width, height, lineHeight: `${height}px` }}
     >
       {columns.map(column => {
         const { key } = column;

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -2,7 +2,6 @@ import React, { createElement } from 'react';
 import classNames from 'classnames';
 
 import { CalculatedColumn } from './common/types';
-import { DEFINE_SORT } from './common/enums';
 import { HeaderRowProps } from './HeaderRow';
 import SortableHeaderCell from './headerCells/SortableHeaderCell';
 import ResizableHeaderCell from './headerCells/ResizableHeaderCell';
@@ -10,6 +9,7 @@ import ResizableHeaderCell from './headerCells/ResizableHeaderCell';
 type SharedHeaderRowProps<R, K extends keyof R> = Pick<HeaderRowProps<R, K>,
 | 'sortColumn'
 | 'sortDirection'
+| 'onSort'
 | 'height'
 | 'onHeaderDrop'
 | 'allRowsSelected'
@@ -20,7 +20,6 @@ export interface HeaderCellProps<R, K extends keyof R> extends SharedHeaderRowPr
   column: CalculatedColumn<R>;
   lastFrozenColumnIndex: number;
   scrollLeft: number | undefined;
-  onSort?(columnKey: keyof R, direction: DEFINE_SORT): void;
   onResize(column: CalculatedColumn<R>, width: number): void;
   onAllRowsSelectionChange(checked: boolean): void;
 }

--- a/src/HeaderRow.test.tsx
+++ b/src/HeaderRow.test.tsx
@@ -102,7 +102,7 @@ describe('HeaderRow', () => {
     it('does pass the height if available from props', () => {
       const wrapper = renderComponent(requiredProps);
       const headerRowDiv = wrapper.find('div').at(0);
-      expect(headerRowDiv.props().style).toStrictEqual({ height: 35, width: 1000 });
+      expect(headerRowDiv.props().style).toStrictEqual({ height: 35, width: 1000, lineHeight: '35px' });
     });
   });
 });

--- a/src/HeaderRow.test.tsx
+++ b/src/HeaderRow.test.tsx
@@ -14,7 +14,7 @@ describe('HeaderRow', () => {
     columns: helpers.columns,
     lastFrozenColumnIndex: -1,
     onColumnResize() { },
-    onGridSort: jest.fn(),
+    onSort: jest.fn(),
     sortDirection: DEFINE_SORT.NONE,
     width: 1000,
     height: 35,
@@ -46,10 +46,10 @@ describe('HeaderRow', () => {
     it('should call onSort when headerRender triggers sort', () => {
       const { wrapper, props } = setup({ sortColumn: defaultProps.columns[sortableColIdx].key, sortDirection: DEFINE_SORT.ASC });
       wrapper.find('.rdg-header-sort-cell').at(0).simulate('click');
-      expect(props.onGridSort).toHaveBeenNthCalledWith(1, 'title', 'DESC');
+      expect(props.onSort).toHaveBeenNthCalledWith(1, 'title', 'DESC');
 
       wrapper.find('.rdg-header-sort-cell').at(1).simulate('click');
-      expect(props.onGridSort).toHaveBeenNthCalledWith(2, 'count', 'ASC');
+      expect(props.onSort).toHaveBeenNthCalledWith(2, 'count', 'ASC');
     });
   });
 
@@ -82,7 +82,7 @@ describe('HeaderRow', () => {
       height: 35,
       columns: helpers.columns,
       lastFrozenColumnIndex: 1,
-      onGridSort: jest.fn(),
+      onSort: jest.fn(),
       allRowsSelected: false,
       onColumnResize: jest.fn(),
       onHeaderDrop() { },

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -11,7 +11,7 @@ type SharedDataGridProps<R, K extends keyof R> = Pick<DataGridProps<R, K>,
 | 'onSelectedRowsChange'
 | 'sortColumn'
 | 'sortDirection'
-| 'onGridSort'
+| 'onSort'
 > & Required<Pick<DataGridProps<R, K>,
 | 'rowKey'
 >>;
@@ -64,7 +64,7 @@ export default function HeaderRow<R, K extends keyof R>({
             allRowsSelected={props.allRowsSelected}
             onAllRowsSelectionChange={handleAllRowsSelectionChange}
             draggableHeaderCell={props.draggableHeaderCell}
-            onSort={props.onGridSort}
+            onSort={props.onSort}
             sortColumn={props.sortColumn}
             sortDirection={props.sortDirection}
             scrollLeft={column.frozen ? props.scrollLeft : undefined}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -50,7 +50,7 @@ export default function HeaderRow<R, K extends keyof R>({
   return (
     <div
       className="rdg-header-row"
-      style={{ width, height }}
+      style={{ width, height, lineHeight: `${height}px` }}
     >
       {props.columns.map(column => {
         return (

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -193,7 +193,7 @@ export interface RowExpandToggleEvent {
   name: string;
 }
 
-export interface GridRowsUpdatedEvent<TRow, TUpdatedValue = never> {
+export interface RowUpdateEvent<TRow, TUpdatedValue = never> {
   cellKey: keyof TRow;
   fromRow: number;
   toRow: number;

--- a/src/masks/InteractionMasks.test.tsx
+++ b/src/masks/InteractionMasks.test.tsx
@@ -34,7 +34,7 @@ describe('InteractionMasks', () => {
       scrollToCell: jest.fn(),
       onSelectedCellChange,
       onSelectedCellRangeChange: jest.fn(),
-      onRowUpdate: jest.fn(),
+      onRowsUpdate: jest.fn(),
       enableCellSelect: true,
       enableCellAutoFocus: false,
       enableCellCopyPaste: true,
@@ -679,7 +679,7 @@ describe('InteractionMasks', () => {
       // Paste copied cell
       pressKey(wrapper, KeyCodes.v, { ctrlKey: true });
 
-      expect(props.onRowUpdate).toHaveBeenCalledWith({
+      expect(props.onRowsUpdate).toHaveBeenCalledWith({
         cellKey: 'Column1',
         fromRow: 2,
         toRow: 1,
@@ -733,7 +733,7 @@ describe('InteractionMasks', () => {
       });
       wrapper.find('.drag-handle').simulate('dragEnd');
 
-      expect(props.onRowUpdate).toHaveBeenCalledWith({
+      expect(props.onRowsUpdate).toHaveBeenCalledWith({
         cellKey: 'Column1',
         fromRow: 2,
         toRow: 6,
@@ -754,7 +754,7 @@ describe('InteractionMasks', () => {
       });
       wrapper.find('.drag-handle').simulate('dragEnd');
 
-      expect(props.onRowUpdate).toHaveBeenCalledWith({
+      expect(props.onRowsUpdate).toHaveBeenCalledWith({
         cellKey: 'Column1',
         fromRow: 4,
         toRow: 0,

--- a/src/masks/InteractionMasks.test.tsx
+++ b/src/masks/InteractionMasks.test.tsx
@@ -34,7 +34,7 @@ describe('InteractionMasks', () => {
       scrollToCell: jest.fn(),
       onSelectedCellChange,
       onSelectedCellRangeChange: jest.fn(),
-      onGridRowsUpdated: jest.fn(),
+      onRowUpdate: jest.fn(),
       enableCellSelect: true,
       enableCellAutoFocus: false,
       enableCellCopyPaste: true,
@@ -679,7 +679,7 @@ describe('InteractionMasks', () => {
       // Paste copied cell
       pressKey(wrapper, KeyCodes.v, { ctrlKey: true });
 
-      expect(props.onGridRowsUpdated).toHaveBeenCalledWith({
+      expect(props.onRowUpdate).toHaveBeenCalledWith({
         cellKey: 'Column1',
         fromRow: 2,
         toRow: 1,
@@ -733,7 +733,7 @@ describe('InteractionMasks', () => {
       });
       wrapper.find('.drag-handle').simulate('dragEnd');
 
-      expect(props.onGridRowsUpdated).toHaveBeenCalledWith({
+      expect(props.onRowUpdate).toHaveBeenCalledWith({
         cellKey: 'Column1',
         fromRow: 2,
         toRow: 6,
@@ -754,7 +754,7 @@ describe('InteractionMasks', () => {
       });
       wrapper.find('.drag-handle').simulate('dragEnd');
 
-      expect(props.onGridRowsUpdated).toHaveBeenCalledWith({
+      expect(props.onRowUpdate).toHaveBeenCalledWith({
         cellKey: 'Column1',
         fromRow: 4,
         toRow: 0,

--- a/src/masks/InteractionMasks.tsx
+++ b/src/masks/InteractionMasks.tsx
@@ -50,7 +50,7 @@ type SharedCanvasProps<R, K extends keyof R> = Pick<CanvasProps<R, K>,
 | 'onCheckCellIsEditable'
 | 'onSelectedCellChange'
 | 'onSelectedCellRangeChange'
-| 'onRowUpdate'
+| 'onRowsUpdate'
 > & Pick<ColumnMetrics<R>, 'columns'>;
 
 export interface InteractionMasksProps<R, K extends keyof R> extends SharedCanvasProps<R, K> {
@@ -88,7 +88,7 @@ export default function InteractionMasks<R, K extends keyof R>({
   contextMenu,
   onSelectedCellChange,
   onCheckCellIsEditable,
-  onRowUpdate,
+  onRowsUpdate,
   scrollToCell
 }: InteractionMasksProps<R, K>) {
   const [selectedPosition, setSelectedPosition] = useState<Position>(() => {
@@ -249,7 +249,7 @@ export default function InteractionMasks<R, K extends keyof R>({
     const { rowIdx: fromRow, idx, value } = copiedPosition;
     const fromCellKey = columns[idx].key;
 
-    onRowUpdate({
+    onRowsUpdate({
       cellKey,
       fromRow,
       toRow,
@@ -317,7 +317,7 @@ export default function InteractionMasks<R, K extends keyof R>({
     const cellKey = column.key;
     const value = rows[rowIdx][cellKey];
 
-    onRowUpdate({
+    onRowsUpdate({
       cellKey,
       fromRow: rowIdx,
       toRow: overRowIdx,
@@ -333,7 +333,7 @@ export default function InteractionMasks<R, K extends keyof R>({
     const cellKey = column.key;
     const value = rows[selectedPosition.rowIdx][cellKey];
 
-    onRowUpdate({
+    onRowsUpdate({
       cellKey,
       fromRow: selectedPosition.rowIdx,
       toRow: rows.length - 1,
@@ -343,7 +343,7 @@ export default function InteractionMasks<R, K extends keyof R>({
   }
 
   function onCommit({ cellKey, rowIdx, updated }: CommitEvent<R>): void {
-    onRowUpdate({
+    onRowsUpdate({
       cellKey,
       fromRow: rowIdx,
       toRow: rowIdx,

--- a/src/masks/InteractionMasks.tsx
+++ b/src/masks/InteractionMasks.tsx
@@ -50,7 +50,7 @@ type SharedCanvasProps<R, K extends keyof R> = Pick<CanvasProps<R, K>,
 | 'onCheckCellIsEditable'
 | 'onSelectedCellChange'
 | 'onSelectedCellRangeChange'
-| 'onGridRowsUpdated'
+| 'onRowUpdate'
 > & Pick<ColumnMetrics<R>, 'columns'>;
 
 export interface InteractionMasksProps<R, K extends keyof R> extends SharedCanvasProps<R, K> {
@@ -88,7 +88,7 @@ export default function InteractionMasks<R, K extends keyof R>({
   contextMenu,
   onSelectedCellChange,
   onCheckCellIsEditable,
-  onGridRowsUpdated,
+  onRowUpdate,
   scrollToCell
 }: InteractionMasksProps<R, K>) {
   const [selectedPosition, setSelectedPosition] = useState<Position>(() => {
@@ -248,7 +248,7 @@ export default function InteractionMasks<R, K extends keyof R>({
     const { rowIdx: fromRow, idx, value } = copiedPosition;
     const fromCellKey = columns[idx].key;
 
-    onGridRowsUpdated({
+    onRowUpdate({
       cellKey,
       fromRow,
       toRow,
@@ -316,7 +316,7 @@ export default function InteractionMasks<R, K extends keyof R>({
     const cellKey = column.key;
     const value = rows[rowIdx][cellKey];
 
-    onGridRowsUpdated({
+    onRowUpdate({
       cellKey,
       fromRow: rowIdx,
       toRow: overRowIdx,
@@ -332,7 +332,7 @@ export default function InteractionMasks<R, K extends keyof R>({
     const cellKey = column.key;
     const value = rows[selectedPosition.rowIdx][cellKey];
 
-    onGridRowsUpdated({
+    onRowUpdate({
       cellKey,
       fromRow: selectedPosition.rowIdx,
       toRow: rows.length - 1,
@@ -342,7 +342,7 @@ export default function InteractionMasks<R, K extends keyof R>({
   }
 
   function onCommit({ cellKey, rowIdx, updated }: CommitEvent<R>): void {
-    onGridRowsUpdated({
+    onRowUpdate({
       cellKey,
       fromRow: rowIdx,
       toRow: rowIdx,

--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -1,7 +1,7 @@
 import faker from 'faker';
 import React, { useState, useMemo, useCallback, useRef } from 'react';
 import { AutoSizer } from 'react-virtualized';
-import DataGrid, { Column, SelectColumn, UpdateActions, DataGridHandle, GridRowsUpdatedEvent } from '../../src';
+import DataGrid, { Column, SelectColumn, UpdateActions, DataGridHandle, RowUpdateEvent } from '../../src';
 import DropDownEditor from './components/Editors/DropDownEditor';
 import { ImageFormatter } from './components/Formatters';
 import Toolbar from './components/Toolbar/Toolbar';
@@ -166,7 +166,7 @@ export default function AllFeatures() {
     }
   ], []);
 
-  const handleGridRowsUpdated = useCallback(({ fromRow, toRow, updated, action }: GridRowsUpdatedEvent<Row, Partial<Row>>): void => {
+  const handleRowUpdate = useCallback(({ fromRow, toRow, updated, action }: RowUpdateEvent<Row, Partial<Row>>): void => {
     const newRows = [...rows];
     let start;
     let end;
@@ -199,7 +199,7 @@ export default function AllFeatures() {
               enableCellSelect
               columns={columns}
               rows={rows}
-              onGridRowsUpdated={handleGridRowsUpdated}
+              onRowUpdate={handleRowUpdate}
               rowHeight={30}
               width={width}
               height={height}

--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -201,8 +201,8 @@ export default function AllFeatures() {
               rows={rows}
               onGridRowsUpdated={handleGridRowsUpdated}
               rowHeight={30}
-              minWidth={width}
-              minHeight={height}
+              width={width}
+              height={height}
               selectedRows={selectedRows}
               onSelectedRowsChange={setSelectedRows}
               enableCellCopyPaste

--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -199,7 +199,7 @@ export default function AllFeatures() {
               enableCellSelect
               columns={columns}
               rows={rows}
-              onRowUpdate={handleRowUpdate}
+              onRowsUpdate={handleRowUpdate}
               rowHeight={30}
               width={width}
               height={height}

--- a/stories/demos/Basic.tsx
+++ b/stories/demos/Basic.tsx
@@ -24,7 +24,7 @@ export default function Basic() {
     <DataGrid<Row, 'id'>
       columns={columns}
       rows={rows}
-      minHeight={150}
+      height={150}
     />
   );
 }

--- a/stories/demos/CellActions.tsx
+++ b/stories/demos/CellActions.tsx
@@ -154,7 +154,7 @@ export default function CellActions() {
       columns={columns}
       rows={rows}
       rowHeight={55}
-      minHeight={600}
+      height={600}
     />
   );
 }

--- a/stories/demos/FrozenColumns.tsx
+++ b/stories/demos/FrozenColumns.tsx
@@ -89,8 +89,8 @@ export default function FrozenColumns() {
           <DataGrid<Row, 'id'>
             columns={columns}
             rows={rows}
-            minHeight={height}
-            minWidth={width}
+            height={height}
+            width={width}
             headerRowHeight={27}
             rowHeight={18}
             minColumnWidth={60}

--- a/stories/demos/ResizableColumns.tsx
+++ b/stories/demos/ResizableColumns.tsx
@@ -80,7 +80,7 @@ export default function ResizableColumns() {
     <DataGrid
       columns={columns}
       rows={rows}
-      minHeight={500}
+      height={500}
       minColumnWidth={120}
     />
   );

--- a/stories/demos/TreeView.tsx
+++ b/stories/demos/TreeView.tsx
@@ -157,7 +157,7 @@ export default function TreeView() {
         enableCellSelect
         columns={columns}
         rows={rows}
-        minHeight={500}
+        height={500}
       />
     </>
   );

--- a/stories/demos/example04-editable.js
+++ b/stories/demos/example04-editable.js
@@ -92,7 +92,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onRowUpdate={this.handleGridRowsUpdated}
+          onRowsUpdate={this.handleGridRowsUpdated}
         />
       </Wrapper>
     );

--- a/stories/demos/example04-editable.js
+++ b/stories/demos/example04-editable.js
@@ -92,7 +92,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onGridRowsUpdated={this.handleGridRowsUpdated}
+          onRowUpdate={this.handleGridRowsUpdated}
         />
       </Wrapper>
     );

--- a/stories/demos/example06-built-in-editors.js
+++ b/stories/demos/example06-built-in-editors.js
@@ -82,7 +82,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onGridRowsUpdated={this.handleGridRowsUpdated}
+          onRowUpdate={this.handleGridRowsUpdated}
         />
       </Wrapper>
     );

--- a/stories/demos/example06-built-in-editors.js
+++ b/stories/demos/example06-built-in-editors.js
@@ -82,7 +82,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onRowUpdate={this.handleGridRowsUpdated}
+          onRowsUpdate={this.handleGridRowsUpdated}
         />
       </Wrapper>
     );

--- a/stories/demos/example08-sortable-cols.js
+++ b/stories/demos/example08-sortable-cols.js
@@ -92,7 +92,7 @@ export default class extends React.Component {
     return (
       <Wrapper title="Sortable Columns Example">
         <DataGrid
-          onGridSort={this.handleGridSort}
+          onSort={this.handleGridSort}
           columns={this._columns}
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}

--- a/stories/demos/example14-all-features-immutable.js
+++ b/stories/demos/example14-all-features-immutable.js
@@ -181,7 +181,7 @@ export default class extends React.Component {
           columns={columns}
           rowGetter={this.getRowAt}
           rowsCount={this.getSize()}
-          onRowUpdate={this.handleGridRowsUpdated}
+          onRowsUpdate={this.handleGridRowsUpdated}
           rowHeight={50}
           minHeight={600}
           enableCellCopyPaste

--- a/stories/demos/example14-all-features-immutable.js
+++ b/stories/demos/example14-all-features-immutable.js
@@ -181,7 +181,7 @@ export default class extends React.Component {
           columns={columns}
           rowGetter={this.getRowAt}
           rowsCount={this.getSize()}
-          onGridRowsUpdated={this.handleGridRowsUpdated}
+          onRowUpdate={this.handleGridRowsUpdated}
           rowHeight={50}
           minHeight={600}
           enableCellCopyPaste

--- a/stories/demos/example16-cell-drag-down.js
+++ b/stories/demos/example16-cell-drag-down.js
@@ -74,7 +74,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onRowUpdate={this.handleGridRowsUpdated}
+          onRowsUpdate={this.handleGridRowsUpdated}
           enableCellDragAndDrop
         />
       </Wrapper>

--- a/stories/demos/example16-cell-drag-down.js
+++ b/stories/demos/example16-cell-drag-down.js
@@ -74,7 +74,7 @@ export default class extends React.Component {
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}
           minHeight={500}
-          onGridRowsUpdated={this.handleGridRowsUpdated}
+          onRowUpdate={this.handleGridRowsUpdated}
           enableCellDragAndDrop
         />
       </Wrapper>

--- a/stories/demos/example16-filterable-sortable-grid.js
+++ b/stories/demos/example16-filterable-sortable-grid.js
@@ -119,7 +119,7 @@ export default class extends React.Component {
           onToggleFilter={this.onToggleFilter}
         />
         <DataGrid
-          onGridSort={this.handleGridSort}
+          onSort={this.handleGridSort}
           sortDirection={this.state.sortDirection}
           sortColumn={this.state.sortColumn}
           enableCellSelect

--- a/stories/demos/example19-column-events.js
+++ b/stories/demos/example19-column-events.js
@@ -93,7 +93,7 @@ export default class extends React.Component {
           columns={this.getColumns()}
           enableCellSelect
           rowGetter={this.rowGetter}
-          onGridRowsUpdated={this.handleGridRowsUpdated}
+          onRowUpdate={this.handleGridRowsUpdated}
           rowsCount={this.state.rows.length}
           minHeight={500}
         />

--- a/stories/demos/example19-column-events.js
+++ b/stories/demos/example19-column-events.js
@@ -93,7 +93,7 @@ export default class extends React.Component {
           columns={this.getColumns()}
           enableCellSelect
           rowGetter={this.rowGetter}
-          onRowUpdate={this.handleGridRowsUpdated}
+          onRowsUpdate={this.handleGridRowsUpdated}
           rowsCount={this.state.rows.length}
           minHeight={500}
         />

--- a/stories/demos/example29-descendingFirstSortable.js
+++ b/stories/demos/example29-descendingFirstSortable.js
@@ -99,7 +99,7 @@ export default class extends React.Component {
     return (
       <Wrapper title="Sort Descending First Sortable Columns Example">
         <DataGrid
-          onGridSort={this.handleGridSort}
+          onSort={this.handleGridSort}
           columns={this._columns}
           rowGetter={this.rowGetter}
           rowsCount={this.state.rows.length}


### PR DESCRIPTION
- Rearranged the main props interface so it makes a bit more sense
- `minHeight` -> `height`
- `minWidth` -> `width`
- `RowsContainer` -> `rowsContainer`
- `onGridSort` -> `onSort`
- `onGridRowsUpdated` -> `onRowsUpdate`
- Fixed header/filter row line heights