### PR TITLE
forwardRef(Cell)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
     "@babel/runtime": "^7.7.4",
+    "@material-ui/core": "^4.7.1",
+    "@material-ui/icons": "^4.5.1",
     "@testing-library/react": "^9.3.2",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.3",

--- a/packages/react-data-grid-addons/package.json
+++ b/packages/react-data-grid-addons/package.json
@@ -25,6 +25,8 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@material-ui/core": "^4.7.1",
+    "@material-ui/icons": "^4.5.1",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-contextmenu": "^2.13.0",

--- a/packages/react-data-grid/src/Cell.tsx
+++ b/packages/react-data-grid/src/Cell.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { forwardRef, memo } from 'react';
 import classNames from 'classnames';
 
 import { CellRendererProps, ColumnEventInfo } from './common/types';
@@ -24,7 +24,7 @@ function Cell<R>({
   rowData,
   rowIdx,
   scrollLeft
-}: CellProps<R>) {
+}: CellProps<R>, ref: React.Ref<HTMLDivElement>) {
   function handleCellClick() {
     cellMetaData.onCellClick({ idx, rowIdx });
   }
@@ -120,6 +120,7 @@ function Cell<R>({
 
   return (
     <div
+      ref={ref}
       className={className}
       style={style}
       {...getEvents()}
@@ -139,4 +140,4 @@ function Cell<R>({
   );
 }
 
-export default memo(Cell) as <R>(props: CellProps<R>) => JSX.Element;
+export default memo(forwardRef(Cell)) as <R>(props: CellProps<R>) => JSX.Element;


### PR DESCRIPTION
Started getting errors regarding missing material-ui as we import icons in rdg-addons/examples, so I added the dependencies. I don't know why this only started happening now.