### PR TITLE
Only make scrollToRow smooth

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -354,7 +354,10 @@ function DataGrid<R, SR>({
     scrollToRow(rowIdx: number) {
       const { current } = gridRef;
       if (!current) return;
-      current.scrollTop = rowIdx * rowHeight;
+      current.scrollTo({
+        top: rowIdx * rowHeight,
+        behavior: 'smooth'
+      });
     },
     selectCell
   }));

--- a/style/core.less
+++ b/style/core.less
@@ -54,7 +54,6 @@
   background-color: var(--background-color);
   color: var(--color);
   font-size: var(--font-size);
-  scroll-behavior: smooth;
 
   *,
   *::before,


### PR DESCRIPTION
`scroll-behavior: smooth;` made all scrolling smooth, including keyboard navigation, which is probably not desirable, especially when holding arrow keys.
I've made it so only `scrollToRow` is smooth.