### PR TITLE
Remove formatterOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@
   - `column.minWidth`
   - `column.maxWidth`
   - `column.headerCellClass`
-  - `column.formatterOptions`
-    - More info in [#2104](https://github.com/adazzle/react-data-grid/pull/2104)
   - `column.editor2`
   - `column.editorOptions`
     - More info in [#2102](https://github.com/adazzle/react-data-grid/pull/2102)

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -18,6 +18,7 @@ function Cell<R, SR>({
   eventBus,
   dragHandleProps,
   onRowClick,
+  onFocus,
   onKeyDown,
   onClick,
   onDoubleClick,
@@ -72,6 +73,7 @@ function Cell<R, SR>({
         width: column.width,
         left: column.left
       }}
+      onFocus={onFocus}
       onKeyDown={onKeyDown}
       onClick={wrapEvent(handleClick, onClick)}
       onDoubleClick={wrapEvent(handleDoubleClick, onDoubleClick)}

--- a/src/Columns.tsx
+++ b/src/Columns.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SelectCellFormatter } from './formatters';
 import { Column } from './types';
+import { stopPropagation } from './utils';
 
 // TODO: fix type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,6 +28,7 @@ export const SelectColumn: Column<any, any> = {
         tabIndex={-1}
         isCellSelected={props.isCellSelected}
         value={props.isRowSelected}
+        onClick={stopPropagation}
         onChange={props.onRowSelectionChange}
       />
     );

--- a/src/Columns.tsx
+++ b/src/Columns.tsx
@@ -30,8 +30,5 @@ export const SelectColumn: Column<any, any> = {
         onChange={props.onRowSelectionChange}
       />
     );
-  },
-  formatterOptions: {
-    focusable: true
   }
 };

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -239,6 +239,7 @@ function DataGrid<R, K extends keyof R, SR>({
   const prevSelectedPosition = useRef(selectedPosition);
   const latestDraggedOverRowIdx = useRef(draggedOverRowIdx);
   const lastSelectedRowIdx = useRef(-1);
+  const isCellFocusable = useRef(false);
 
   /**
    * computed values
@@ -273,12 +274,8 @@ function DataGrid<R, K extends keyof R, SR>({
     prevSelectedPosition.current = selectedPosition;
     scrollToCell(selectedPosition);
 
-    const focusable = columns[selectedPosition.idx]?.formatterOptions?.focusable;
-    if (
-      (typeof focusable === 'function' && focusable(rows[selectedPosition.rowIdx]))
-      || focusable === true
-    ) {
-      // Let the formatter handle focus
+    if (isCellFocusable.current) {
+      isCellFocusable.current = false;
       return;
     }
     focusSinkRef.current!.focus();
@@ -708,6 +705,9 @@ function DataGrid<R, K extends keyof R, SR>({
     return {
       mode: 'SELECT',
       idx: selectedPosition.idx,
+      onFocus() {
+        isCellFocusable.current = true;
+      },
       onKeyDown: handleKeyDown,
       dragHandleProps: enableCellDragAndDrop && isCellEditable(selectedPosition)
         ? { onMouseDown: handleMouseDown, onDoubleClick: handleDoubleClick }

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -369,6 +369,10 @@ function DataGrid<R, K extends keyof R, SR>({
     }
   }
 
+  function handleFocus() {
+    isCellFocusable.current = true;
+  }
+
   function handleScroll(event: React.UIEvent<HTMLDivElement>) {
     const { scrollTop, scrollLeft } = event.currentTarget;
     setScrollTop(scrollTop);
@@ -705,9 +709,7 @@ function DataGrid<R, K extends keyof R, SR>({
     return {
       mode: 'SELECT',
       idx: selectedPosition.idx,
-      onFocus() {
-        isCellFocusable.current = true;
-      },
+      onFocus: handleFocus,
       onKeyDown: handleKeyDown,
       dragHandleProps: enableCellDragAndDrop && isCellEditable(selectedPosition)
         ? { onMouseDown: handleMouseDown, onDoubleClick: handleDoubleClick }

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -80,8 +80,8 @@ function Row<R, SR = unknown>({
             isCellSelected={isCellSelected}
             isRowSelected={isRowSelected}
             eventBus={eventBus}
-            dragHandleProps={isCellSelected ? (selectedCellProps as SelectedCellProps)!.dragHandleProps : undefined}
-            onFocus={isCellSelected ? (selectedCellProps as SelectedCellProps)!.onFocus : undefined}
+            dragHandleProps={isCellSelected ? (selectedCellProps as SelectedCellProps).dragHandleProps : undefined}
+            onFocus={isCellSelected ? (selectedCellProps as SelectedCellProps).onFocus : undefined}
             onKeyDown={isCellSelected ? selectedCellProps!.onKeyDown : undefined}
             onRowClick={onRowClick}
           />

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -81,6 +81,7 @@ function Row<R, SR = unknown>({
             isRowSelected={isRowSelected}
             eventBus={eventBus}
             dragHandleProps={isCellSelected ? (selectedCellProps as SelectedCellProps)!.dragHandleProps : undefined}
+            onFocus={isCellSelected ? (selectedCellProps as SelectedCellProps)!.onFocus : undefined}
             onKeyDown={isCellSelected ? selectedCellProps!.onKeyDown : undefined}
             onRowClick={onRowClick}
           />

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -42,6 +42,7 @@ export function SelectCellFormatter({
         className="rdg-checkbox-input"
         disabled={disabled}
         onChange={handleChange}
+        onClick={e => e.stopPropagation()}
         checked={value}
       />
       <div className="rdg-checkbox" />

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -8,6 +8,7 @@ type SharedInputProps = Pick<React.InputHTMLAttributes<HTMLInputElement>,
   | 'tabIndex'
   | 'aria-label'
   | 'aria-labelledby'
+  | 'onClick'
 >;
 
 export interface SelectCellFormatterProps extends SharedInputProps {
@@ -21,6 +22,7 @@ export function SelectCellFormatter({
   tabIndex,
   isCellSelected,
   disabled,
+  onClick,
   onChange,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy
@@ -42,7 +44,7 @@ export function SelectCellFormatter({
         className="rdg-checkbox-input"
         disabled={disabled}
         onChange={handleChange}
-        onClick={e => e.stopPropagation()}
+        onClick={onClick}
         checked={value}
       />
       <div className="rdg-checkbox" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,9 +21,6 @@ export interface Column<TRow, TSummaryRow = unknown> {
   summaryCellClass?: string | ((row: TSummaryRow) => string);
   /** Formatter to be used to render the cell content */
   formatter?: React.ComponentType<FormatterProps<TRow, TSummaryRow>>;
-  formatterOptions?: {
-    focusable?: boolean | ((row: TRow) => boolean);
-  };
   /** Formatter to be used to render the summary cell content */
   summaryFormatter?: React.ComponentType<SummaryFormatterProps<TSummaryRow, TRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
@@ -149,6 +146,7 @@ export interface EditCellProps<TRow> extends SelectedCellPropsBase {
 
 export interface SelectedCellProps extends SelectedCellPropsBase {
   mode: 'SELECT';
+  onFocus: () => void;
   dragHandleProps?: Pick<React.HTMLAttributes<HTMLDivElement>, 'onMouseDown' | 'onDoubleClick'>;
 }
 

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -2,6 +2,10 @@ export function preventDefault(event: React.SyntheticEvent) {
   event.preventDefault();
 }
 
+export function stopPropagation(event: React.SyntheticEvent) {
+  event.stopPropagation();
+}
+
 export function wrapEvent<E extends React.SyntheticEvent>(ourHandler: React.EventHandler<E>, theirHandler: React.EventHandler<E> | undefined) {
   if (theirHandler === undefined) return ourHandler;
 

--- a/stories/demos/TreeView.tsx
+++ b/stories/demos/TreeView.tsx
@@ -106,7 +106,6 @@ export default function TreeView() {
       {
         key: 'format',
         name: 'format',
-        formatterOptions: { focusable: true },
         formatter({ row, isCellSelected }) {
           const hasChildren = row.children !== undefined;
           const style = !hasChildren ? { marginLeft: 30 } : undefined;


### PR DESCRIPTION
`onFocus` bubbles so we can use it to check if a cell was focused or not. This behavior is not changing in react 17. We won't need special handling for group row cells and conditional focusing 

https://reactjs.org/blog/2020/08/10/react-v17-rc.html#aligning-with-browsers