### PR TITLE
Rechart import casing issue

### DIFF
--- a/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
+++ b/packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
@@ -1,7 +1,7 @@
 import ReactDataGrid from 'react-data-grid';
 import exampleWrapper from '../components/exampleWrapper';
 import React from 'react';
-import {AreaChart, Area} from 'Recharts';
+import {AreaChart, Area} from 'recharts';
 
 const getRandom = (min, max) => {
   min = Math.ceil(min);


### PR DESCRIPTION
## Description
Running 'npm install' 'npm run dev-server' throws an error:
./packages/react-data-grid-examples/src/scripts/example31-isScrolling.js
Module not found: Error: Can't resolve 'Recharts' in 'react-data-grid/packages/react-data-grid-examples/src/scripts'
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/docs/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/adazzle/react-data-grid/issues/1295
Currently the casing of rechart causes the dev server to fail. 


**What is the new behavior?**
Corrected the import so that the server boots up


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

**Other information**:
Ubuntu machine,
npm -v 6.13.6
node -v v13.8.0
