### PR TITLE
RefForwardingComponent -> ForwardRefRenderFunction

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -93,4 +93,4 @@ function Cell<R, SR>({
   );
 }
 
-export default memo(forwardRef(Cell)) as <R, SR = unknown>(props: CellRendererProps<R, SR> & { ref?: React.Ref<HTMLDivElement> }) => JSX.Element;
+export default memo(forwardRef(Cell)) as <R, SR = unknown>(props: CellRendererProps<R, SR> & React.RefAttributes<HTMLDivElement>) => JSX.Element;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -834,5 +834,5 @@ function DataGrid<R, K extends keyof R, SR>({
 }
 
 export default forwardRef(
-  DataGrid as React.RefForwardingComponent<DataGridHandle>
-) as <R, K extends keyof R, SR = unknown>(props: DataGridProps<R, K, SR> & { ref?: React.Ref<DataGridHandle> }) => JSX.Element;
+  DataGrid as React.ForwardRefRenderFunction<DataGridHandle>
+) as <R, K extends keyof R, SR = unknown>(props: DataGridProps<R, K, SR> & React.RefAttributes<DataGridHandle>) => JSX.Element;

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -113,4 +113,4 @@ function EditCell<R, SR>({
   );
 }
 
-export default forwardRef(EditCell) as <R, SR = unknown>(props: EditCellRendererProps<R, SR> & { ref?: React.Ref<HTMLDivElement> }) => JSX.Element;
+export default forwardRef(EditCell) as <R, SR = unknown>(props: EditCellRendererProps<R, SR> & React.RefAttributes<HTMLDivElement>) => JSX.Element;

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -90,4 +90,4 @@ function Row<R, SR = unknown>({
   );
 }
 
-export default memo(forwardRef(Row)) as <R, SR = unknown>(props: RowRendererProps<R, SR> & { ref?: React.Ref<HTMLDivElement> }) => JSX.Element;
+export default memo(forwardRef(Row)) as <R, SR = unknown>(props: RowRendererProps<R, SR> & React.RefAttributes<HTMLDivElement>) => JSX.Element;

--- a/stories/demos/components/Editors/DropDownEditor.tsx
+++ b/stories/demos/components/Editors/DropDownEditor.tsx
@@ -59,6 +59,4 @@ function DropDownEditor<TRow>({ column, value, onCommit, options }: DropDownEdit
   );
 }
 
-export default forwardRef(
-  DropDownEditor as React.RefForwardingComponent<DropDownEditorHandle>
-) as <R>(props: DropDownEditorProps<R> & { ref?: React.Ref<DropDownEditorHandle> }) => JSX.Element;
+export default forwardRef(DropDownEditor) as <R>(props: DropDownEditorProps<R> & React.RefAttributes<DropDownEditorHandle>) => JSX.Element;


### PR DESCRIPTION
The `RefForwardingComponent` type is deprecated:
```
    /**
     * @deprecated Use ForwardRefRenderFunction. forwardRef doesn't accept a
     *             "real" component.
     */
    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderFunction<T, P> {}
```

And with TS 4 + vscode it shows up like this:
![image](https://user-images.githubusercontent.com/567105/91301273-8cb7ed80-e79c-11ea-8aa6-bec7deed4968.png)
![image](https://user-images.githubusercontent.com/567105/91301305-97728280-e79c-11ea-8210-9e741afea3bb.png)

---

I've also replaced  `{ ref?: React.Ref<T> }` with `RefAttributes<T>` for cleaner types, and maybe better future-proofing?