### PR TITLE
Add `scroll-behavior: smooth;`

### DIFF
--- a/style/core.less
+++ b/style/core.less
@@ -54,6 +54,7 @@
   background-color: var(--background-color);
   color: var(--color);
   font-size: var(--font-size);
+  scroll-behavior: smooth;
 
   *,
   *::before,


### PR DESCRIPTION
It makes the "Scroll To Row" demo scroll the grid smoothly.
Since it's just CSS it's easy to disable.
WDYT?