### PR TITLE
Remove wrapEvent

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,8 @@
 export default {
   coverageProvider: 'v8',
   collectCoverageFrom: [
-    'src/**/*.{ts,tsx}'
+    'src/**/*.{ts,tsx}',
+    '!src/types.ts'
   ],
   coverageReporters: [
     'text'

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -3,7 +3,7 @@ import type { RefAttributes } from 'react';
 import { css } from '@linaria/core';
 
 import { cellSelectedClassname } from './style';
-import { getCellStyle, getCellClassname, wrapEvent } from './utils';
+import { getCellStyle, getCellClassname } from './utils';
 import type { CellRendererProps } from './types';
 
 const cellCopied = css`
@@ -76,17 +76,20 @@ function Cell<R, SR>({
     selectCell({ idx: column.idx, rowIdx }, openEditor);
   }
 
-  function handleClick() {
+  function handleClick(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper(column.editorOptions?.editOnClick);
     onRowClick?.(rowIdx, row, column);
+    onClick?.(event);
   }
 
-  function handleContextMenu() {
+  function handleContextMenu(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper();
+    onContextMenu?.(event);
   }
 
-  function handleDoubleClick() {
+  function handleDoubleClick(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper(true);
+    onDoubleClick?.(event);
   }
 
   function handleRowChange(newRow: R) {
@@ -105,9 +108,9 @@ function Cell<R, SR>({
       ref={ref}
       className={className}
       style={getCellStyle(column)}
-      onClick={wrapEvent(handleClick, onClick)}
-      onDoubleClick={wrapEvent(handleDoubleClick, onDoubleClick)}
-      onContextMenu={wrapEvent(handleContextMenu, onContextMenu)}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      onContextMenu={handleContextMenu}
       {...props}
     >
       {!column.rowGroup && (

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -37,9 +37,10 @@ import type {
   SelectedCellProps,
   EditCellProps,
   FillEvent,
-  PasteEvent
+  PasteEvent,
+  CellNavigationMode,
+  SortDirection
 } from './types';
-import type { CellNavigationMode, SortDirection } from './enums';
 
 interface SelectCellState extends Position {
   mode: 'SELECT';

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -1,10 +1,9 @@
 import { css } from '@linaria/core';
 
-import type { CalculatedColumn } from './types';
+import type { CalculatedColumn, SortDirection } from './types';
 import type { HeaderRowProps } from './HeaderRow';
 import SortableHeaderCell from './headerCells/SortableHeaderCell';
 import { getCellStyle, getCellClassname } from './utils';
-import type { SortDirection } from './enums';
 
 const cellResizable = css`
   &::after {

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -6,7 +6,6 @@ import { groupRowSelectedClassname, rowClassname, rowSelectedClassname } from '.
 import Cell from './Cell';
 import EditCell from './EditCell';
 import type { RowRendererProps, SelectedCellProps } from './types';
-import { wrapEvent } from './utils';
 
 function Row<R, SR = unknown>({
   cellRenderer: CellRenderer = Cell,
@@ -30,8 +29,9 @@ function Row<R, SR = unknown>({
   'aria-selected': ariaSelected,
   ...props
 }: RowRendererProps<R, SR>, ref: React.Ref<HTMLDivElement>) {
-  function handleDragEnter() {
+  function handleDragEnter(event: React.MouseEvent<HTMLDivElement>) {
     setDraggedOverRowIdx?.(rowIdx);
+    onMouseEnter?.(event);
   }
 
   className = clsx(
@@ -51,7 +51,7 @@ function Row<R, SR = unknown>({
       aria-selected={ariaSelected}
       ref={ref}
       className={className}
-      onMouseEnter={wrapEvent(handleDragEnter, onMouseEnter)}
+      onMouseEnter={handleDragEnter}
       style={{ top }}
       {...props}
     >

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,2 +1,0 @@
-export type CellNavigationMode = 'NONE' | 'CHANGE_ROW' | 'LOOP_OVER_ROW';
-export type SortDirection = 'ASC' | 'DESC' | 'NONE';

--- a/src/headerCells/SortableHeaderCell.tsx
+++ b/src/headerCells/SortableHeaderCell.tsx
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 import type { HeaderCellProps } from '../HeaderCell';
-import type { SortDirection } from '../enums';
+import type { SortDirection } from '../types';
 
 const headerSortCell = css`
   cursor: pointer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,6 @@ export * from './formatters';
 export { default as TextEditor } from './editors/TextEditor';
 export { default as SortableHeaderCell } from './headerCells/SortableHeaderCell';
 export type {
-  CellNavigationMode,
-  SortDirection
-} from './enums';
-export type {
   Column,
   CalculatedColumn,
   FormatterProps,
@@ -25,5 +21,7 @@ export type {
   RowsChangeData,
   SelectRowEvent,
   FillEvent,
-  PasteEvent
+  PasteEvent,
+  CellNavigationMode,
+  SortDirection
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ReactElement } from 'react';
-import type { SortDirection } from './enums';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -224,3 +223,6 @@ export interface GroupRow<TRow> {
   setSize: number;
   startRowIndex: number;
 }
+
+export type CellNavigationMode = 'NONE' | 'CHANGE_ROW' | 'LOOP_OVER_ROW';
+export type SortDirection = 'ASC' | 'DESC' | 'NONE';

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,12 +1,3 @@
 export function stopPropagation(event: React.SyntheticEvent) {
   event.stopPropagation();
 }
-
-export function wrapEvent<E extends React.SyntheticEvent>(ourHandler: React.EventHandler<E>, theirHandler: React.EventHandler<E> | undefined) {
-  if (theirHandler === undefined) return ourHandler;
-
-  return function(event: E) {
-    ourHandler(event);
-    theirHandler(event);
-  };
-}

--- a/src/utils/selectedCellUtils.ts
+++ b/src/utils/selectedCellUtils.ts
@@ -1,5 +1,4 @@
-import type { CellNavigationMode } from '../enums';
-import type { CalculatedColumn, Position, GroupRow } from '../types';
+import type { CalculatedColumn, Position, GroupRow, CellNavigationMode } from '../types';
 
 interface IsSelectedCellEditableOpts<R, SR> {
   selectedPosition: Position;


### PR DESCRIPTION
We don't gain much from `wrapEvent`.
It gets called on each row/cell render, and it possible creates another closure.
Any extra work can be offloaded at event time.

I've also merged `enums.ts` into `types.ts`, it's just 2 types.