### PR TITLE
Add Column.cellClass function support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Rename `RowsContainer` to `rowsContainer`
 - Rename `onGridSort` to `onSort`
 - Rename `onGridRowsUpdated` to `onRowsUpdate`
+- Added function support for `column.cellClass`:
+  - `column = { ..., cellClass(row) { return string; } }`
+  - `column.cellClass` does not affect header cells anymore
 
 ## next -> canary
 - Column resize now resizes all the cells which means re-rendering the whole grid when resizing columns.
@@ -34,7 +37,7 @@
 - Drop dynamic height row support. This was not an official feature but it was still possible to implement dynamic rows via custom Row renderer. This was a buggy feature so it has been removed.
 - Remove `formatter.isScrolling` prop. `isScrolling` prop was introduced to improve performance of expensive formatters. This is no longer required as the internals of the grid were rewritten to improve performance
 - Add summary rows [1773](https://github.com/adazzle/react-data-grid/pull/1773)
-- Remove row reordering support. This was a buggy feature so it has been removed. 
+- Remove row reordering support. This was a buggy feature so it has been removed.
 - Remove toolbar prop. Check [here](https://github.com/adazzle/react-data-grid/pull/1769) on how to migrate.
 - Remove internal `sortColumn` and `sortDirection` states. Sorting is now only controlled by `sortColumn` and `sortDirection` props. Check [here](https://github.com/adazzle/react-data-grid/pull/1768) on how to migrate.
 - Improve scrolling performance

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -67,13 +67,15 @@ function Cell<R>({
     eventBus.dispatch('SELECT_ROW', { rowIdx, checked, isShiftClick });
   }
 
+  const { cellClass } = column;
   className = classNames(
-    column.cellClass,
     'rdg-cell',
-    className, {
+    {
       'rdg-cell-frozen': column.frozen,
       'rdg-cell-frozen-last': column.idx === lastFrozenColumnIndex
-    }
+    },
+    className,
+    typeof cellClass === 'function' ? cellClass(rowData) : cellClass
   );
 
   const style: React.CSSProperties = {

--- a/src/FilterRow.tsx
+++ b/src/FilterRow.tsx
@@ -45,7 +45,7 @@ export default function FilterRow<R, K extends keyof R>({
         const className = classNames('rdg-cell', {
           'rdg-cell-frozen': column.frozen,
           'rdg-cell-frozen-last': column.idx === lastFrozenColumnIndex
-        }, column.cellClass);
+        });
         const style: React.CSSProperties = {
           width: column.width,
           left: column.left

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -56,7 +56,7 @@ export default function HeaderCell<R, K extends keyof R>({
   const className = classNames('rdg-cell', {
     'rdg-cell-frozen': column.frozen,
     'rdg-cell-frozen-last': column.idx === props.lastFrozenColumnIndex
-  }, column.cellClass);
+  });
   const style: React.CSSProperties = {
     width: column.width,
     left: column.left

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,7 +12,7 @@ interface ColumnValue<TRow, TField extends keyof TRow = keyof TRow> {
   key: TField;
   /** Column width. If not specified, it will be determined automatically based on grid width and specified widths of other columns*/
   width?: number | string;
-  cellClass?: string;
+  cellClass?: string | ((rowData: TRow) => string);
   /** Formatter to be used to render the cell content */
   formatter?: React.ComponentType<FormatterProps<TRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */


### PR DESCRIPTION
Not sure if passing `row` is enough.
Not sure if it makes sense for header/filter cells to have custom classes as well, so I removed them.
WDYT?