### PR TITLE
Topic/fix erratic column resizing

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -143,8 +143,10 @@ export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
   onRowClick?: (rowIdx: number, row: R, column: CalculatedColumn<R, SR>) => void;
   /** Called when the grid is scrolled */
   onScroll?: (event: React.UIEvent<HTMLDivElement>) => void;
-  /** Called when a column is resized */
+  /** Called while a column is resized */
   onColumnResize?: (idx: number, width: number) => void;
+  /** Called when column resizing is done */
+  onColumnResized?: (idx: number, width: number) => void;
   /** Function called whenever selected cell is changed */
   onSelectedCellChange?: (position: Position) => void;
 
@@ -202,6 +204,7 @@ function DataGrid<R, SR>({
   onRowClick,
   onScroll,
   onColumnResize,
+  onColumnResized,
   onSelectedCellChange,
   onFill,
   onPaste,
@@ -322,6 +325,10 @@ function DataGrid<R, SR>({
 
     onColumnResize?.(column.idx, width);
   }, [columnWidths, onColumnResize]);
+
+  const handleColumnResized = useCallback((column: CalculatedColumn<R, SR>, width: number) => {
+    onColumnResized?.(column.idx, width);
+  }, [onColumnResized]);
 
   const setDraggedOverRowIdx = useCallback((rowIdx?: number) => {
     setOverRowIdx(rowIdx);
@@ -930,6 +937,7 @@ function DataGrid<R, SR>({
         rows={rawRows}
         columns={viewportColumns}
         onColumnResize={handleColumnResize}
+        onColumnResized={handleColumnResized}
         allRowsSelected={selectedRows?.size === rawRows.length}
         onSelectedRowsChange={onSelectedRowsChange}
         sortColumn={sortColumn}

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -40,12 +40,14 @@ type SharedHeaderRowProps<R, SR> = Pick<HeaderRowProps<R, SR>,
 export interface HeaderCellProps<R, SR> extends SharedHeaderRowProps<R, SR> {
   column: CalculatedColumn<R, SR>;
   onResize: (column: CalculatedColumn<R, SR>, width: number) => void;
+  onResized: (column: CalculatedColumn<R, SR>, width: number) => void;
   onAllRowsSelectionChange: (checked: boolean) => void;
 }
 
 export default function HeaderCell<R, SR>({
   column,
   onResize,
+  onResized,
   allRowsSelected,
   onAllRowsSelectionChange,
   sortColumn,
@@ -56,7 +58,7 @@ export default function HeaderCell<R, SR>({
     if (event.pointerType === 'mouse' && event.buttons !== 1) {
       return;
     }
-    const { currentTarget, pointerId } = event;
+    const { currentTarget } = event;
 
     function onPointerMove(event: PointerEvent) {
       if (event.pointerType === 'mouse' && event.buttons !== 1) {
@@ -74,7 +76,7 @@ export default function HeaderCell<R, SR>({
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
       const width = event.clientX - currentTarget.getBoundingClientRect().left;
-      onResize(column, width);
+      onResized(column, width);
     }
 
     event.preventDefault();

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -56,31 +56,25 @@ export default function HeaderCell<R, SR>({
     if (event.pointerType === 'mouse' && event.buttons !== 1) {
       return;
     }
-
     const { currentTarget, pointerId } = event;
-    const { right } = currentTarget.getBoundingClientRect();
-    const offset = right - event.clientX;
-
-    if (offset > 11) { // +1px to account for the border size
-      return;
-    }
 
     function onPointerMove(event: PointerEvent) {
-      if (event.pointerId !== pointerId) return;
       if (event.pointerType === 'mouse' && event.buttons !== 1) {
-        onPointerUp();
+        onPointerUp(event);
         return;
       }
-      const width = event.clientX + offset - currentTarget.getBoundingClientRect().left;
+      const width = event.clientX - currentTarget.getBoundingClientRect().left;
+
       if (width > 0) {
         onResize(column, width);
       }
     }
 
-    function onPointerUp() {
-      if (event.pointerId !== pointerId) return;
+    function onPointerUp(event: PointerEvent) {
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
+      const width = event.clientX - currentTarget.getBoundingClientRect().left;
+      onResize(column, width);
     }
 
     event.preventDefault();

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -19,6 +19,7 @@ export interface HeaderRowProps<R, SR> extends SharedDataGridProps<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
   allRowsSelected: boolean;
   onColumnResize: (column: CalculatedColumn<R, SR>, width: number) => void;
+  onColumnResized: (column: CalculatedColumn<R, SR>, width: number) => void;
 }
 
 function HeaderRow<R, SR>({
@@ -28,6 +29,7 @@ function HeaderRow<R, SR>({
   onSelectedRowsChange,
   allRowsSelected,
   onColumnResize,
+  onColumnResized,
   sortColumn,
   sortDirection,
   onSort
@@ -53,6 +55,7 @@ function HeaderRow<R, SR>({
             key={column.key}
             column={column}
             onResize={onColumnResize}
+            onResized={onColumnResized}
             allRowsSelected={allRowsSelected}
             onAllRowsSelectionChange={handleAllRowsSelectionChange}
             onSort={onSort}


### PR DESCRIPTION
We experienced erratic column resizing on a non trivial page layout containing a react-data-grid. By simplifying the resize logic, the behaviour is now stable in our application, no more resizing of the wrong columns or big jumps in column width when moving the mouse only a few pixels.

Additionally, I've introduced the onColumnResized callback to be able to process column resizing when the resizing is done, which is a big performance boost for, eg, storing the column width in the local storage