### PR TITLE
Commit changes when EditorContainer is unmounted

### DIFF
--- a/src/editors/EditorContainer.test.tsx
+++ b/src/editors/EditorContainer.test.tsx
@@ -228,22 +228,22 @@ describe('EditorContainer', () => {
       expect(props.onCommit).toHaveBeenCalledTimes(1);
     });
 
-    // it('hitting escape should call commitCancel only once', () => {
-    //   const { wrapper, props } = setup();
-    //   const editor = wrapper.find(SimpleTextEditor);
-    //   editor.simulate('keydown', { key: 'Escape' });
+    it('hitting escape should call commitCancel only once', () => {
+      const { wrapper, props } = setup();
+      const editor = wrapper.find(SimpleTextEditor);
+      editor.simulate('keydown', { key: 'Escape' });
 
-    //   expect(props.onCommitCancel).toHaveBeenCalledTimes(1);
-    // });
+      expect(props.onCommitCancel).toHaveBeenCalledTimes(1);
+    });
 
-    // it('hitting escape should not call commit changes on componentWillUnmount', () => {
-    //   const { wrapper, props } = setup();
-    //   const editor = wrapper.find(SimpleTextEditor);
-    //   editor.simulate('keydown', { key: 'Escape' });
-    //   wrapper.unmount();
+    it('hitting escape should not call commit changes on componentWillUnmount', () => {
+      const { wrapper, props } = setup();
+      const editor = wrapper.find(SimpleTextEditor);
+      editor.simulate('keydown', { key: 'Escape' });
+      wrapper.unmount();
 
-    //   expect(props.onCommit).not.toHaveBeenCalled();
-    // });
+      expect(props.onCommit).not.toHaveBeenCalled();
+    });
 
     it('should commit if any element outside the editor is clicked', () => {
       const { props } = setup();

--- a/src/editors/EditorContainer.tsx
+++ b/src/editors/EditorContainer.tsx
@@ -139,6 +139,8 @@ export default function EditorContainer<R, SR>({
       e.stopPropagation();
     } else if (['Enter', 'Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
       commit();
+    } else if (e.key === 'Escape') {
+      commitCancel();
     }
   }
 

--- a/src/editors/EditorContainer.tsx
+++ b/src/editors/EditorContainer.tsx
@@ -40,6 +40,7 @@ export default function EditorContainer<R, SR>({
   const [isValid, setValid] = useState(true);
   const prevScrollLeft = useRef(scrollLeft);
   const prevScrollTop = useRef(scrollTop);
+  const isUnmounting = useRef(false);
 
   const getInputNode = useCallback(() => editorRef.current?.getInputNode(), []);
 
@@ -66,15 +67,16 @@ export default function EditorContainer<R, SR>({
     }
   }, [commitCancel, scrollLeft, scrollTop]);
 
-  // commit changes when editor is closed
-  useEffect(() => {
-    return () => {
-      if (!changeCommitted.current && !changeCanceled.current) {
-        commit();
-      }
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => () => {
+    isUnmounting.current = true;
   }, []);
+
+  // commit changes when editor is closed
+  useEffect(() => () => {
+    if (isUnmounting.current && !changeCommitted.current && !changeCanceled.current) {
+      commit();
+    }
+  });
 
   function getInitialValue() {
     const value = row[column.key as keyof R];


### PR DESCRIPTION
This matches the legacy behavior.
https://github.com/adazzle/react-data-grid/blob/alpha/packages/react-data-grid/src/common/editors/EditorContainer.tsx#L56

`ClickOutside` does not commit changes when another cell is selected. I think it may be due to fact that component is unmounted before `ClickOutside` has a chance to commit changes. You can remove `onBlur` event handler in `SimpleTextEditor` to test this fix
https://github.com/adazzle/react-data-grid/blob/canary/src/editors/SimpleTextEditor.tsx#L25

Most of the textbox editors do not handle onBlur event so I think we should add the commit logic back

