### PR TITLE
Add content-visibility: auto to the root element

### DIFF
--- a/style/cell.less
+++ b/style/cell.less
@@ -1,5 +1,6 @@
 .rdg-cell {
   contain: strict;
+  contain: size layout style paint;
   position: absolute;
   height: inherit;
   padding: 0 8px;

--- a/style/core.less
+++ b/style/core.less
@@ -4,6 +4,7 @@
   // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
   // We set a stacking context so internal elements don't render on top of external components.
   contain: strict;
+  contain: size layout style paint;
   content-visibility: auto;
   height: 350px;
   border: 1px solid @borderColor;

--- a/style/core.less
+++ b/style/core.less
@@ -4,6 +4,7 @@
   // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
   // We set a stacking context so internal elements don't render on top of external components.
   contain: strict;
+  content-visibility: auto;
   height: 350px;
   border: 1px solid @borderColor;
   box-sizing: border-box;

--- a/style/header.less
+++ b/style/header.less
@@ -3,6 +3,7 @@
 .rdg-header-row,
 .rdg-filter-row {
   contain: strict;
+  contain: size layout style paint;
   display: flex;
   width: var(--row-width);
   position: -webkit-sticky;

--- a/style/row.less
+++ b/style/row.less
@@ -1,5 +1,6 @@
 .rdg-row {
   contain: strict;
+  contain: size layout style paint;
   display: flex;
   position: absolute;
   left: 0;


### PR DESCRIPTION
https://web.dev/content-visibility/
https://www.chromestatus.com/feature/4613920211861504
https://drafts.csswg.org/css-contain/#propdef-content-visibility

I've not added `content-visibility` to the rows/cells since we already apply strict containment, and it seems to reduce performance instead of improving it.

I've also added `contain: size layout style paint;` **in addition to** `contain: strict;`.
Firefox doesn't support `style` containment, so
- `contain: strict;` will be applied on Firefox
- `contain: size layout style paint;` will be applied on Chrome, and will override `contain: strict;`