### PR TITLE
Add a quick animation to the caret

### DIFF
--- a/src/formatters/ToggleGroupFormatter.tsx
+++ b/src/formatters/ToggleGroupFormatter.tsx
@@ -26,7 +26,7 @@ export function ToggleGroupFormatter<R, SR>({
       onKeyDown={handleKeyDown}
     >
       {groupKey}
-      <svg viewBox="0 0 14 8" width="14" height="8">
+      <svg viewBox="0 0 14 8" width="14" height="8" className="rdg-caret">
         <path d={d} />
       </svg>
     </span>

--- a/style/grouprow.less
+++ b/style/grouprow.less
@@ -23,12 +23,16 @@
 
 .rdg-group-cell-content {
   outline: none;
+}
 
-  > svg {
-    margin-left: 4px;
-    stroke: currentColor;
-    stroke-width: 1.5px;
-    fill: transparent;
-    vertical-align: middle;
+.rdg-caret {
+  margin-left: 4px;
+  stroke: currentColor;
+  stroke-width: 1.5px;
+  fill: transparent;
+  vertical-align: middle;
+
+  > path {
+    transition: d .1s;
   }
 }


### PR DESCRIPTION
Makes grouping delightful to use.
https://css-tricks.com/animate-svg-path-changes-in-css/
Doesn't work in Firefox/Safari though.