### PR TITLE
Hotfix unnecessary horizontal scrollbar in Firefox

### DIFF
--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -83,8 +83,14 @@ export function useViewportColumns<R, SR>({
       // Sort other columns last:
       return 0;
     });
+          
+    // Fix unnecessary horizontal scrollbar in Firefox by checking if the CSS property "scrollbar-width" exists,
+    // and then subtracting it from the unallocatedWidth.
+    const bodyElement = document.querySelector('body');
+    const bodyScrollbarWidth: number = bodyElement && getComputedStyle(bodyElement).scrollbarWidth === 'auto' ? 16 : 0;
+          
 
-    const unallocatedWidth = viewportWidth - allocatedWidths;
+    const unallocatedWidth = viewportWidth - allocatedWidths - bodyScrollbarWidth;
     const unallocatedColumnWidth = Math.max(
       Math.floor(unallocatedWidth / unassignedColumnsCount),
       minColumnWidth

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -88,7 +88,6 @@ export function useViewportColumns<R, SR>({
     // and then subtracting it from the unallocatedWidth.
     const bodyElement = document.querySelector('body');
     const bodyScrollbarWidth: number = bodyElement && getComputedStyle(bodyElement).scrollbarWidth === 'auto' ? 16 : 0;
-          
 
     const unallocatedWidth = viewportWidth - allocatedWidths - bodyScrollbarWidth;
     const unallocatedColumnWidth = Math.max(


### PR DESCRIPTION
See issue #2173

If one or more column width's are auto calculated, the elements will overflow in Firefox, and thus create an unnecessary scrollbar.
This fix subtracts 16 pixels from the unallocatedWidth, before the column widths are calculated.

This is a bad solution as it assumes the scrollbar is always 16 pixels wide in Firefox.