### PR TITLE
rm CellRendererProps.idx and SummaryCellProps.idx

### DIFF
--- a/src/Cell.test.tsx
+++ b/src/Cell.test.tsx
@@ -18,7 +18,6 @@ const defaultColumn: CalculatedColumn<Row> = {
 
 const testProps: CellRendererProps<Row> = {
   rowIdx: 0,
-  idx: 1,
   column: defaultColumn,
   lastFrozenColumnIndex: -1,
   row: { id: 1, description: 'Wicklow' },
@@ -63,7 +62,6 @@ describe('Cell', () => {
 
     const requiredProperties: CellRendererProps<Row> = {
       rowIdx: 18,
-      idx: 19,
       column: helpers.columns[0],
       lastFrozenColumnIndex: -1,
       row: helpers.rows[11],

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -8,7 +8,6 @@ function Cell<R, SR>({
   children,
   className,
   column,
-  idx,
   isRowSelected,
   lastFrozenColumnIndex,
   row,
@@ -26,7 +25,7 @@ function Cell<R, SR>({
   ...props
 }: CellRendererProps<R, SR>) {
   function selectCell(openEditor?: boolean) {
-    eventBus.dispatch('SELECT_CELL', { idx, rowIdx }, openEditor);
+    eventBus.dispatch('SELECT_CELL', { idx: column.idx, rowIdx }, openEditor);
   }
 
   function handleCellClick() {
@@ -35,7 +34,7 @@ function Cell<R, SR>({
   }
 
   function handleCellMouseDown() {
-    eventBus.dispatch('SELECT_START', { idx, rowIdx });
+    eventBus.dispatch('SELECT_START', { idx: column.idx, rowIdx });
 
     function handleWindowMouseUp() {
       eventBus.dispatch('SELECT_END');
@@ -46,7 +45,7 @@ function Cell<R, SR>({
   }
 
   function handleCellMouseEnter() {
-    eventBus.dispatch('SELECT_UPDATE', { idx, rowIdx });
+    eventBus.dispatch('SELECT_UPDATE', { idx: column.idx, rowIdx });
   }
 
   function handleCellContextMenu() {

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -40,7 +40,6 @@ export default function Row<R, SR = unknown>({
       return (
         <CellRenderer
           key={column.key}
-          idx={column.idx}
           rowIdx={rowIdx}
           column={column}
           lastFrozenColumnIndex={lastFrozenColumnIndex}

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { CellRendererProps } from './common/types';
 
 type SharedCellRendererProps<R, SR> = Pick<CellRendererProps<R, SR>,
-  | 'idx'
   | 'lastFrozenColumnIndex'
   | 'scrollLeft'
   | 'column'
@@ -20,12 +19,12 @@ function SummaryCell<R, SR>({
   row,
   scrollLeft
 }: SummaryCellProps<R, SR>) {
-  const { summaryFormatter: SummaryFormatter, frozen, idx, width, left, summaryCellClass } = column;
+  const { summaryFormatter: SummaryFormatter, width, left, summaryCellClass } = column;
   const className = classNames(
     'rdg-cell',
     {
-      'rdg-cell-frozen': frozen,
-      'rdg-cell-frozen-last': idx === lastFrozenColumnIndex
+      'rdg-cell-frozen': column.frozen,
+      'rdg-cell-frozen-last': column.idx === lastFrozenColumnIndex
     },
     typeof summaryCellClass === 'function' ? summaryCellClass(row) : summaryCellClass
   );

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -38,7 +38,6 @@ function SummaryRow<R, SR>({
       {viewportColumns.map(column => (
         <SummaryCell<R, SR>
           key={column.key}
-          idx={column.idx}
           column={column}
           lastFrozenColumnIndex={lastFrozenColumnIndex}
           row={row}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -123,7 +123,6 @@ export interface HeaderRendererProps<TRow, TSummaryRow> {
 }
 
 export interface CellRendererProps<TRow, TSummaryRow = unknown> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style'> {
-  idx: number;
   rowIdx: number;
   column: CalculatedColumn<TRow, TSummaryRow>;
   lastFrozenColumnIndex: number;


### PR DESCRIPTION
`idx === column.idx`, and we already pass `column` so I this prop is redundant.