### PR TITLE
Drag handler sends itself as the first edited cell

### DIFF
--- a/packages/react-data-grid/src/masks/InteractionMasks.js
+++ b/packages/react-data-grid/src/masks/InteractionMasks.js
@@ -600,14 +600,14 @@ class InteractionMasks extends React.Component {
     const { draggedPosition } = this.state;
     if (draggedPosition != null) {
       const { rowIdx, overRowIdx } = draggedPosition;
-      if (overRowIdx != null) {
+      const offsetRowIdx = rowIdx + 1;
+      if (overRowIdx != null && rowIdx !== overRowIdx) {
         const { columns, onCellsDragged, onGridRowsUpdated, rowGetter } = this.props;
         const column = getSelectedColumn({ selectedPosition: draggedPosition, columns });
         const value = getSelectedCellValue({ selectedPosition: draggedPosition, columns, rowGetter });
         const cellKey = column.key;
-        const fromRow = rowIdx < overRowIdx ? rowIdx : overRowIdx;
-        const toRow = rowIdx > overRowIdx ? rowIdx : overRowIdx;
-
+        const fromRow = offsetRowIdx < overRowIdx ? offsetRowIdx : overRowIdx;
+        const toRow = offsetRowIdx > overRowIdx ? offsetRowIdx : overRowIdx;
         if (isFunction(onCellsDragged)) {
           onCellsDragged({ cellKey, fromRow, toRow, value });
         }
@@ -622,11 +622,13 @@ class InteractionMasks extends React.Component {
   };
 
   onDragHandleDoubleClick = () => {
-    const { onDragHandleDoubleClick, rowGetter } = this.props;
+    const { onDragHandleDoubleClick, rowGetter, rowsCount } = this.props;
     const { selectedPosition } = this.state;
     const { idx, rowIdx } = selectedPosition;
     const rowData = getSelectedRow({ selectedPosition, rowGetter });
-    onDragHandleDoubleClick({ idx, rowIdx, rowData });
+    if(rowIdx !== rowsCount - 1) {
+      onDragHandleDoubleClick({ idx, rowIdx: rowIdx + 1, rowData });
+    }
   };
 
   onCommit = (...args) => {

--- a/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.js
+++ b/packages/react-data-grid/src/masks/__tests__/InteractionMasks.spec.js
@@ -760,9 +760,36 @@ describe('<InteractionMasks/>', () => {
       props.eventBus.dispatch(EventTypes.DRAG_ENTER, { overRowIdx: 6 });
       wrapper.find(DragHandle).simulate('dragEnd');
 
-      expect(props.onGridRowsUpdated).toHaveBeenCalledWith('Column1', 2, 6, { Column1: '3' }, UpdateActions.CELL_DRAG);
+      expect(props.onGridRowsUpdated).toHaveBeenCalledWith('Column1', 3, 6, { Column1: '3' }, UpdateActions.CELL_DRAG);
+    });
+
+    it('should ignore drag interacations that do not cause edits', () => {
+      const { wrapper, props } = setupDrag();
+      const setData = jasmine.createSpy();
+      wrapper.find(DragHandle).simulate('dragstart', {
+        target: { className: 'test' },
+        dataTransfer: { setData }
+      });
+      props.eventBus.dispatch(EventTypes.DRAG_ENTER, { overRowIdx: 2 });
+      wrapper.find(DragHandle).simulate('dragEnd');
+
+      expect(props.onGridRowsUpdated).not.toHaveBeenCalled();
+    });
+
+    it('should update a lone adjacent dragged over cell on drag end', () => {
+      const { wrapper, props } = setupDrag();
+      const setData = jasmine.createSpy();
+      wrapper.find(DragHandle).simulate('dragstart', {
+        target: { className: 'test' },
+        dataTransfer: { setData }
+      });
+      props.eventBus.dispatch(EventTypes.DRAG_ENTER, { overRowIdx: 3 });
+      wrapper.find(DragHandle).simulate('dragEnd');
+
+      expect(props.onGridRowsUpdated).toHaveBeenCalledWith('Column1', 3, 3, { Column1: '3' }, UpdateActions.CELL_DRAG);
     });
   });
+
 
   describe('ContextMenu functionality', () => {
     it('should render the context menu if it a valid element', () => {


### PR DESCRIPTION
## Description
Floating this breaking change as an idea for v7 onwards as the current functionality seems weird to me.

Currently, selecting an editable cell and dragging downward calls onGridRowsUpdated with itself included in the range. It's impossible for this action to change the value of the cell being copied, and thus it should be excluded from this handler.

NOTE: These changes did not break any tests for the COLUMN_FILL action. That's probably a bad thing. I tried to add some however I couldn't get the the the doubleclick event on DragHandler to trigger any callbacks in interactionmasks.spec.js

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/docs/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
**What is the new behavior?**
If I click the drag handler, but do not drag over any new cells, the onGridRowsUpdated should not be called.
Currently called with (fromRow: draggedCellIndex, toRow: draggedCellIndex)
If I click the drag hander, and cover n cells, the range should include n values.
Currently the range includes n + 1 starting at itself
If I double click the drag handler, but the cell is in the last row, onGridRowsUpdated should not be called. 
Currently called with itself as the only row in the range. 
If I double click the drag handler, onGridRowsUpdated should be called with the n rows below it.
Currently called with n+1 rows starting at itself

**Does this PR introduce a breaking change?** (check one with "x")
```
[ x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
All applications which depend on the dragHandler cell being passed through will be broken. 

**Other information**:
