### PR TITLE
:art: Set width from maxWidth if exists

### DIFF
--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -44,7 +44,8 @@ export function useViewportColumns<R, SR>({
         rowGroup,
         sortable: rawColumn.sortable ?? defaultSortable,
         resizable: rawColumn.resizable ?? defaultResizable,
-        formatter: rawColumn.formatter ?? defaultFormatter
+        formatter: rawColumn.formatter ?? defaultFormatter,
+        width: rawColumn.width ?? rawColumn.maxWidth
       };
 
       if (rowGroup) {


### PR DESCRIPTION
This PR fixes issues where table grid layouts break (not filling the whole table) if you only define a maxWidth, but no width.

Current result:
<img width="1482" alt="Screenshot 2021-04-01 at 15 24 36" src="https://user-images.githubusercontent.com/10929022/113300679-73f95280-92fe-11eb-9aaa-1b6cc34b5f9e.png">

Does not work now:
```
{
   key: 'key',
   maxWidth: 123,
}
```

Expected and now the result after this change:
<img width="1503" alt="Screenshot 2021-04-01 at 15 24 53" src="https://user-images.githubusercontent.com/10929022/113300670-722f8f00-92fe-11eb-9c59-1e66e5ff931c.png">

Works now:
```
{
   key: 'key',
   maxWidth: 123,
   width: 123,
}
```
Works after this PR:
```
{
   key: 'key',
   maxWidth: 123,
}
```


I can also make it work now, but it is a bit annoying to have to define `width` as well since it already works with `minWidth`.

