### PR TITLE
Commit changes before exiting grid

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -730,6 +730,7 @@ function DataGrid<R, SR>({
     if (key === 'Tab') {
       // If we are in a position to leave the grid, stop editing but stay in that cell
       if (canExitGrid({ shiftKey, cellNavigationMode, columns, rowsCount: rows.length, selectedPosition })) {
+        commitEditorChanges();
         // Allow focus to leave the grid so the next control in the tab order can be focused
         return;
       }


### PR DESCRIPTION
We should revisit tabbing behavior again. Tab in/out of the grid does not work as expected 