### PR TITLE
Prevert scroll on focus

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -301,7 +301,7 @@ function DataGrid<R, K extends keyof R, SR>({
       isCellFocusable.current = false;
       return;
     }
-    focusSinkRef.current!.focus();
+    focusSinkRef.current!.focus({ preventScroll: true });
   });
 
   useEffect(() => {


### PR DESCRIPTION
When the `focusSink` in not in the viewport then the page scrolls on focus 