### PR TITLE
Fix for Browserify without babelify

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "start-storybook --quiet -p 6006",
     "build": "tsc",
-    "postbuild": "node tools/buildStylesheets.mjs",
+    "postbuild": "node --experimental-modules tools/buildStylesheets.mjs",
     "test": "jest",
     "test:watch": "jest --watch",
     "eslint": "eslint --ext mjs,ts,tsx --max-warnings 0 -f codeframe --cache --color src stories jest tools",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "inlineSources": true,
     "jsx": "react",
     "lib": ["es2020", "dom", "dom.iterable"],
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "declaration": true,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSources": true,
     "jsx": "react",


### PR DESCRIPTION
Since you are building to the esnext standard, some builders (browserify) are unable to build your code into a bundle without help or special configuration. 

This simple change allows more people to run your package without problems.

Also, we use the `--experimental-modules ` flag so more versions of node can run your `buildStylesheets.mjs` script. 