### PR TITLE
Handle focus on focusable formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - `column.minWidth`
   - `column.maxWidth`
   - `column.headerCellClass`
+  - `column.formatterOptions`
+    - More info in [#2104](https://github.com/adazzle/react-data-grid/pull/2104)
   - `scrollToRow` method
     - ⚠️ This replaces the `scrollToRowIndex` prop
 - **Removed:**
@@ -30,7 +32,7 @@
     - ⚠️ `cellContentRenderer`
     - ⚠️ `contextMenu`
       <!-- TODO: fill link to storybook -->
-      - Check the [Context Menu]() example
+      - Check the [Context Menu](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--context-menu) example
     - ⚠️ `enableCellSelect`
     - ⚠️ `enableCellAutoFocus`
     - ⚠️ `getValidFilterValues`

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -91,6 +91,7 @@ function Cell<R, SR>({
           column={column}
           rowIdx={rowIdx}
           row={row}
+          isCellSelected={isSelected}
           isRowSelected={isRowSelected}
           onRowSelectionChange={onRowSelectionChange}
         />

--- a/src/Columns.tsx
+++ b/src/Columns.tsx
@@ -23,9 +23,14 @@ export const SelectColumn: Column<any, any> = {
     return (
       <SelectCellFormatter
         aria-label="Select"
+        tabIndex={-1}
+        isCellSelected={props.isCellSelected}
         value={props.isRowSelected}
         onChange={props.onRowSelectionChange}
       />
     );
+  },
+  formatterOptions: {
+    focusable: true
   }
 };

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -276,6 +276,8 @@ function DataGrid<R, K extends keyof R, SR>({
     if (selectedPosition === prevSelectedPosition.current || selectedPosition.mode === 'EDIT' || !isCellWithinBounds(selectedPosition)) return;
     prevSelectedPosition.current = selectedPosition;
     scrollToCell(selectedPosition);
+    const column = columns[selectedPosition.idx];
+    if (column.formatterOptions?.focusable) return; // Let the formatter handle focus
     focusSinkRef.current!.focus();
   });
 

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -1,24 +1,22 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
-type SharedInputProps = Pick<React.InputHTMLAttributes<HTMLInputElement>,
-  | 'disabled'
-  | 'aria-label'
-  | 'aria-labelledby'
->;
-
-export interface SelectCellFormatterProps extends SharedInputProps {
+export interface SelectCellFormatterProps {
   value: boolean;
+  tabIndex?: number;
+  isCellSelected?: boolean;
+  disabled?: boolean;
   onChange: (value: boolean, isShiftClick: boolean) => void;
 }
 
-export function SelectCellFormatter({
-  value,
-  disabled,
-  onChange,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy
-}: SelectCellFormatterProps) {
+export function SelectCellFormatter({ value, tabIndex, isCellSelected, disabled, onChange }: SelectCellFormatterProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (isCellSelected) {
+      inputRef.current?.focus();
+    }
+  }, [isCellSelected]);
+
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     onChange(e.target.checked, (e.nativeEvent as MouseEvent).shiftKey);
   }
@@ -26,8 +24,8 @@ export function SelectCellFormatter({
   return (
     <label className={clsx('rdg-checkbox-label', { 'rdg-checkbox-label-disabled': disabled })}>
       <input
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
+        tabIndex={tabIndex}
+        ref={inputRef}
         type="checkbox"
         className="rdg-checkbox-input"
         disabled={disabled}

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -47,7 +47,6 @@ export function SelectCellFormatter({
         disabled={disabled}
         onChange={handleChange}
         checked={value}
-        onClick={e => e.stopPropagation()}
       />
       <div className="rdg-checkbox" />
     </label>

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -26,9 +26,8 @@ export function SelectCellFormatter({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useLayoutEffect(() => {
-    if (isCellSelected) {
-      inputRef.current?.focus();
-    }
+    if (!isCellSelected) return;
+    inputRef.current?.focus();
   }, [isCellSelected]);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -1,17 +1,31 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import clsx from 'clsx';
 
-export interface SelectCellFormatterProps {
-  value: boolean;
-  tabIndex?: number;
+type SharedInputProps = Pick<React.InputHTMLAttributes<HTMLInputElement>,
+  | 'disabled'
+  | 'tabIndex'
+  | 'aria-label'
+  | 'aria-labelledby'
+>;
+
+export interface SelectCellFormatterProps extends SharedInputProps {
   isCellSelected?: boolean;
-  disabled?: boolean;
+  value: boolean;
   onChange: (value: boolean, isShiftClick: boolean) => void;
 }
 
-export function SelectCellFormatter({ value, tabIndex, isCellSelected, disabled, onChange }: SelectCellFormatterProps) {
+export function SelectCellFormatter({
+  value,
+  tabIndex,
+  isCellSelected,
+  disabled,
+  onChange,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy
+}: SelectCellFormatterProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
+
+  useLayoutEffect(() => {
     if (isCellSelected) {
       inputRef.current?.focus();
     }
@@ -24,6 +38,8 @@ export function SelectCellFormatter({ value, tabIndex, isCellSelected, disabled,
   return (
     <label className={clsx('rdg-checkbox-label', { 'rdg-checkbox-label-disabled': disabled })}>
       <input
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         tabIndex={tabIndex}
         ref={inputRef}
         type="checkbox"
@@ -31,6 +47,7 @@ export function SelectCellFormatter({ value, tabIndex, isCellSelected, disabled,
         disabled={disabled}
         onChange={handleChange}
         checked={value}
+        onClick={e => e.stopPropagation()}
       />
       <div className="rdg-checkbox" />
     </label>

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,9 @@ export interface Column<TRow, TSummaryRow = unknown> {
   summaryCellClass?: string | ((row: TSummaryRow) => string);
   /** Formatter to be used to render the cell content */
   formatter?: React.ComponentType<FormatterProps<TRow, TSummaryRow>>;
+  formatterOptions?: {
+    focusable?: boolean;
+  };
   /** Formatter to be used to render the summary cell content */
   summaryFormatter?: React.ComponentType<SummaryFormatterProps<TSummaryRow, TRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
@@ -69,6 +72,7 @@ export interface FormatterProps<TRow = any, TSummaryRow = any> {
   rowIdx: number;
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TRow;
+  isCellSelected: boolean;
   isRowSelected: boolean;
   onRowSelectionChange: (checked: boolean, isShiftClick: boolean) => void;
 }

--- a/stories/demos/TreeView.tsx
+++ b/stories/demos/TreeView.tsx
@@ -106,13 +106,15 @@ export default function TreeView() {
       {
         key: 'format',
         name: 'format',
-        formatter({ row }) {
+        formatterOptions: { focusable: true },
+        formatter({ row, isCellSelected }) {
           const hasChildren = row.children !== undefined;
           const style = !hasChildren ? { marginLeft: 30 } : undefined;
           return (
             <>
               {hasChildren && (
                 <CellExpanderFormatter
+                  isCellSelected={isCellSelected}
                   expanded={row.isExpanded === true}
                   onCellExpand={() => dispatch({ id: row.id, type: 'toggleSubRow' })}
                 />
@@ -120,8 +122,9 @@ export default function TreeView() {
               <div className="rdg-cell-value">
                 {!hasChildren && (
                   <ChildRowDeleteButton
-                    onDeleteSubRow={() => dispatch({ id: row.id, type: 'deleteSubRow' })}
+                    isCellSelected={isCellSelected}
                     isDeleteSubRowEnabled={allowDelete}
+                    onDeleteSubRow={() => dispatch({ id: row.id, type: 'deleteSubRow' })}
                   />
                 )}
                 <div style={style}>
@@ -130,18 +133,6 @@ export default function TreeView() {
               </div>
             </>
           );
-        },
-        unsafe_onCellInput(event, row) {
-          const hasChildren = row.children !== undefined;
-          if (event.key === ' ' && hasChildren) {
-            event.preventDefault();
-            dispatch({ id: row.id, type: 'toggleSubRow' });
-          }
-
-          if (event.key === 'Delete' && !hasChildren) {
-            event.preventDefault();
-            dispatch({ id: row.id, type: 'deleteSubRow' });
-          }
         }
       },
       {

--- a/stories/demos/components/Formatters/CellExpanderFormatter.tsx
+++ b/stories/demos/components/Formatters/CellExpanderFormatter.tsx
@@ -12,7 +12,7 @@ export function CellExpanderFormatter({ isCellSelected, expanded, onCellExpand }
   const iconRef = useRef<HTMLSpanElement>(null);
   useLayoutEffect(() => {
     if (!isCellSelected) return;
-    iconRef.current?.focus();
+    iconRef.current?.focus({ preventScroll: true });
   }, [isCellSelected]);
 
   function handleClick(e: React.MouseEvent<HTMLSpanElement>) {

--- a/stories/demos/components/Formatters/CellExpanderFormatter.tsx
+++ b/stories/demos/components/Formatters/CellExpanderFormatter.tsx
@@ -1,22 +1,45 @@
-import React from 'react';
+import React, { useRef, useLayoutEffect } from 'react';
 
 import './CellExpanderFormatter.less';
 
 export interface CellExpanderFormatterProps {
+  isCellSelected: boolean;
   expanded: boolean;
   onCellExpand: () => void;
 }
 
-export function CellExpanderFormatter({ expanded, onCellExpand }: CellExpanderFormatterProps) {
-  function handleCellExpand(e: React.MouseEvent<HTMLSpanElement>) {
+export function CellExpanderFormatter({ isCellSelected, expanded, onCellExpand }: CellExpanderFormatterProps) {
+  const iconRef = useRef<HTMLSpanElement>(null);
+  useLayoutEffect(() => {
+    if (isCellSelected) {
+      iconRef.current?.focus();
+    }
+  }, [isCellSelected]);
+
+  function handleClick(e: React.MouseEvent<HTMLSpanElement>) {
     e.stopPropagation();
     onCellExpand();
   }
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      onCellExpand();
+    }
+  }
+
   return (
     <div className="rdg-cell-expand">
-      <span onClick={handleCellExpand}>
-        {expanded ? '\u25BC' : '\u25B6'}
+      <span
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      >
+        <span
+          ref={iconRef}
+          tabIndex={-1}
+        >
+          {expanded ? '\u25BC' : '\u25B6'}
+        </span>
       </span>
     </div>
   );

--- a/stories/demos/components/Formatters/CellExpanderFormatter.tsx
+++ b/stories/demos/components/Formatters/CellExpanderFormatter.tsx
@@ -11,9 +11,8 @@ export interface CellExpanderFormatterProps {
 export function CellExpanderFormatter({ isCellSelected, expanded, onCellExpand }: CellExpanderFormatterProps) {
   const iconRef = useRef<HTMLSpanElement>(null);
   useLayoutEffect(() => {
-    if (isCellSelected) {
-      iconRef.current?.focus();
-    }
+    if (!isCellSelected) return;
+    iconRef.current?.focus();
   }, [isCellSelected]);
 
   function handleClick(e: React.MouseEvent<HTMLSpanElement>) {

--- a/stories/demos/components/Formatters/ChildRowDeleteButton.tsx
+++ b/stories/demos/components/Formatters/ChildRowDeleteButton.tsx
@@ -10,7 +10,7 @@ export function ChildRowDeleteButton({ isCellSelected, onDeleteSubRow, isDeleteS
   const iconRef = useRef<HTMLSpanElement>(null);
   useLayoutEffect(() => {
     if (!isCellSelected) return;
-    iconRef.current?.focus();
+    iconRef.current?.focus({ preventScroll: true });
   }, [isCellSelected]);
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {

--- a/stories/demos/components/Formatters/ChildRowDeleteButton.tsx
+++ b/stories/demos/components/Formatters/ChildRowDeleteButton.tsx
@@ -1,17 +1,38 @@
-import React from 'react';
+import React, { useRef, useLayoutEffect } from 'react';
 
 export interface ChildRowDeleteButtonProps {
-  onDeleteSubRow: () => void;
+  isCellSelected: boolean;
   isDeleteSubRowEnabled: boolean;
+  onDeleteSubRow: () => void;
 }
 
-export function ChildRowDeleteButton({ onDeleteSubRow, isDeleteSubRowEnabled }: ChildRowDeleteButtonProps) {
+export function ChildRowDeleteButton({ isCellSelected, onDeleteSubRow, isDeleteSubRowEnabled }: ChildRowDeleteButtonProps) {
+  const iconRef = useRef<HTMLSpanElement>(null);
+  useLayoutEffect(() => {
+    if (isCellSelected) {
+      iconRef.current?.focus();
+    }
+  }, [isCellSelected]);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onDeleteSubRow();
+    }
+  }
+
   return (
     <>
       <div className="rdg-child-row-action-cross" />
       {isDeleteSubRowEnabled && (
         <div className="rdg-child-row-btn" onClick={onDeleteSubRow}>
-          ❌
+          <span
+            ref={iconRef}
+            tabIndex={-1}
+            onKeyDown={handleKeyDown}
+          >
+            ❌
+          </span>
         </div>
       )}
     </>

--- a/stories/demos/components/Formatters/ChildRowDeleteButton.tsx
+++ b/stories/demos/components/Formatters/ChildRowDeleteButton.tsx
@@ -9,9 +9,8 @@ export interface ChildRowDeleteButtonProps {
 export function ChildRowDeleteButton({ isCellSelected, onDeleteSubRow, isDeleteSubRowEnabled }: ChildRowDeleteButtonProps) {
   const iconRef = useRef<HTMLSpanElement>(null);
   useLayoutEffect(() => {
-    if (isCellSelected) {
-      iconRef.current?.focus();
-    }
+    if (!isCellSelected) return;
+    iconRef.current?.focus();
   }, [isCellSelected]);
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {


### PR DESCRIPTION
https://www.w3.org/TR/wai-aria-practices/#gridNav_focus

> For assistive technology users, the quality of experience when navigating a grid heavily depends on both what a cell contains and on where keyboard focus is set. For example, if a cell contains a button and a grid navigation key places focus on the cell instead of the button, screen readers announce the button label but do not tell users a button is present.

>There are two optimal cell design and focus behavior combinations:
> - A cell contains one widget whose operation does not require arrow keys and grid navigation keys set focus on that widget. Examples of such widgets include link, button, menubutton, toggle button, radio button (not radio group), switch, and checkbox.
> - A cell contains text or a single graphic and grid navigation keys set focus on the cell.

https://www.loom.com/share/3a0e559f0ea04db98226c3169dffad04