### PR TITLE
EmptyRowsView in canvas to keep horizontal scroll position when filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 /coverage
-/dist
-/lib
-/node_modules
+**/dist
+**/lib
+**/node_modules
 /storybook-static
 /.eslintcache
-/package-lock.json
+**/package-lock.json
 
 npm-debug.log
 **.orig

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useImperativeHandle, useEffect, forwardRef } from 'react';
+import React, { useRef, useState, useImperativeHandle, useEffect, forwardRef, createElement } from 'react';
 
 import { ColumnMetrics, Position, ScrollPosition, CalculatedColumn, SelectRowEvent } from './common/types';
 import EventBus from './EventBus';
@@ -12,6 +12,7 @@ type SharedDataGridProps<R, K extends keyof R, SR> = Pick<DataGridProps<R, K, SR
   | 'rows'
   | 'rowRenderer'
   | 'rowGroupRenderer'
+  | 'emptyRowsView'
   | 'selectedRows'
   | 'summaryRows'
   | 'onCheckCellIsEditable'
@@ -48,6 +49,7 @@ export interface CanvasHandle {
 
 function Canvas<R, K extends keyof R, SR>({
   columnMetrics,
+  emptyRowsView,
   viewportColumns,
   height,
   scrollLeft,
@@ -232,46 +234,53 @@ function Canvas<R, K extends keyof R, SR>({
     </div>
   );
 
+  const canvasHeight = height - 2 - (summaryRows ? summaryRows.length * rowHeight + 2 : 0);
   return (
     <>
       <div
         className="rdg-viewport"
-        style={{ height: height - 2 - (summaryRows ? summaryRows.length * rowHeight + 2 : 0) }}
+        style={{ height: canvasHeight }}
         ref={canvasRef}
         onScroll={handleScroll}
       >
-        <InteractionMasks<R, SR>
-          rows={rows}
-          rowHeight={rowHeight}
-          columns={columns}
-          height={clientHeight}
-          enableCellAutoFocus={props.enableCellAutoFocus}
-          enableCellCopyPaste={props.enableCellCopyPaste}
-          enableCellDragAndDrop={props.enableCellDragAndDrop}
-          cellNavigationMode={props.cellNavigationMode}
-          eventBus={eventBus}
-          canvasRef={canvasRef}
-          scrollLeft={scrollLeft}
-          scrollTop={scrollTop}
-          scrollToCell={scrollToCell}
-          editorPortalTarget={props.editorPortalTarget}
-          onCheckCellIsEditable={props.onCheckCellIsEditable}
-          onRowsUpdate={props.onRowsUpdate}
-          onSelectedCellChange={props.onSelectedCellChange}
-          onSelectedCellRangeChange={props.onSelectedCellRangeChange}
-        />
-        <div
-          className="rdg-grid"
-          style={{
-            width: columnMetrics.totalColumnWidth,
-            paddingTop: rowOverscanStartIdx * rowHeight,
-            paddingBottom: (rows.length - 1 - rowOverscanEndIdx) * rowHeight
-          }}
-        >
-          {getViewportRows()}
-        </div>
+        {rows.length === 0 && emptyRowsView
+          ? createElement(emptyRowsView, { height: canvasHeight, width: columnMetrics.totalColumnWidth })
+          : (
+            <>
+              <InteractionMasks<R, SR>
+                rows={rows}
+                rowHeight={rowHeight}
+                columns={columns}
+                height={clientHeight}
+                enableCellAutoFocus={props.enableCellAutoFocus}
+                enableCellCopyPaste={props.enableCellCopyPaste}
+                enableCellDragAndDrop={props.enableCellDragAndDrop}
+                cellNavigationMode={props.cellNavigationMode}
+                eventBus={eventBus}
+                canvasRef={canvasRef}
+                scrollLeft={scrollLeft}
+                scrollTop={scrollTop}
+                scrollToCell={scrollToCell}
+                editorPortalTarget={props.editorPortalTarget}
+                onCheckCellIsEditable={props.onCheckCellIsEditable}
+                onRowsUpdate={props.onRowsUpdate}
+                onSelectedCellChange={props.onSelectedCellChange}
+                onSelectedCellRangeChange={props.onSelectedCellRangeChange}
+              />
+              <div
+                className="rdg-grid"
+                style={{
+                  width: columnMetrics.totalColumnWidth,
+                  paddingTop: rowOverscanStartIdx * rowHeight,
+                  paddingBottom: (rows.length - 1 - rowOverscanEndIdx) * rowHeight
+                }}
+              >
+                {getViewportRows()}
+              </div>
+              {summary}
+            </>
+          )}
       </div>
-      {summary}
     </>
   );
 }

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -3,8 +3,7 @@ import React, {
   useState,
   useRef,
   useLayoutEffect,
-  useMemo,
-  createElement
+  useMemo
 } from 'react';
 
 import HeaderRow from './HeaderRow';
@@ -24,7 +23,8 @@ import {
   RowRendererProps,
   ScrollPosition,
   Filters,
-  FormatterProps
+  FormatterProps,
+  EmptyRowsViewProps
 } from './common/types';
 
 export { DataGridHandle };
@@ -92,7 +92,7 @@ export interface DataGridProps<R, K extends keyof R, SR = unknown> {
   defaultFormatter?: React.ComponentType<FormatterProps<R, SR>>;
   rowRenderer?: React.ComponentType<RowRendererProps<R, SR>>;
   rowGroupRenderer?: React.ComponentType;
-  emptyRowsView?: React.ComponentType<{}>;
+  emptyRowsView?: React.ComponentType<EmptyRowsViewProps>;
   /** Component used to render a draggable header cell */
   draggableHeaderCell?: React.ComponentType<{ column: CalculatedColumn<R, SR>; onHeaderDrop: () => void }>;
 
@@ -158,6 +158,7 @@ function DataGrid<R, K extends keyof R, SR>({
   rows,
   selectedRows,
   onSelectedRowsChange,
+  emptyRowsView,
   ...props
 }: DataGridProps<R, K, SR>, ref: React.Ref<DataGridHandle>) {
   const [columnWidths, setColumnWidths] = useState<ReadonlyMap<string, number>>(() => new Map());
@@ -279,35 +280,34 @@ function DataGrid<R, K extends keyof R, SR>({
               />
             )}
           </div>
-          {rows.length === 0 && props.emptyRowsView ? createElement(props.emptyRowsView) : (
-            <Canvas<R, K, SR>
-              ref={ref}
-              rowKey={rowKey}
-              rowHeight={rowHeight}
-              rowRenderer={props.rowRenderer}
-              rows={rows}
-              selectedRows={selectedRows}
-              onSelectedRowsChange={onSelectedRowsChange}
-              columnMetrics={columnMetrics}
-              viewportColumns={viewportColumns}
-              onScroll={handleScroll}
-              height={height - rowOffsetHeight}
-              rowGroupRenderer={props.rowGroupRenderer}
-              enableCellAutoFocus={enableCellAutoFocus}
-              enableCellCopyPaste={enableCellCopyPaste}
-              enableCellDragAndDrop={enableCellDragAndDrop}
-              cellNavigationMode={cellNavigationMode}
-              scrollLeft={scrollLeft}
-              editorPortalTarget={editorPortalTarget}
-              summaryRows={props.summaryRows}
-              onCheckCellIsEditable={props.onCheckCellIsEditable}
-              onRowsUpdate={handleRowUpdate}
-              onSelectedCellChange={props.onSelectedCellChange}
-              onSelectedCellRangeChange={props.onSelectedCellRangeChange}
-              onRowClick={props.onRowClick}
-              onRowExpandToggle={props.onRowExpandToggle}
-            />
-          )}
+          <Canvas<R, K, SR>
+            ref={ref}
+            rowKey={rowKey}
+            emptyRowsView={emptyRowsView}
+            rowHeight={rowHeight}
+            rowRenderer={props.rowRenderer}
+            rows={rows}
+            selectedRows={selectedRows}
+            onSelectedRowsChange={onSelectedRowsChange}
+            columnMetrics={columnMetrics}
+            viewportColumns={viewportColumns}
+            onScroll={handleScroll}
+            height={height - rowOffsetHeight}
+            rowGroupRenderer={props.rowGroupRenderer}
+            enableCellAutoFocus={enableCellAutoFocus}
+            enableCellCopyPaste={enableCellCopyPaste}
+            enableCellDragAndDrop={enableCellDragAndDrop}
+            cellNavigationMode={cellNavigationMode}
+            scrollLeft={scrollLeft}
+            editorPortalTarget={editorPortalTarget}
+            summaryRows={props.summaryRows}
+            onCheckCellIsEditable={props.onCheckCellIsEditable}
+            onRowsUpdate={handleRowUpdate}
+            onSelectedCellChange={props.onSelectedCellChange}
+            onSelectedCellRangeChange={props.onSelectedCellRangeChange}
+            onRowClick={props.onRowClick}
+            onRowExpandToggle={props.onRowExpandToggle}
+          />
         </>
       )}
     </div>

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -155,6 +155,11 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown> extends Omit<Reac
   onRowClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
 }
 
+export interface EmptyRowsViewProps {
+  height: number;
+  width: number;
+}
+
 export interface FilterRendererProps<TRow, TFilterValue = unknown, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   value: TFilterValue;

--- a/stories/demos/NoRows.tsx
+++ b/stories/demos/NoRows.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import DataGrid, { Column } from '../../src';
+import DataGrid, { Column, EmptyRowsViewProps } from '../../src';
+import { AutoSizer } from 'react-virtualized';
 
-function EmptyRowsView() {
-  return <div style={{ textAlign: 'center' }}>Nothing to show <span lang="ja" title="ショボーン">(´・ω・`)</span></div>;
+function EmptyRowsView({ width, height }: EmptyRowsViewProps) {
+  return <div style={{ textAlign: 'center', height, width }}>Nothing to show <span lang="ja" title="ショボーン">(´・ω・`)</span></div>;
 }
 
 interface Row {
@@ -12,20 +13,25 @@ interface Row {
 }
 
 const columns: readonly Column<Row>[] = [
-  { key: 'id', name: 'ID' },
-  { key: 'title', name: 'Title' },
-  { key: 'count', name: 'Count' }
+  { key: 'id', name: 'ID', resizable: true },
+  { key: 'title', name: 'Title', resizable: true },
+  { key: 'count', name: 'Count', resizable: true }
 ];
 
 const rows: readonly Row[] = [];
 
 export default function NoRows() {
   return (
-    <DataGrid
-      columns={columns}
-      rows={rows}
-      width={600}
-      emptyRowsView={EmptyRowsView}
-    />
+    <AutoSizer>
+      {({ width, height }) => (
+        <DataGrid
+          columns={columns}
+          rows={rows}
+          width={width}
+          height={height}
+          emptyRowsView={EmptyRowsView}
+        />
+      )}
+    </AutoSizer>
   );
 }


### PR DESCRIPTION
Currently:
EmptyRowsView is outside the viewport,
It does not render the proper width, h-scroll loosing position when having overflow headers
** it also breaks the headers position **

![current](https://user-images.githubusercontent.com/23088305/78209265-871bdd00-7474-11ea-9c00-cffa7ffd9bde.gif)

Wanted Behavior:
EmptyRowsView inside the viewport,
This way we can share to this component the calculated height and width of the viewport so it can adjusted itself to keep track of the headers (when many) and so we don't lose current position of the horizontal scroll when filtering results

![expected](https://user-images.githubusercontent.com/23088305/78209270-8a16cd80-7474-11ea-819f-29a895733646.gif)



