### PR TITLE
Use ResizeObserver to calculate grid width

### DIFF
--- a/src/hooks/useGridWidth.ts
+++ b/src/hooks/useGridWidth.ts
@@ -1,16 +1,7 @@
 import { useRef, useState, useLayoutEffect, useMemo } from 'react';
 
 // https://github.com/microsoft/TypeScript/issues/37861
-interface ResizeObserverSize {
-  inlineSize: number;
-}
-
-interface ResizeObserverEntry {
-  target: Element;
-  borderBoxSize?: ResizeObserverSize;
-}
-
-type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
+type ResizeObserverCallback = () => void;
 
 type ResizeObserver = new (callback: ResizeObserverCallback) => {
   observe: (target: Element) => void;
@@ -26,11 +17,8 @@ export function useGridWidth<T>(width?: number): [React.RefObject<HTMLDivElement
       return null;
     }
 
-    return new ResizeObserver((entries: ResizeObserverEntry[]) => {
-      if (entries.length > 0) {
-        const newWidth = entries[0].borderBoxSize?.inlineSize ?? entries[0].target.getBoundingClientRect().width;
-        setGridWidth(newWidth);
-      }
+    return new ResizeObserver(() => {
+      setGridWidth(gridRef.current!.getBoundingClientRect().width);
     });
   }, []);
 

--- a/src/hooks/useGridWidth.ts
+++ b/src/hooks/useGridWidth.ts
@@ -18,7 +18,7 @@ type ResizeObserver = new (callback: ResizeObserverCallback) => {
 };
 
 
-const { ResizeObserver } = window as (typeof window & { ResizeObserver: ResizeObserver });
+const { ResizeObserver } = window as (typeof window & { ResizeObserver?: ResizeObserver });
 
 export function useGridWidth<T>(width?: number): [React.RefObject<HTMLDivElement>, number] {
   const gridRef = useRef<HTMLDivElement>(null);

--- a/src/hooks/useGridWidth.ts
+++ b/src/hooks/useGridWidth.ts
@@ -13,7 +13,7 @@ export function useGridWidth<T>(width?: number): [React.RefObject<HTMLDivElement
   const [gridWidth, setGridWidth] = useState(0);
   const resizeObserver = useMemo(() => {
     const { ResizeObserver } = window as (typeof window & { ResizeObserver?: ResizeObserver });
-    if (typeof width === 'number' || ResizeObserver === undefined) {
+    if (ResizeObserver === undefined) {
       return null;
     }
 

--- a/src/hooks/useGridWidth.ts
+++ b/src/hooks/useGridWidth.ts
@@ -1,23 +1,65 @@
 import { useRef, useState, useLayoutEffect } from 'react';
 
+// https://github.com/microsoft/TypeScript/issues/37861
+interface ResizeObserverSize {
+  inlineSize: number;
+}
+
+interface ResizeObserverEntry {
+  target: Element;
+  borderBoxSize?: ResizeObserverSize;
+}
+
+type ResizeObserverCallback = (entries?: ResizeObserverEntry[]) => void;
+
+type ResizeObserver = new (callback: ResizeObserverCallback) => {
+  observe: (target: Element) => void;
+  unobserve: (target: Element) => void;
+};
+
+
+const { ResizeObserver } = window as (typeof window & { ResizeObserver: ResizeObserver });
+
 export function useGridWidth<T>(width?: number): [React.RefObject<HTMLDivElement>, number] {
   const gridRef = useRef<HTMLDivElement>(null);
+  const [resizeObserver] = useState(() => {
+    if (ResizeObserver === undefined) {
+      return null;
+    }
+
+    return new ResizeObserver((entries?: ResizeObserverEntry[]) => {
+      if (Array.isArray(entries) && entries.length > 0) {
+        const newWidth = entries[0].borderBoxSize?.inlineSize ?? entries[0].target.getBoundingClientRect().width;
+        setGridWidth(newWidth);
+      }
+    });
+  });
   const [gridWidth, setGridWidth] = useState(0);
 
   useLayoutEffect(() => {
     // Do not calculate the width if width is provided
     if (typeof width === 'number') return;
+
+    // Use ResizeObserver if supported
+    if (resizeObserver !== null) {
+      const node = gridRef.current!;
+      resizeObserver.observe(node);
+      return () => resizeObserver.unobserve(node);
+    }
+
     function onResize() {
-    // Immediately re-render when the component is mounted to get valid columnMetrics.
+      // Immediately re-render when the component is mounted to get valid columnMetrics.
       setGridWidth(gridRef.current!.getBoundingClientRect().width);
     }
+
+    // Fallback to window resize
     onResize();
 
     window.addEventListener('resize', onResize);
     return () => {
       window.removeEventListener('resize', onResize);
     };
-  }, [width]);
+  }, [width, resizeObserver]);
 
   return [gridRef, width || gridWidth];
 }

--- a/src/hooks/useGridWidth.ts
+++ b/src/hooks/useGridWidth.ts
@@ -10,7 +10,7 @@ interface ResizeObserverEntry {
   borderBoxSize?: ResizeObserverSize;
 }
 
-type ResizeObserverCallback = (entries?: ResizeObserverEntry[]) => void;
+type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
 
 type ResizeObserver = new (callback: ResizeObserverCallback) => {
   observe: (target: Element) => void;
@@ -26,8 +26,8 @@ export function useGridWidth<T>(width?: number): [React.RefObject<HTMLDivElement
       return null;
     }
 
-    return new ResizeObserver((entries?: ResizeObserverEntry[]) => {
-      if (Array.isArray(entries) && entries.length > 0) {
+    return new ResizeObserver((entries: ResizeObserverEntry[]) => {
+      if (entries.length > 0) {
         const newWidth = entries[0].borderBoxSize?.inlineSize ?? entries[0].target.getBoundingClientRect().width;
         setGridWidth(newWidth);
       }

--- a/src/hooks/useGridWidth.ts
+++ b/src/hooks/useGridWidth.ts
@@ -13,7 +13,7 @@ export function useGridWidth<T>(width?: number): [React.RefObject<HTMLDivElement
   const [gridWidth, setGridWidth] = useState(0);
   const resizeObserver = useMemo(() => {
     const { ResizeObserver } = window as (typeof window & { ResizeObserver?: ResizeObserver });
-    if (ResizeObserver === undefined) {
+    if (typeof width === 'number' || ResizeObserver === undefined) {
       return null;
     }
 


### PR DESCRIPTION
ResizeObserver has a pretty good browser support now
https://caniuse.com/#feat=resizeobserver
https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver

This can solve a few issues
- Grid container resize may not always trigger window resize but resize observer will catch it
- If the grid is initially hidden and then displayed then grid width will be calculated again

TS does not have definitions for `ResizeObserver` so I copied some from https://www.w3.org/TR/resize-observer/#resizeobserversize