### PR TITLE
Added links to docs more prominently on top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [ci-badge]: https://github.com/adazzle/react-data-grid/workflows/CI/badge.svg
 [ci-url]: https://github.com/adazzle/react-data-grid/actions?query=workflow%3ACI
 
+## Docs
+Visit [this website](https://adazzle.github.io/react-data-grid/canary) for the most recent examples of what you can do with `react-data-grid`.
+
+You can also see the API Docs on our [legacy website](https://adazzle.github.io/react-data-grid/). Note that a lot of the APIs have changed!
+
 ## Install
 
 ```sh


### PR DESCRIPTION
It took me forever to find the correct docs. I was also stuck for a while trying to figure out why `onGridRowUpdates` wasn't working