### PR TITLE
Pin @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/faker": "^5.1.0",
     "@types/jest": "^26.0.13",
     "@types/lodash": "^4.14.161",
+    "@types/node": "14.10.0",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/react-select": "^3.0.19",


### PR DESCRIPTION
Typechecking is broken since Friday because of a type update.
https://github.com/adazzle/react-data-grid/pull/2152/checks?check_run_id=1112808477
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45993