### PR TITLE
Fix broken link to migration docs in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install react-data-grid@alpha
 
 Migrations
 --------
-If you intend to do a major release update for you react-data-grid check [the migration documents](migrations).
+If you intend to do a major release update for you react-data-grid check [the migration documents](docs/migrations).
 
 Features
 --------


### PR DESCRIPTION
The old link returned a 404, this updates the link to what I presume is the correct location within the repo.