### PR TITLE
CI: Use a git worktree instead of checking out gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,21 +52,22 @@ jobs:
     - name: Deploy master
       if: github.ref == 'refs/heads/master'
       run: |
-        git checkout --orphan gh-pages
-        git rm --cached $(git ls-files)
-        git add -f storybook-static
-        git mv storybook-static/* .
         git fetch origin gh-pages
-        git checkout origin/gh-pages -- canary
-        git commit -m "master storybook deployment"
+        git worktree add gh-pages
+        git rm -r .
+        git checkout gh-pages -- canary
+        mv ../storybook-static/* .
+        git add .
+        git commit --allow-empty -m "master storybook deployment"
         git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git
     - name: Deploy canary
       if: github.ref == 'refs/heads/canary'
       run: |
         git fetch origin gh-pages
-        git checkout gh-pages
+        git worktree add gh-pages
+        cd gh-pages
         git rm -r --ignore-unmatch canary
-        mv storybook-static canary
+        mv ../storybook-static canary
         git add canary
-        git commit -m "canary storybook deployment"
+        git commit --allow-empty -m "canary storybook deployment"
         git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git


### PR DESCRIPTION
- the `cache` action was [crashing](https://github.com/adazzle/react-data-grid/runs/451176173?check_suite_focus=true) since it couldn't find and hash the `package.json` file, because we checked out the `gh-pages`
- this PR fixes this issue by using the [git-worktree](https://git-scm.com/docs/git-worktree) feature instead.
  - we'll now preserve `gh-pages` git history on when deploying the master storybook. Not that we lost any history since we don't yet have a storybook for the master branch.
- also fixed potential "crash" when there was nothing new to commit by adding `--allow-empty`

I was testing this on this branch before cleaning it out (didn't push anything to `gh-pages`):
https://github.com/adazzle/react-data-grid/runs/452700654?check_suite_focus=true