### PR TITLE
Save resized columns on the parent component and remove internal columnWidths state

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -19,6 +19,7 @@ function Cell<R, SR>({
   onClick,
   onDoubleClick,
   onContextMenu,
+  onRowChange,
   selectCell,
   selectRow,
   ...props
@@ -56,6 +57,10 @@ function Cell<R, SR>({
     selectCellWrapper(true);
   }
 
+  function handleRowChange(newRow: R) {
+    onRowChange(rowIdx, newRow);
+  }
+
   function onRowSelectionChange(checked: boolean, isShiftClick: boolean) {
     selectRow({ rowIdx, checked, isShiftClick });
   }
@@ -85,6 +90,7 @@ function Cell<R, SR>({
             isCellSelected={isCellSelected}
             isRowSelected={isRowSelected}
             onRowSelectionChange={onRowSelectionChange}
+            onRowChange={handleRowChange}
           />
           {dragHandleProps && (
             <div className="rdg-cell-drag-handle" {...dragHandleProps} />

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -235,6 +235,7 @@ function DataGrid<R, SR>({
   const selectRowWrapper = useLatestFunc(selectRow);
   const selectCellWrapper = useLatestFunc(selectCell);
   const toggleGroupWrapper = useLatestFunc(toggleGroup);
+  const handleFormatterRowChangeWrapper = useLatestFunc(handleFormatterRowChange);
 
   /**
    * computed values
@@ -577,7 +578,13 @@ function DataGrid<R, SR>({
     onRowsChange(updatedRows);
   }
 
-  function handleRowChange(row: Readonly<R>, commitChanges?: boolean) {
+  function handleFormatterRowChange(rowIdx: number, row: Readonly<R>) {
+    const newRows = [...rawRows];
+    newRows[rowIdx] = row;
+    onRowsChange?.(newRows);
+  }
+
+  function handleEditorRowChange(row: Readonly<R>, commitChanges?: boolean) {
     if (selectedPosition.mode === 'SELECT') return;
     if (commitChanges) {
       const updatedRows = [...rawRows];
@@ -766,7 +773,7 @@ function DataGrid<R, SR>({
           editorPortalTarget,
           rowHeight,
           row: selectedPosition.row,
-          onRowChange: handleRowChange,
+          onRowChange: handleEditorRowChange,
           onClose: handleOnClose
         }
       };
@@ -842,6 +849,7 @@ function DataGrid<R, SR>({
           draggedOverCellIdx={getDraggedOverCellIdx(rowIdx)}
           setDraggedOverRowIdx={isDragging ? setDraggedOverRowIdx : undefined}
           selectedCellProps={getSelectedCellProps(rowIdx)}
+          onRowChange={handleFormatterRowChangeWrapper}
           selectCell={selectCellWrapper}
           selectRow={selectRowWrapper}
         />

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -21,6 +21,7 @@ function Row<R, SR = unknown>({
   setDraggedOverRowIdx,
   onMouseEnter,
   top,
+  onRowChange,
   selectCell,
   selectRow,
   'aria-rowindex': ariaRowIndex,
@@ -81,6 +82,7 @@ function Row<R, SR = unknown>({
             onFocus={isCellSelected ? (selectedCellProps as SelectedCellProps).onFocus : undefined}
             onKeyDown={isCellSelected ? selectedCellProps!.onKeyDown : undefined}
             onRowClick={onRowClick}
+            onRowChange={onRowChange}
             selectCell={selectCell}
             selectRow={selectRow}
           />

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -10,12 +10,10 @@ interface ViewportColumnsArgs<R, SR> extends Pick<DataGridProps<R, SR>, 'default
   rawGroupBy?: readonly string[];
   viewportWidth: number;
   scrollLeft: number;
-  columnWidths: ReadonlyMap<string, number>;
 }
 
 export function useViewportColumns<R, SR>({
   rawColumns,
-  columnWidths,
   viewportWidth,
   scrollLeft,
   defaultColumnOptions,
@@ -36,7 +34,7 @@ export function useViewportColumns<R, SR>({
     let totalFrozenColumnWidth = 0;
 
     const columns = rawColumns.map(metricsColumn => {
-      let width = getSpecifiedWidth(metricsColumn, columnWidths, viewportWidth);
+      let width = getSpecifiedWidth(metricsColumn, viewportWidth);
 
       if (width === undefined) {
         unassignedColumnsCount++;
@@ -128,7 +126,7 @@ export function useViewportColumns<R, SR>({
       totalColumnWidth: totalWidth,
       groupBy
     };
-  }, [columnWidths, defaultFormatter, defaultResizable, defaultSortable, minColumnWidth, rawColumns, rawGroupBy, viewportWidth]);
+  }, [defaultFormatter, defaultResizable, defaultSortable, minColumnWidth, rawColumns, rawGroupBy, viewportWidth]);
 
   const [colOverscanStartIdx, colOverscanEndIdx] = useMemo((): [number, number] => {
     // get the viewport's left side and right side positions for non-frozen columns
@@ -189,14 +187,9 @@ export function useViewportColumns<R, SR>({
 }
 
 function getSpecifiedWidth<R, SR>(
-  { key, width }: Column<R, SR>,
-  columnWidths: ReadonlyMap<string, number>,
+  { width }: Column<R, SR>,
   viewportWidth: number
 ): number | undefined {
-  if (columnWidths.has(key)) {
-    // Use the resized width if available
-    return columnWidths.get(key);
-  }
   if (typeof width === 'number') {
     return width;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ReactElement } from 'react';
 import { SortDirection } from './enums';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export interface Column<TRow, TSummaryRow = unknown> {
   /** The name of the column. By default it will be displayed in the header cell */
-  name: string;
+  name: string | ReactElement;
   /** A unique key to distinguish each column */
   key: string;
   /** Column width. If not specified, it will be determined automatically based on grid width and specified widths of other columns */

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export interface FormatterProps<TRow = any, TSummaryRow = any> {
   isCellSelected: boolean;
   isRowSelected: boolean;
   onRowSelectionChange: (checked: boolean, isShiftClick: boolean) => void;
+  onRowChange: (row: Readonly<TRow>) => void;
 }
 
 export interface SummaryFormatterProps<TSummaryRow, TRow = any> {
@@ -145,6 +146,7 @@ export interface CellRendererProps<TRow, TSummaryRow = unknown> extends Omit<Rea
   isCellSelected: boolean;
   isRowSelected: boolean;
   dragHandleProps?: Pick<React.HTMLAttributes<HTMLDivElement>, 'onMouseDown' | 'onDoubleClick'>;
+  onRowChange: (rowIdx: number, newRow: TRow) => void;
   onRowClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
   selectCell: (position: Position, enableEditor?: boolean) => void;
   selectRow: (selectRowEvent: SelectRowEvent) => void;
@@ -160,6 +162,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown> extends Omit<Reac
   isRowSelected: boolean;
   top: number;
   selectedCellProps?: EditCellProps<TRow> | SelectedCellProps;
+  onRowChange: (rowIdx: number, row: TRow) => void;
   onRowClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
   rowClass?: (row: TRow) => string | undefined;
   setDraggedOverRowIdx?: (overRowIdx: number) => void;

--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -29,109 +29,111 @@ function rowKeyGetter(row: Row) {
 
 faker.locale = 'en_GB';
 
-const columns: readonly Column<Row>[] = [
-  SelectColumn,
-  {
-    key: 'id',
-    name: 'ID',
-    width: 80,
-    resizable: true,
-    frozen: true
-  },
-  {
-    key: 'avatar',
-    name: 'Avatar',
-    width: 40,
-    resizable: true,
-    headerRenderer: () => <ImageFormatter value={faker.image.cats()} />,
-    formatter: ({ row }) => <ImageFormatter value={row.avatar} />
-  },
-  {
-    key: 'title',
-    name: 'Title',
-    width: 200,
-    resizable: true,
-    formatter(props) {
-      return <>{props.row.title}</>;
+function createColumns(): readonly Column<Row>[] {
+  return [
+    SelectColumn,
+    {
+      key: 'id',
+      name: 'ID',
+      width: 80,
+      resizable: true,
+      frozen: true
     },
-    editor: DropDownEditor,
-    editorOptions: {
-      editOnClick: true
+    {
+      key: 'avatar',
+      name: 'Avatar',
+      width: 40,
+      resizable: true,
+      headerRenderer: () => <ImageFormatter value={faker.image.cats()} />,
+      formatter: ({ row }) => <ImageFormatter value={row.avatar} />
+    },
+    {
+      key: 'title',
+      name: 'Title',
+      width: 200,
+      resizable: true,
+      formatter(props) {
+        return <>{props.row.title}</>;
+      },
+      editor: DropDownEditor,
+      editorOptions: {
+        editOnClick: true
+      }
+    },
+    {
+      key: 'firstName',
+      name: 'First Name',
+      width: 200,
+      resizable: true,
+      frozen: true,
+      editor: TextEditor
+    },
+    {
+      key: 'lastName',
+      name: 'Last Name',
+      width: 200,
+      resizable: true,
+      frozen: true,
+      editor: TextEditor
+    },
+    {
+      key: 'email',
+      name: 'Email',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'street',
+      name: 'Street',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'zipCode',
+      name: 'ZipCode',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'date',
+      name: 'Date',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'bs',
+      name: 'bs',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'catchPhrase',
+      name: 'Catch Phrase',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'companyName',
+      name: 'Company Name',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
+    },
+    {
+      key: 'sentence',
+      name: 'Sentence',
+      width: 200,
+      resizable: true,
+      editor: TextEditor
     }
-  },
-  {
-    key: 'firstName',
-    name: 'First Name',
-    width: 200,
-    resizable: true,
-    frozen: true,
-    editor: TextEditor
-  },
-  {
-    key: 'lastName',
-    name: 'Last Name',
-    width: 200,
-    resizable: true,
-    frozen: true,
-    editor: TextEditor
-  },
-  {
-    key: 'email',
-    name: 'Email',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'street',
-    name: 'Street',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'zipCode',
-    name: 'ZipCode',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'date',
-    name: 'Date',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'bs',
-    name: 'bs',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'catchPhrase',
-    name: 'Catch Phrase',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'companyName',
-    name: 'Company Name',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  },
-  {
-    key: 'sentence',
-    name: 'Sentence',
-    width: 200,
-    resizable: true,
-    editor: TextEditor
-  }
-];
+  ];
+}
 
 function createFakeRowObjectData(index: number): Row {
   return {
@@ -181,6 +183,7 @@ function loadMoreRows(newRowsCount: number, length: number): Promise<Row[]> {
 
 export function AllFeatures() {
   const [rows, setRows] = useState(() => createRows(2000));
+  const [columns, setColumns] = useState(createColumns);
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const [isLoading, setIsLoading] = useState(false);
   const gridRef = useRef<DataGridHandle>(null);
@@ -222,6 +225,7 @@ export function AllFeatures() {
         onRowsChange={setRows}
         onFill={handleFill}
         onPaste={handlePaste}
+        onColumnResize={setColumns}
         rowHeight={30}
         selectedRows={selectedRows}
         onScroll={handleScroll}

--- a/stories/demos/CellActions.tsx
+++ b/stories/demos/CellActions.tsx
@@ -38,8 +38,7 @@ const columns: Column<Row>[] = [
   {
     key: 'id',
     name: 'ID',
-    width: 80,
-    resizable: true
+    width: 80
   },
   {
     key: 'avatar',

--- a/stories/demos/ColumnsReordering.tsx
+++ b/stories/demos/ColumnsReordering.tsx
@@ -124,6 +124,7 @@ export function ColumnsReordering() {
         sortColumn={sortColumn}
         sortDirection={sortDirection}
         onSort={handleSort}
+        onColumnResize={setColumns}
       />
     </DndProvider>
   );

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo, createContext, useContext } from 'react';
 import faker from 'faker';
-import DataGrid, { SelectColumn, Column, SortDirection, TextEditor, EditorProps } from '../../src';
+import DataGrid, { SelectColumn, Column, SortDirection, TextEditor, EditorProps, SelectCellFormatter } from '../../src';
 import { SelectEditor } from './components/Editors/SelectEditor';
 
 interface SummaryRow {
@@ -168,8 +168,15 @@ function createColumns(): readonly Column<Row, SummaryRow>[] {
       key: 'available',
       name: 'Available',
       width: 80,
-      formatter(props) {
-        return <>{props.row.available ? '✔️' : '❌'}</>;
+      formatter({ row, onRowChange }) {
+        return (
+          <SelectCellFormatter
+            value={row.available}
+            onChange={() => {
+              onRowChange({ ...row, available: !row.available });
+            }}
+          />
+        );
       },
       summaryFormatter({ row: { yesCount, totalCount } }) {
         return (

--- a/stories/demos/Grouping.tsx
+++ b/stories/demos/Grouping.tsx
@@ -25,56 +25,58 @@ interface Option {
 
 const sports = ['Swimming', 'Gymnastics', 'Speed Skating', 'Cross Country Skiing', 'Short-Track Speed Skating', 'Diving', 'Cycling', 'Biathlon', 'Alpine Skiing', 'Ski Jumping', 'Nordic Combined', 'Athletics', 'Table Tennis', 'Tennis', 'Synchronized Swimming', 'Shooting', 'Rowing', 'Fencing', 'Equestrian', 'Canoeing', 'Bobsleigh', 'Badminton', 'Archery', 'Wrestling', 'Weightlifting', 'Waterpolo', 'Wrestling', 'Weightlifting'];
 
-const columns: readonly Column<Row>[] = [
-  SelectColumn,
-  {
-    key: 'country',
-    name: 'Country'
-  },
-  {
-    key: 'year',
-    name: 'Year'
-  },
-  {
-    key: 'sport',
-    name: 'Sport'
-  },
-  {
-    key: 'athlete',
-    name: 'Athlete'
-  },
-  {
-    key: 'gold',
-    name: 'Gold',
-    groupFormatter({ childRows }) {
-      return <>{childRows.reduce((prev, { gold }) => prev + gold, 0)}</>;
-    }
-  },
-  {
-    key: 'silver',
-    name: 'Silver',
-    groupFormatter({ childRows }) {
-      return <>{childRows.reduce((prev, { silver }) => prev + silver, 0)}</>;
-    }
-  },
-  {
-    key: 'bronze',
-    name: 'Bronze',
-    groupFormatter({ childRows }) {
-      return <>{childRows.reduce((prev, { silver }) => prev + silver, 0)}</>;
-    }
-  },
-  {
-    key: 'total',
-    name: 'Total',
-    formatter({ row }) {
-      return <>{row.gold + row.silver + row.bronze}</>;
+function createColumns(): readonly Column<Row>[] {
+  return [
+    SelectColumn,
+    {
+      key: 'country',
+      name: 'Country'
     },
-    groupFormatter({ childRows }) {
-      return <>{childRows.reduce((prev, row) => prev + row.gold + row.silver + row.bronze, 0)}</>;
+    {
+      key: 'year',
+      name: 'Year'
+    },
+    {
+      key: 'sport',
+      name: 'Sport'
+    },
+    {
+      key: 'athlete',
+      name: 'Athlete'
+    },
+    {
+      key: 'gold',
+      name: 'Gold',
+      groupFormatter({ childRows }) {
+        return <>{childRows.reduce((prev, { gold }) => prev + gold, 0)}</>;
+      }
+    },
+    {
+      key: 'silver',
+      name: 'Silver',
+      groupFormatter({ childRows }) {
+        return <>{childRows.reduce((prev, { silver }) => prev + silver, 0)}</>;
+      }
+    },
+    {
+      key: 'bronze',
+      name: 'Bronze',
+      groupFormatter({ childRows }) {
+        return <>{childRows.reduce((prev, { silver }) => prev + silver, 0)}</>;
+      }
+    },
+    {
+      key: 'total',
+      name: 'Total',
+      formatter({ row }) {
+        return <>{row.gold + row.silver + row.bronze}</>;
+      },
+      groupFormatter({ childRows }) {
+        return <>{childRows.reduce((prev, row) => prev + row.gold + row.silver + row.bronze, 0)}</>;
+      }
     }
-  }
-];
+  ];
+}
 
 function rowKeyGetter(row: Row) {
   return row.id;
@@ -119,6 +121,7 @@ const options: OptionsType<Option> = [
 
 export function Grouping() {
   const [rows] = useState(createRows);
+  const [columns, setColumns] = useState(createColumns);
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
   const [selectedOptions, setSelectedOptions] = useState<ValueType<Option>>([options[0], options[1]]);
   const [expandedGroupIds, setExpandedGroupIds] = useState(() => new Set<unknown>(['United States of America', 'United States of America__2015']));
@@ -167,6 +170,7 @@ export function Grouping() {
         rowGrouper={rowGrouper}
         expandedGroupIds={expandedGroupIds}
         onExpandedGroupIdsChange={setExpandedGroupIds}
+        onColumnResize={setColumns}
         defaultColumnOptions={{ resizable: true }}
       />
     </div>

--- a/stories/demos/MillionCells.tsx
+++ b/stories/demos/MillionCells.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useState } from 'react';
 import DataGrid, { Column, FormatterProps } from '../../src';
 
 type Row = undefined;
@@ -9,7 +9,7 @@ function CellFormatter(props: FormatterProps<Row>) {
 }
 
 export function MillionCells() {
-  const columns = useMemo((): readonly Column<Row>[] => {
+  const [columns, setColumns] = useState<readonly Column<Row>[]>(() => {
     const columns: Column<Row>[] = [];
 
     for (let i = 0; i < 1000; i++) {
@@ -24,7 +24,7 @@ export function MillionCells() {
     }
 
     return columns;
-  }, []);
+  });
 
   return (
     <DataGrid
@@ -32,6 +32,7 @@ export function MillionCells() {
       rows={rows}
       rowHeight={22}
       className="fill-grid"
+      onColumnResize={setColumns}
     />
   );
 }


### PR DESCRIPTION
- [x] Change `column.name` type from `string` to `string/ReactElement`
- [x] Add `formatterProps.onRowChange` prop. Calling this method would commit the value immediately. This behavior is different from `editorProps.onRowChange` which only commits the value when clicked outside of if changes are manually committed using `onRowChange(updatedRow, true)` or `onClose(true)`.
- [x] Change `onColumnResize` type from `(idx: number, width: number) => void` to `(columns: Column<R, SR>[]) => void`. This is a breaking change as grid no longer keeps track or updated column widths. Save the updated columns in the parent component to reflect the updated widths (`onColumnResize={setColumns}`)

Fixes 
https://github.com/adazzle/react-data-grid/issues/2042 
https://github.com/adazzle/react-data-grid/issues/2161