### PR TITLE
rm superfluous `@supports` block

### DIFF
--- a/packages/react-data-grid/style/rdg-cell.less
+++ b/packages/react-data-grid/style/rdg-cell.less
@@ -13,15 +13,10 @@
 }
 
 .rdg-cell-frozen {
+  position: -webkit-sticky;
+  position: sticky;
   /* Should have a higher value than 1 to show in front of cell masks */
   z-index: 2;
-
-  @supports (position: sticky) or (position: -webkit-sticky) {
-    & {
-      position: -webkit-sticky;
-      position: sticky;
-    }
-  }
 }
 
 .rdg-cell-frozen-last {


### PR DESCRIPTION
This `@supports` block is superfluous, we don't add anything more than the properties we check support for.
We've also seen a case where a minifier removes the spaces around the `or`, which ends up breaking parsing in Chrome, so the properties end up not being applied. Our published stylesheet don't have that issue FWIW.