### PR TITLE
Cleanup onRowsUpdate type

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -52,7 +52,8 @@ export interface DataGridProps<R, K extends keyof R, SR = unknown> {
    * 3. Update multiple cells by dragging the fill handle of a cell up or down to a destination cell.
    * 4. Update all cells under a given cell by double clicking the cell's fill handle.
    */
-  onRowsUpdate?: <E extends RowsUpdateEvent>(event: E) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onRowsUpdate?: (event: RowsUpdateEvent<any>) => void;
 
   /**
    * Dimensions props
@@ -237,7 +238,7 @@ function DataGrid<R, K extends keyof R, SR>({
     props.onScroll?.(scrollPosition);
   }
 
-  function handleRowUpdate(event: RowsUpdateEvent) {
+  function handleRowUpdate(event: RowsUpdateEvent<unknown>) {
     props.onRowsUpdate?.(event);
   }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -85,7 +85,7 @@ export interface Dimension {
   zIndex: number;
 }
 
-export interface Editor<TValue = never> {
+export interface Editor<TValue = unknown> {
   getInputNode: () => Element | Text | undefined | null;
   getValue: () => TValue;
   hasResults?: () => boolean;
@@ -173,10 +173,10 @@ export interface RowGroupMetaData {
 
 export type Filters = Record<string, any>;
 
-export interface CommitEvent<TUpdatedValue = never> {
+export interface CommitEvent {
   cellKey: string;
   rowIdx: number;
-  updated: TUpdatedValue;
+  updated: unknown;
 }
 
 export interface RowExpandToggleEvent {
@@ -186,7 +186,7 @@ export interface RowExpandToggleEvent {
   name: string;
 }
 
-export interface RowsUpdateEvent<TUpdatedValue = never> {
+export interface RowsUpdateEvent<TUpdatedValue> {
   cellKey: string;
   fromRow: number;
   toRow: number;

--- a/src/editors/EditorContainer.tsx
+++ b/src/editors/EditorContainer.tsx
@@ -34,7 +34,7 @@ export default function EditorContainer<R, SR>({
   scrollTop,
   firstEditorKeyPress: key
 }: EditorContainerProps<R, SR>) {
-  const editorRef = useRef<Editor>(null);
+  const editorRef = useRef<Editor<{ [key: string]: R[keyof R] }>>(null);
   const changeCommitted = useRef(false);
   const changeCanceled = useRef(false);
   const [isValid, setValid] = useState(true);

--- a/src/masks/InteractionMasks.tsx
+++ b/src/masks/InteractionMasks.tsx
@@ -241,7 +241,7 @@ export default function InteractionMasks<R, SR>({
       cellKey,
       fromRow,
       toRow,
-      updated: { [cellKey]: value } as never,
+      updated: { [cellKey]: value },
       action: UpdateActions.COPY_PASTE,
       fromCellKey
     });
@@ -297,7 +297,7 @@ export default function InteractionMasks<R, SR>({
       cellKey,
       fromRow: rowIdx,
       toRow: overRowIdx,
-      updated: { [cellKey]: value } as never,
+      updated: { [cellKey]: value },
       action: UpdateActions.CELL_DRAG
     });
 
@@ -313,7 +313,7 @@ export default function InteractionMasks<R, SR>({
       cellKey,
       fromRow: selectedPosition.rowIdx,
       toRow: rows.length - 1,
-      updated: { [cellKey]: value } as never,
+      updated: { [cellKey]: value },
       action: UpdateActions.COLUMN_FILL
     });
   }


### PR DESCRIPTION
I am not sure if there is an easy way to support types for `onRowsUpdate` handler. We might as well cleanup the internal types