### PR TITLE
rowKey -> rowKeyGetter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
   - ⚠️ `onGridSort` to `onSort`
   - ⚠️ `onGridRowsUpdated` to `onRowsUpdate`
   - ⚠️ `emptyRowsView` to `emptyRowsRenderer`
+  - ⚠️ `rowKey` to `rowKeyGetter`
   - ⚠️ `rowData` to `row`
   - ⚠️ `fromRowData` to `fromRow`
   - ⚠️ `idx` to `rowIdx` in `Row` renderer
@@ -105,7 +106,7 @@
     - Added `column.summaryCellClass` and `column.summaryFormatter` props
     - `column.formatter` isn't used anymore to render summary row cells.
   - Only visible headers cells are now rendered. [#1837](https://github.com/adazzle/react-data-grid/pull/1837)
-  - ⚠️ the `rowKey` prop is now required for row selection.
+  - ⚠️ the `rowKeyGetter` prop is now required for row selection.
   - ⚠️ `column.cellClass` does not affect header cells anymore.
   - ⚠️ `onScroll` will directly pass the UIEvent rather than the scrollLeft and scrollRight only.
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -88,7 +88,7 @@ export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
    * Bottom horizontal scroll bar can move the row left / right. Or a customized row renderer can be used to disabled the scrolling support.
    */
   summaryRows?: readonly SR[];
-  /** The primary key property of each row */
+  /** The getter should return a unique key for each row */
   rowKeyGetter?: (row: R) => React.Key;
   /**
    * Callback called whenever row data is updated
@@ -346,7 +346,7 @@ function DataGrid<R, SR>({
     };
 
     return eventBus.subscribe('SelectRow', handleRowSelectionChange);
-  }, [eventBus, isGroupRow, onSelectedRowsChange, rowKeyGetter, rows, selectedRows]);
+  });
 
   useEffect(() => {
     return eventBus.subscribe('SelectCell', selectCell);
@@ -859,10 +859,10 @@ function DataGrid<R, SR>({
       let key: string | number = hasGroups ? startRowIndex : rowIdx;
       let isRowSelected = false;
       if (typeof rowKeyGetter === 'function') {
-        const rowId = rowKeyGetter(row);
-        isRowSelected = selectedRows?.has(rowId) ?? false;
-        if (typeof rowId === 'string' || typeof rowId === 'number') {
-          key = rowId;
+        const rowKey = rowKeyGetter(row);
+        isRowSelected = selectedRows?.has(rowKey) ?? false;
+        if (typeof rowKey === 'string' || typeof rowKey === 'number') {
+          key = rowKey;
         }
       }
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -18,7 +18,7 @@ import Row from './Row';
 import GroupRowRenderer from './GroupRow';
 import SummaryRow from './SummaryRow';
 import {
-  assertIsValidKey,
+  assertIsValidKeyGetter,
   getColumnScrollPosition,
   getNextSelectedCellPosition,
   isSelectedCellEditable,
@@ -75,7 +75,7 @@ type SharedDivProps = Pick<React.HTMLAttributes<HTMLDivElement>,
   | 'style'
 >;
 
-export interface DataGridProps<R, K extends keyof R, SR = unknown> extends SharedDivProps {
+export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
   /**
    * Grid and data Props
    */
@@ -89,7 +89,7 @@ export interface DataGridProps<R, K extends keyof R, SR = unknown> extends Share
    */
   summaryRows?: readonly SR[];
   /** The primary key property of each row */
-  rowKey?: K;
+  rowKeyGetter?: (row: R) => React.Key;
   /**
    * Callback called whenever row data is updated
    * When editing is enabled, this callback will be called for the following scenarios
@@ -115,9 +115,9 @@ export interface DataGridProps<R, K extends keyof R, SR = unknown> extends Share
    * Feature props
    */
   /** Set of selected row keys */
-  selectedRows?: ReadonlySet<R[K]>;
+  selectedRows?: ReadonlySet<React.Key>;
   /** Function called whenever row selection is changed */
-  onSelectedRowsChange?: (selectedRows: Set<R[K]>) => void;
+  onSelectedRowsChange?: (selectedRows: Set<React.Key>) => void;
   /** The key of the column which is currently being sorted */
   sortColumn?: string;
   /** The direction to sort the sortColumn*/
@@ -176,12 +176,12 @@ export interface DataGridProps<R, K extends keyof R, SR = unknown> extends Share
  *
  * <DataGrid columns={columns} rows={rows} />
 */
-function DataGrid<R, K extends keyof R, SR>({
+function DataGrid<R, SR>({
   // Grid and data Props
   columns: rawColumns,
   rows: rawRows,
   summaryRows,
-  rowKey,
+  rowKeyGetter,
   onRowsUpdate,
   onRowsChange,
   // Dimensions props
@@ -224,7 +224,7 @@ function DataGrid<R, K extends keyof R, SR>({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   'aria-describedby': ariaDescribedBy
-}: DataGridProps<R, K, SR>, ref: React.Ref<DataGridHandle>) {
+}: DataGridProps<R, SR>, ref: React.Ref<DataGridHandle>) {
   /**
    * states
    */
@@ -308,24 +308,25 @@ function DataGrid<R, K extends keyof R, SR>({
     if (!onSelectedRowsChange) return;
 
     const handleRowSelectionChange = ({ rowIdx, checked, isShiftClick }: SelectRowEvent) => {
-      assertIsValidKey(rowKey);
+      assertIsValidKeyGetter(rowKeyGetter);
       const newSelectedRows = new Set(selectedRows);
       const row = rows[rowIdx];
       if (isGroupRow(row)) {
         for (const childRow of row.childRows) {
+          const rowKey = rowKeyGetter(childRow);
           if (checked) {
-            newSelectedRows.add(childRow[rowKey]);
+            newSelectedRows.add(rowKey);
           } else {
-            newSelectedRows.delete(childRow[rowKey]);
+            newSelectedRows.delete(rowKey);
           }
         }
         onSelectedRowsChange(newSelectedRows);
         return;
       }
 
-      const rowId = row[rowKey];
+      const rowKey = rowKeyGetter(row);
       if (checked) {
-        newSelectedRows.add(rowId);
+        newSelectedRows.add(rowKey);
         const previousRowIdx = lastSelectedRowIdx.current;
         lastSelectedRowIdx.current = rowIdx;
         if (isShiftClick && previousRowIdx !== -1 && previousRowIdx !== rowIdx) {
@@ -333,11 +334,11 @@ function DataGrid<R, K extends keyof R, SR>({
           for (let i = previousRowIdx + step; i !== rowIdx; i += step) {
             const row = rows[i];
             if (isGroupRow(row)) continue;
-            newSelectedRows.add(row[rowKey]);
+            newSelectedRows.add(rowKeyGetter(row));
           }
         }
       } else {
-        newSelectedRows.delete(rowId);
+        newSelectedRows.delete(rowKey);
         lastSelectedRowIdx.current = -1;
       }
 
@@ -345,7 +346,7 @@ function DataGrid<R, K extends keyof R, SR>({
     };
 
     return eventBus.subscribe('SelectRow', handleRowSelectionChange);
-  }, [eventBus, isGroupRow, onSelectedRowsChange, rowKey, rows, selectedRows]);
+  }, [eventBus, isGroupRow, onSelectedRowsChange, rowKeyGetter, rows, selectedRows]);
 
   useEffect(() => {
     return eventBus.subscribe('SelectCell', selectCell);
@@ -845,7 +846,7 @@ function DataGrid<R, K extends keyof R, SR>({
             level={row.level}
             isExpanded={row.isExpanded}
             selectedCellIdx={selectedPosition.rowIdx === rowIdx ? selectedPosition.idx : undefined}
-            isRowSelected={isSelectable && row.childRows.every(cr => selectedRows?.has(cr[rowKey!]))}
+            isRowSelected={isSelectable && row.childRows.every(cr => selectedRows?.has(rowKeyGetter!(cr)))}
             eventBus={eventBus}
             onFocus={selectedPosition.rowIdx === rowIdx ? handleFocus : undefined}
             onKeyDown={selectedPosition.rowIdx === rowIdx ? handleKeyDown : undefined}
@@ -857,8 +858,8 @@ function DataGrid<R, K extends keyof R, SR>({
       startRowIndex++;
       let key: string | number = hasGroups ? startRowIndex : rowIdx;
       let isRowSelected = false;
-      if (rowKey !== undefined) {
-        const rowId = row[rowKey];
+      if (typeof rowKeyGetter === 'function') {
+        const rowId = rowKeyGetter(row);
         isRowSelected = selectedRows?.has(rowId) ?? false;
         if (typeof rowId === 'string' || typeof rowId === 'number') {
           key = rowId;
@@ -921,8 +922,8 @@ function DataGrid<R, K extends keyof R, SR>({
       ref={gridRef}
       onScroll={handleScroll}
     >
-      <HeaderRow<R, K, SR>
-        rowKey={rowKey}
+      <HeaderRow<R, SR>
+        rowKeyGetter={rowKeyGetter}
         rows={rawRows}
         columns={viewportColumns}
         onColumnResize={handleColumnResize}
@@ -967,4 +968,4 @@ function DataGrid<R, K extends keyof R, SR>({
 
 export default forwardRef(
   DataGrid as React.ForwardRefRenderFunction<DataGridHandle>
-) as <R, K extends keyof R, SR = unknown>(props: DataGridProps<R, K, SR> & React.RefAttributes<DataGridHandle>) => JSX.Element;
+) as <R, SR = unknown>(props: DataGridProps<R, SR> & React.RefAttributes<DataGridHandle>) => JSX.Element;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -856,14 +856,11 @@ function DataGrid<R, SR>({
       }
 
       startRowIndex++;
-      let key: string | number = hasGroups ? startRowIndex : rowIdx;
+      let key: React.Key = hasGroups ? startRowIndex : rowIdx;
       let isRowSelected = false;
       if (typeof rowKeyGetter === 'function') {
-        const rowKey = rowKeyGetter(row);
-        isRowSelected = selectedRows?.has(rowKey) ?? false;
-        if (typeof rowKey === 'string' || typeof rowKey === 'number') {
-          key = rowKey;
-        }
+        key = rowKeyGetter(row);
+        isRowSelected = selectedRows?.has(key) ?? false;
       }
 
       rowElements.push(

--- a/src/FilterRow.tsx
+++ b/src/FilterRow.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { CalculatedColumn, Filters } from './types';
 import { DataGridProps } from './DataGrid';
 
-type SharedDataGridProps<R, SR> = Pick<DataGridProps<R, never, SR>,
+type SharedDataGridProps<R, SR> = Pick<DataGridProps<R, SR>,
   | 'filters'
   | 'onFiltersChange'
 >;

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -18,7 +18,7 @@ function getAriaSort(sortDirection?: SortDirection) {
   }
 }
 
-type SharedHeaderRowProps<R, SR> = Pick<HeaderRowProps<R, never, SR>,
+type SharedHeaderRowProps<R, SR> = Pick<HeaderRowProps<R, SR>,
   | 'sortColumn'
   | 'sortDirection'
   | 'onSort'

--- a/src/HeaderRow.test.tsx
+++ b/src/HeaderRow.test.tsx
@@ -7,8 +7,8 @@ import HeaderRow, { HeaderRowProps } from './HeaderRow';
 import HeaderCell from './HeaderCell';
 
 describe('HeaderRow', () => {
-  const defaultProps: HeaderRowProps<Row, 'id', unknown> = {
-    rowKey: 'id',
+  const defaultProps: HeaderRowProps<Row, unknown> = {
+    rowKeyGetter: row => row.id,
     rows: [],
     columns: helpers.columns,
     onColumnResize() { },
@@ -17,8 +17,8 @@ describe('HeaderRow', () => {
     allRowsSelected: false
   };
 
-  const setup = (testProps?: Partial<HeaderRowProps<Row, 'id', unknown>>) => {
-    const props: HeaderRowProps<Row, 'id', unknown> = { ...defaultProps, ...testProps };
+  const setup = (testProps?: Partial<HeaderRowProps<Row, unknown>>) => {
+    const props: HeaderRowProps<Row, unknown> = { ...defaultProps, ...testProps };
     const wrapper = mount(<HeaderRow {...props} />);
     const headerCells = wrapper.find(HeaderCell);
     return { wrapper, headerCells, props };
@@ -64,12 +64,12 @@ describe('HeaderRow', () => {
   });
 
   describe('Rendering HeaderRow component', () => {
-    const renderComponent = (props: HeaderRowProps<Row, 'id', unknown>) => {
+    const renderComponent = (props: HeaderRowProps<Row, unknown>) => {
       return mount(<HeaderRow {...props} />);
     };
 
-    const requiredProps: HeaderRowProps<Row, 'id', unknown> = {
-      rowKey: 'id',
+    const requiredProps: HeaderRowProps<Row, unknown> = {
+      rowKeyGetter: row => row.id,
       rows: [],
       columns: helpers.columns,
       onSort: jest.fn(),

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -2,49 +2,49 @@ import React, { useCallback, memo } from 'react';
 
 import HeaderCell from './HeaderCell';
 import { CalculatedColumn } from './types';
-import { assertIsValidKey } from './utils';
+import { assertIsValidKeyGetter } from './utils';
 import { DataGridProps } from './DataGrid';
 
-type SharedDataGridProps<R, K extends keyof R, SR> = Pick<DataGridProps<R, K, SR>,
+type SharedDataGridProps<R, SR> = Pick<DataGridProps<R, SR>,
   | 'rows'
   | 'onSelectedRowsChange'
   | 'sortColumn'
   | 'sortDirection'
   | 'onSort'
-  | 'rowKey'
+  | 'rowKeyGetter'
 >;
 
-export interface HeaderRowProps<R, K extends keyof R, SR> extends SharedDataGridProps<R, K, SR> {
+export interface HeaderRowProps<R, SR> extends SharedDataGridProps<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
   allRowsSelected: boolean;
   onColumnResize: (column: CalculatedColumn<R, SR>, width: number) => void;
 }
 
-function HeaderRow<R, K extends keyof R, SR>({
+function HeaderRow<R, SR>({
   columns,
   rows,
-  rowKey,
+  rowKeyGetter,
   onSelectedRowsChange,
   allRowsSelected,
   onColumnResize,
   sortColumn,
   sortDirection,
   onSort
-}: HeaderRowProps<R, K, SR>) {
+}: HeaderRowProps<R, SR>) {
   const handleAllRowsSelectionChange = useCallback((checked: boolean) => {
     if (!onSelectedRowsChange) return;
 
-    assertIsValidKey(rowKey);
+    assertIsValidKeyGetter(rowKeyGetter);
 
-    const newSelectedRows = new Set<R[K]>();
+    const newSelectedRows = new Set<React.Key>();
     if (checked) {
       for (const row of rows) {
-        newSelectedRows.add(row[rowKey]);
+        newSelectedRows.add(rowKeyGetter(row));
       }
     }
 
     onSelectedRowsChange(newSelectedRows);
-  }, [onSelectedRowsChange, rows, rowKey]);
+  }, [onSelectedRowsChange, rows, rowKeyGetter]);
 
   return (
     <div
@@ -70,4 +70,4 @@ function HeaderRow<R, K extends keyof R, SR>({
   );
 }
 
-export default memo(HeaderRow) as <R, K extends keyof R, SR>(props: HeaderRowProps<R, K, SR>) => JSX.Element;
+export default memo(HeaderRow) as <R, SR>(props: HeaderRowProps<R, SR>) => JSX.Element;

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -5,12 +5,12 @@ import { getColumnMetrics } from '../utils';
 import { DataGridProps } from '../DataGrid';
 import { ValueFormatter } from '../formatters';
 
-type SharedDataGridProps<R, K extends keyof R, SR> = Pick<DataGridProps<R, K, SR>,
+type SharedDataGridProps<R, SR> = Pick<DataGridProps<R, SR>,
   | 'defaultColumnOptions'
   | 'rowGrouper'
 >;
 
-interface ViewportColumnsArgs<R, K extends keyof R, SR> extends SharedDataGridProps<R, K, SR> {
+interface ViewportColumnsArgs<R, SR> extends SharedDataGridProps<R, SR> {
   rawColumns: readonly Column<R, SR>[];
   rawGroupBy?: readonly string[];
   viewportWidth: number;
@@ -18,7 +18,7 @@ interface ViewportColumnsArgs<R, K extends keyof R, SR> extends SharedDataGridPr
   columnWidths: ReadonlyMap<string, number>;
 }
 
-export function useViewportColumns<R, K extends keyof R, SR>({
+export function useViewportColumns<R, SR>({
   rawColumns,
   columnWidths,
   viewportWidth,
@@ -26,7 +26,7 @@ export function useViewportColumns<R, K extends keyof R, SR>({
   defaultColumnOptions,
   rawGroupBy,
   rowGrouper
-}: ViewportColumnsArgs<R, K, SR>) {
+}: ViewportColumnsArgs<R, SR>) {
   const minColumnWidth = defaultColumnOptions?.minWidth ?? 80;
   const defaultFormatter = defaultColumnOptions?.formatter ?? ValueFormatter;
   const defaultSortable = defaultColumnOptions?.sortable ?? false;

--- a/src/test/GridPropHelpers.ts
+++ b/src/test/GridPropHelpers.ts
@@ -2,7 +2,7 @@ import { ValueFormatter, SimpleCellFormatter } from '../formatters';
 import { CalculatedColumn } from '../types';
 
 export interface Row {
-  id?: number;
+  id: number;
   title?: string;
   count?: number;
   description?: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,9 +3,9 @@ export * from './columnUtils';
 export * from './keyboardUtils';
 export * from './selectedCellUtils';
 
-export function assertIsValidKey<R>(key: unknown): asserts key is keyof R {
-  if (key === undefined) {
-    throw new Error('Please specify the rowKey prop to use selection');
+export function assertIsValidKeyGetter<R>(keyGetter?: unknown): asserts keyGetter is (row: R) => React.Key {
+  if (typeof keyGetter !== 'function') {
+    throw new Error('Please specify the rowKeyGetter prop to use selection');
   }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@ export * from './columnUtils';
 export * from './keyboardUtils';
 export * from './selectedCellUtils';
 
-export function assertIsValidKeyGetter<R>(keyGetter?: unknown): asserts keyGetter is (row: R) => React.Key {
+export function assertIsValidKeyGetter<R>(keyGetter: unknown): asserts keyGetter is (row: R) => React.Key {
   if (typeof keyGetter !== 'function') {
     throw new Error('Please specify the rowKeyGetter prop to use selection');
   }

--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -24,6 +24,10 @@ interface Row {
   sentence: string;
 }
 
+function rowKeyGetter(row: Row) {
+  return row.id;
+}
+
 faker.locale = 'en_GB';
 
 const titles = ['Dr.', 'Mr.', 'Mrs.', 'Miss', 'Ms.'];
@@ -76,7 +80,7 @@ function loadMoreRows(newRowsCount: number, length: number): Promise<Row[]> {
 
 export function AllFeatures() {
   const [rows, setRows] = useState(() => createRows(2000));
-  const [selectedRows, setSelectedRows] = useState(() => new Set<string>());
+  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const [isLoading, setIsLoading] = useState(false);
   const gridRef = useRef<DataGridHandle>(null);
 
@@ -227,7 +231,7 @@ export function AllFeatures() {
         ref={gridRef}
         columns={columns}
         rows={rows}
-        rowKey="id"
+        rowKeyGetter={rowKeyGetter}
         onRowsUpdate={handleRowUpdate}
         onRowClick={handleRowClick}
         rowHeight={30}

--- a/stories/demos/CellActions.tsx
+++ b/stories/demos/CellActions.tsx
@@ -147,7 +147,7 @@ export function CellActions() {
   const [rows] = useState(createRows);
 
   return (
-    <DataGrid<Row, 'id'>
+    <DataGrid
       columns={columns}
       rows={rows}
       rowHeight={55}

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -176,6 +176,10 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
   ];
 }
 
+function rowKeyGetter(row: Row) {
+  return row.id;
+}
+
 function createRows(): readonly Row[] {
   const now = Date.now();
   const rows: Row[] = [];
@@ -206,7 +210,7 @@ function createRows(): readonly Row[] {
 export function CommonFeatures() {
   const [rows, setRows] = useState(createRows);
   const [[sortColumn, sortDirection], setSort] = useState<[string, SortDirection]>(['id', 'NONE']);
-  const [selectedRows, setSelectedRows] = useState(() => new Set<number>());
+  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
 
   const countries = useMemo(() => {
     return [...new Set(rows.map(r => r.country))].sort();
@@ -268,7 +272,7 @@ export function CommonFeatures() {
 
   return (
     <DataGrid
-      rowKey="id"
+      rowKeyGetter={rowKeyGetter}
       columns={columns}
       rows={sortedRows}
       defaultColumnOptions={{

--- a/stories/demos/ContextMenu.tsx
+++ b/stories/demos/ContextMenu.tsx
@@ -30,6 +30,10 @@ const columns: readonly Column<Row>[] = [
   { key: 'price', name: 'Price' }
 ];
 
+function rowKeyGetter(row: Row) {
+  return row.id;
+}
+
 function RowRenderer(props: RowRendererProps<Row>) {
   return (
     <ContextMenuTrigger id="grid-context-menu" collect={() => ({ rowIdx: props.rowIdx })}>
@@ -75,7 +79,7 @@ export function ContextMenuStory() {
   return (
     <>
       <DataGrid
-        rowKey="id"
+        rowKeyGetter={rowKeyGetter}
         columns={columns}
         rows={rows}
         rowRenderer={RowRenderer}

--- a/stories/demos/Grouping.tsx
+++ b/stories/demos/Grouping.tsx
@@ -76,6 +76,10 @@ const columns: readonly Column<Row>[] = [
   }
 ];
 
+function rowKeyGetter(row: Row) {
+  return row.id;
+}
+
 function createRows(): readonly Row[] {
   const rows: Row[] = [];
   for (let i = 1; i < 10000; i++) {
@@ -115,7 +119,7 @@ const options: OptionsType<Option> = [
 
 export function Grouping() {
   const [rows] = useState(createRows);
-  const [selectedRows, setSelectedRows] = useState(() => new Set<number>());
+  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const [selectedOptions, setSelectedOptions] = useState<ValueType<Option>>([options[0], options[1]]);
   const [expandedGroupIds, setExpandedGroupIds] = useState(() => new Set<unknown>(['United States of America', 'United States of America__2015']));
 
@@ -154,7 +158,7 @@ export function Grouping() {
         />
       </label>
       <DataGrid
-        rowKey="id"
+        rowKeyGetter={rowKeyGetter}
         columns={columns}
         rows={rows}
         selectedRows={selectedRows}


### PR DESCRIPTION
Pros:
- Rows can now be of any type, and we type-check that the row key is a `React.Key`.
- It's a lot more flexible, it doesn't have to be a value held in the row data for example.
- -1 generic

Cons:
- Users must implement the function.
  - Implementations should be trivial, I think this is a non-issue
  - It's still optional, unless row selection is enabled.
- The function should be static to avoid re-renders
  - A static function declaration outside the functional component should work, at worst users have to use `useCallback`.
  - Class members are still good.