### PR TITLE
rdg height was fixed as 350px but it's not useful

### DIFF
--- a/style/core.less
+++ b/style/core.less
@@ -8,7 +8,7 @@
   contain: strict;
   contain: size layout style paint;
   content-visibility: auto;
-  height: 350px;
+  height: 100%;
   border: 1px solid @borderColor;
   box-sizing: border-box;
   overflow-x: auto;


### PR DESCRIPTION
rdg height was fixed as 350px but height and width should be responsible in many cases, so it should be changed to 100%. I hope this change will be accepted, because I love this grid but I always make another wrapped css only for this changes.