### PR TITLE
Fix isAtBottom when browser is zoomed

### DIFF
--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -165,7 +165,7 @@ function createRows(numberOfRows: number): Row[] {
 
 function isAtBottom(event: React.UIEvent<HTMLDivElement>): boolean {
   const target = event.target as HTMLDivElement;
-  return target.clientHeight + target.scrollTop === target.scrollHeight;
+  return (target.scrollHeight - Math.ceil(target.scrollTop)) <= target.clientHeight;
 }
 
 function loadMoreRows(newRowsCount: number, length: number): Promise<Row[]> {


### PR DESCRIPTION
When zoomed, scrollTop is a decimal value, causing the equality check to fail.