### PR TITLE
Replace classnames with clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postpublish": "git push --follow-tags origin HEAD"
   },
   "dependencies": {
-    "classnames": "^2.2.6"
+    "clsx": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
@@ -46,7 +46,6 @@
     "@babel/runtime": "^7.9.2",
     "@storybook/react": "^5.3.18",
     "@testing-library/react": "^10.0.2",
-    "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/faker": "^4.1.11",

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, memo } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import { CellRendererProps } from './common/types';
 import { preventDefault, wrapEvent } from './utils';
@@ -41,7 +41,7 @@ function Cell<R, SR>({
   }
 
   const { cellClass } = column;
-  className = classNames(
+  className = clsx(
     'rdg-cell',
     {
       'rdg-cell-frozen': column.frozen,

--- a/src/FilterRow.tsx
+++ b/src/FilterRow.tsx
@@ -1,5 +1,5 @@
 import React, { createElement, memo } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import { CalculatedColumn, Filters } from './common/types';
 import { DataGridProps } from './DataGrid';
@@ -31,7 +31,7 @@ function FilterRow<R, SR>({
       {columns.map(column => {
         const { key } = column;
 
-        const className = classNames('rdg-cell', {
+        const className = clsx('rdg-cell', {
           'rdg-cell-frozen': column.frozen,
           'rdg-cell-frozen-last': column.idx === lastFrozenColumnIndex
         });

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -1,5 +1,5 @@
 import React, { createElement } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import { CalculatedColumn } from './common/types';
 import { HeaderRowProps } from './HeaderRow';
@@ -51,7 +51,7 @@ export default function HeaderCell<R, SR>({
     );
   }
 
-  const className = classNames('rdg-cell', column.headerCellClass, {
+  const className = clsx('rdg-cell', column.headerCellClass, {
     'rdg-cell-frozen': column.frozen,
     'rdg-cell-frozen-last': column.idx === lastFrozenColumnIndex
   });

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -1,5 +1,5 @@
-import classNames from 'classnames';
 import React, { memo } from 'react';
+import clsx from 'clsx';
 
 import Cell from './Cell';
 import { RowRendererProps } from './common/types';
@@ -31,7 +31,7 @@ function Row<R, SR = unknown>({
     event.dataTransfer.dropEffect = 'copy';
   }
 
-  className = classNames(
+  className = clsx(
     'rdg-row',
     `rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'}`,
     { 'rdg-row-selected': isRowSelected },

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import { CellRendererProps } from './common/types';
 
@@ -18,7 +18,7 @@ function SummaryCell<R, SR>({
   row
 }: SummaryCellProps<R, SR>) {
   const { summaryFormatter: SummaryFormatter, width, left, summaryCellClass } = column;
-  const className = classNames(
+  const className = clsx(
     'rdg-cell',
     {
       'rdg-cell-frozen': column.frozen,

--- a/src/editors/EditorContainer.tsx
+++ b/src/editors/EditorContainer.tsx
@@ -1,5 +1,5 @@
 import React, { KeyboardEvent, useRef, useState, useLayoutEffect, useCallback, useEffect } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import { CalculatedColumn, Editor, CommitEvent } from '../common/types';
 import SimpleTextEditor from './SimpleTextEditor';
@@ -176,7 +176,7 @@ export default function EditorContainer<R, SR>({
     );
   }
 
-  const className = classNames('rdg-editor-container', {
+  const className = clsx('rdg-editor-container', {
     'rdg-editor-invalid': !isValid
   });
 

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 export interface SelectCellFormatterProps {
   value: boolean;
@@ -13,7 +13,7 @@ export function SelectCellFormatter({ value, disabled = false, onChange }: Selec
   }
 
   return (
-    <label className={classNames('rdg-checkbox-label', { 'rdg-checkbox-label-disabled': disabled })}>
+    <label className={clsx('rdg-checkbox-label', { 'rdg-checkbox-label-disabled': disabled })}>
       <input
         type="checkbox"
         className="rdg-checkbox-input"

--- a/src/masks/CellMask.tsx
+++ b/src/masks/CellMask.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { Dimension } from '../common/types';
 
 export type CellMaskProps = React.HTMLAttributes<HTMLDivElement> & Dimension;
@@ -7,7 +7,7 @@ export type CellMaskProps = React.HTMLAttributes<HTMLDivElement> & Dimension;
 export default forwardRef<HTMLDivElement, CellMaskProps>(function CellMask({ width, height, top, left, zIndex, className, ...props }, ref) {
   return (
     <div
-      className={classNames('rdg-cell-mask', className)}
+      className={clsx('rdg-cell-mask', className)}
       style={{
         height,
         width,

--- a/stories/demos/components/Formatters/CellActionsFormatter.tsx
+++ b/stories/demos/components/Formatters/CellActionsFormatter.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ReactNode } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './CellActionsFormatter.less';
 
@@ -21,11 +21,11 @@ interface CellActionProps extends CellActionButton {
 function CellAction({ icon, actions, callback, isFirst }: CellActionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const cellActionClasses = classNames('rdg-cell-action', {
+  const cellActionClasses = clsx('rdg-cell-action', {
     'rdg-cell-action-last': isFirst
   });
 
-  const actionButtonClasses = classNames('rdg-cell-action-button', {
+  const actionButtonClasses = clsx('rdg-cell-action-button', {
     'rdg-cell-action-button-toggled': isOpen
   });
 


### PR DESCRIPTION
- https://github.com/lukeed/clsx
- `classnames` is an umd module,, `clsx` provides an es module, types are bundled as well.
- Should be faster than `classnames`
  https://github.com/lukeed/clsx/tree/master/bench
- `classnames` uses a temporary array + `join(' ')`, while `clsx` just does string concatenation, which is well optimized by js engines.
- `@material-ui` packages use `clsx`
- There's also a babel plugin to optimize both :eyes:
  https://github.com/merceyz/babel-plugin-optimize-clsx/tree/master/benchmark