### PR TITLE
Add onRowDoubleClick callback

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -52,6 +52,7 @@ function Cell<R, SR>({
   rowIdx,
   dragHandleProps,
   onRowClick,
+  onRowDoubleClick,
   onClick,
   onDoubleClick,
   onContextMenu,
@@ -79,6 +80,7 @@ function Cell<R, SR>({
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper(column.editorOptions?.editOnClick);
     onRowClick?.(rowIdx, row, column);
+
     onClick?.(event);
   }
 
@@ -89,6 +91,8 @@ function Cell<R, SR>({
 
   function handleDoubleClick(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper(true);
+    onRowDoubleClick?.(rowIdx, row, column);
+
     onDoubleClick?.(event);
   }
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -139,6 +139,8 @@ export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
    */
   /** Function called whenever a row is clicked */
   onRowClick?: (rowIdx: number, row: R, column: CalculatedColumn<R, SR>) => void;
+  /** Function called whenever a row is double clicked */
+  onRowDoubleClick?: (rowIdx: number, row: R, column: CalculatedColumn<R, SR>) => void;
   /** Called when the grid is scrolled */
   onScroll?: (event: React.UIEvent<HTMLDivElement>) => void;
   /** Called when a column is resized */
@@ -197,6 +199,7 @@ function DataGrid<R, SR>({
   emptyRowsRenderer: EmptyRowsRenderer,
   // Event props
   onRowClick,
+  onRowDoubleClick,
   onScroll,
   onColumnResize,
   onSelectedCellChange,
@@ -873,6 +876,7 @@ function DataGrid<R, SR>({
           viewportColumns={viewportColumns}
           isRowSelected={isRowSelected}
           onRowClick={onRowClick}
+          onRowDoubleClick={onRowDoubleClick}
           rowClass={rowClass}
           top={top}
           copiedCellIdx={copiedCell !== null && copiedCell.row === row ? columns.findIndex(c => c.key === copiedCell.columnKey) : undefined}

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -18,6 +18,7 @@ function Row<R, SR = unknown>({
   viewportColumns,
   selectedCellProps,
   onRowClick,
+  onRowDoubleClick,
   rowClass,
   setDraggedOverRowIdx,
   onMouseEnter,
@@ -84,6 +85,7 @@ function Row<R, SR = unknown>({
             onFocus={isCellSelected ? (selectedCellProps as SelectedCellProps).onFocus : undefined}
             onKeyDown={isCellSelected ? selectedCellProps!.onKeyDown : undefined}
             onRowClick={onRowClick}
+            onRowDoubleClick={onRowDoubleClick}
             onRowChange={onRowChange}
             selectCell={selectCell}
             selectRow={selectRow}

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,7 @@ export interface CellRendererProps<TRow, TSummaryRow = unknown> extends Omit<Rea
   dragHandleProps?: Pick<React.HTMLAttributes<HTMLDivElement>, 'onMouseDown' | 'onDoubleClick'>;
   onRowChange: (rowIdx: number, newRow: TRow) => void;
   onRowClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
+  onRowDoubleClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
   selectCell: (position: Position, enableEditor?: boolean) => void;
   selectRow: (selectRowEvent: SelectRowEvent) => void;
 }
@@ -168,6 +169,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown> extends Omit<Reac
   selectedCellProps?: EditCellProps<TRow> | SelectedCellProps;
   onRowChange: (rowIdx: number, row: TRow) => void;
   onRowClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
+  onRowDoubleClick?: (rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void;
   rowClass?: (row: TRow) => string | undefined;
   setDraggedOverRowIdx?: (overRowIdx: number) => void;
   selectCell: (position: Position, enableEditor?: boolean) => void;


### PR DESCRIPTION
I want to make an external editor for a the table row, and I tried, but with the current interface it is not possible.
So I proposing this new onRowDoubleClick callback very similarly with onRowClick.
The example image what I want to achieve with it.
![image](https://user-images.githubusercontent.com/17799600/109963420-b07c6300-7cec-11eb-8416-bb49d6e3fb0b.png)
