### PR TITLE
Add rdg-editor-container2 class

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -9,6 +9,8 @@
   ],
   "plugins": [
     ["@babel/transform-runtime", { "useESModules": true }],
+    "@babel/proposal-nullish-coalescing-operator",
+    "@babel/proposal-optional-chaining",
     "babel-plugin-optimize-clsx"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/faker": "^5.1.0",
     "@types/jest": "^26.0.13",
     "@types/lodash": "^4.14.161",
-    "@types/node": "14.10.0",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/react-select": "^3.0.19",

--- a/src/editors/Editor2Container.tsx
+++ b/src/editors/Editor2Container.tsx
@@ -15,7 +15,7 @@ export default function Editor2Container<R, SR>({
   if (column.editor2 === undefined) return null;
 
   const editor = (
-    <div onClickCapture={onClickCapture}>
+    <div className="rdg-editor-container2" onClickCapture={onClickCapture}>
       <column.editor2
         row={row}
         column={column}

--- a/style/editor.less
+++ b/style/editor.less
@@ -2,6 +2,10 @@
   position: absolute;
 }
 
+.rdg-editor-container2 {
+  display: contents;
+}
+
 .rdg-text-editor {
   -moz-appearance: none;
   -webkit-appearance: none;


### PR DESCRIPTION
- removed `@types/node` that was previously added as a type issue workaround
- fixed storybook builds