### PR TITLE
:new: Implement initialScrollTop and initialScrollLeft

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -158,6 +158,12 @@ export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
   /** The node where the editor portal should mount. */
   editorPortalTarget?: Element;
   rowClass?: (row: R) => string | undefined;
+
+  /**
+   * Initial scrolling states
+   */
+  initialScrollTop?: number;
+  initialScrollLeft?: number;
 }
 
 /**
@@ -212,13 +218,15 @@ function DataGrid<R, SR>({
   // ARIA
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
-  'aria-describedby': ariaDescribedBy
+  'aria-describedby': ariaDescribedBy,
+  initialScrollTop = 0,
+  initialScrollLeft = 0
 }: DataGridProps<R, SR>, ref: React.Ref<DataGridHandle>) {
   /**
    * states
    */
-  const [scrollTop, setScrollTop] = useState(0);
-  const [scrollLeft, setScrollLeft] = useState(0);
+  const [scrollTop, setScrollTop] = useState(initialScrollTop);
+  const [scrollLeft, setScrollLeft] = useState(initialScrollLeft);
   const [columnWidths, setColumnWidths] = useState<ReadonlyMap<string, number>>(() => new Map());
   const [selectedPosition, setSelectedPosition] = useState<SelectCellState | EditCellState<R>>({ idx: -1, rowIdx: -1, mode: 'SELECT' });
   const [copiedCell, setCopiedCell] = useState<{ row: R; columnKey: string } | null>(null);
@@ -290,6 +298,20 @@ function DataGrid<R, SR>({
       return;
     }
     focusSinkRef.current!.focus({ preventScroll: true });
+  });
+
+  useLayoutEffect(() => {
+    const { current } = gridRef;
+    if (!current) return;
+    // setTimeout needed for the rendering to finish
+    // do this as soon as everything else has finished
+    setTimeout(() => {
+      current.scrollTo({
+        top: initialScrollTop,
+        left: initialScrollLeft,
+        behavior: 'auto'
+      });
+    });
   });
 
   useImperativeHandle(ref, () => ({

--- a/stories/demos/InitialScroll.tsx
+++ b/stories/demos/InitialScroll.tsx
@@ -44,7 +44,7 @@ export function InitialScroll() {
       rows={rows}
       rowHeight={22}
       className="fill-grid"
-      onScroll={(e) => setScroll([e.target.scrollTop, e.target.scrollLeft])}
+      onScroll={(e) => setScroll([(e.target as HTMLDivElement).scrollTop, (e.target as HTMLDivElement).scrollLeft])}
       initialScrollLeft={left}
       initialScrollTop={top}
     />

--- a/stories/demos/InitialScroll.tsx
+++ b/stories/demos/InitialScroll.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from 'react';
+import DataGrid from '../../src';
+import type { Column, FormatterProps } from '../../src';
+
+type Row = undefined;
+const rows: readonly Row[] = Array(1000);
+
+function CellFormatter(props: FormatterProps<Row>) {
+  return <>{props.column.key}&times;{props.rowIdx}</>;
+}
+
+// simulating a case where scroll could be store in redux or similar storage outside the components
+let externalScroll = [0, 0];
+
+export function InitialScroll() {
+  const [scroll, setScroll] = useState(externalScroll);
+
+  useEffect(() => {
+    externalScroll = scroll;
+  }, [scroll]);
+
+  const [top, left] = scroll;
+
+  const columns = useMemo((): readonly Column<Row>[] => {
+    const columns: Column<Row>[] = [];
+
+    for (let i = 0; i < 1000; i++) {
+      const key = String(i);
+      columns.push({
+        key,
+        name: key,
+        frozen: i < 5,
+        resizable: true,
+        formatter: CellFormatter
+      });
+    }
+
+    return columns;
+  }, []);
+
+  return (
+    <DataGrid
+      columns={columns}
+      rows={rows}
+      rowHeight={22}
+      className="fill-grid"
+      onScroll={(e) => setScroll([e.target.scrollTop, e.target.scrollLeft])}
+      initialScrollLeft={left}
+      initialScrollTop={top}
+    />
+  );
+}
+
+InitialScroll.storyName = 'Initial scroll';

--- a/stories/index.story.ts
+++ b/stories/index.story.ts
@@ -1,6 +1,7 @@
 export * from './demos/CommonFeatures';
 export * from './demos/AllFeatures';
 export * from './demos/MillionCells';
+export * from './demos/InitialScroll';
 export * from './demos/NoRows';
 export * from './demos/CellActions';
 export * from './demos/TreeView';


### PR DESCRIPTION
This PR implements a way to restore scroll of a Grid on mount when the previous scroll values have been stored somewhere - redux, a context somewhere, localstorage, etc.

I also added a story where you can scroll around down and right, look at another story and upon returning to the "Initial scroll" demo, the original scroll is restored during the initial mount.