### PR TITLE
TypeScript 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,8 @@
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/faker": "^4.1.12",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.10",
     "@types/lodash": "^4.14.158",
-    "@types/node": "^14.0.27",
     "@types/react": "^16.9.44",
     "@types/react-dom": "^16.9.8",
     "@types/react-select": "^3.0.15",
@@ -87,8 +86,8 @@
     "react-select": "^3.1.0",
     "react-virtualized": "^9.21.2",
     "ts-jest": "^26.1.4",
-    "ts-loader": "^7.0.5",
-    "typescript": "^3.9.7"
+    "ts-loader": "^8.0.2",
+    "typescript": "~4.0.2"
   },
   "peerDependencies": {
     "react": "^16.8",


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html
https://github.com/microsoft/TypeScript/issues/38510

https://github.com/TypeStrong/ts-loader/blob/master/CHANGELOG.md

Also removed `@types/node`, I don't remember why we added it.