### PR TITLE
Grouped excel-like columns RFC

### DIFF
--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -19,6 +19,8 @@ export interface HeaderRowProps<R, SR> extends SharedDataGridProps<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
   allRowsSelected: boolean;
   onColumnResize: (column: CalculatedColumn<R, SR>, width: number) => void;
+  rowIndex?: number;
+  topOffset?: number;
 }
 
 function HeaderRow<R, SR>({
@@ -30,7 +32,9 @@ function HeaderRow<R, SR>({
   onColumnResize,
   sortColumn,
   sortDirection,
-  onSort
+  onSort,
+  rowIndex = 1,
+  topOffset = 0
 }: HeaderRowProps<R, SR>) {
   const handleAllRowsSelectionChange = useCallback((checked: boolean) => {
     if (!onSelectedRowsChange) return;
@@ -50,8 +54,11 @@ function HeaderRow<R, SR>({
   return (
     <div
       role="row"
-      aria-rowindex={1} // aria-rowindex is 1 based
+      aria-rowindex={rowIndex} // aria-rowindex is 1 based
       className={headerRowClassname}
+      style={{
+        top: topOffset
+      }}
     >
       {columns.map(column => {
         return (

--- a/src/ParentHeaderCell.tsx
+++ b/src/ParentHeaderCell.tsx
@@ -1,0 +1,35 @@
+import type { CalculatedParentColumn } from './types';
+import { getParentCellClassname, getParentCellStyle } from './utils';
+
+export interface HeaderCellProps<R, SR> {
+  column: CalculatedParentColumn<R, SR>;
+}
+
+export default function ParentHeaderCell<R, SR>({
+  column
+}: HeaderCellProps<R, SR>) {
+  function getCell() {
+    if (column.parentHeaderRenderer) {
+      return (
+        <column.parentHeaderRenderer
+          column={column}
+        />
+      );
+    }
+
+    return column.name;
+  }
+
+  const className = getParentCellClassname(column, column.parentHeaderCellClass);
+
+  return (
+    <div
+      role="columnheader"
+      aria-colindex={column.idx + 1}
+      className={className}
+      style={getParentCellStyle(column)}
+    >
+      {getCell()}
+    </div>
+  );
+}

--- a/src/ParentHeaderRow.tsx
+++ b/src/ParentHeaderRow.tsx
@@ -1,0 +1,32 @@
+import { memo } from 'react';
+
+import type { CalculatedParentColumn } from './types';
+import { headerRowClassname } from './style';
+import ParentHeaderCell from './ParentHeaderCell';
+
+export interface ParentHeaderRowProps<R, SR> {
+  columns: readonly CalculatedParentColumn<R, SR>[];
+}
+
+function ParentHeaderRow<R, SR>({
+  columns
+}: ParentHeaderRowProps<R, SR>) {
+  return (
+    <div
+      role="row"
+      aria-rowindex={1} // aria-rowindex is 1 based
+      className={headerRowClassname}
+    >
+      {columns.map(column => {
+        return (
+          <ParentHeaderCell<R, SR>
+            key={column.key}
+            column={column}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export default memo(ParentHeaderRow) as <R, SR>(props: ParentHeaderRowProps<R, SR>) => JSX.Element;

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -44,7 +44,8 @@ export function useViewportColumns<R, SR>({
         rowGroup,
         sortable: rawColumn.sortable ?? defaultSortable,
         resizable: rawColumn.resizable ?? defaultResizable,
-        formatter: rawColumn.formatter ?? defaultFormatter
+        formatter: rawColumn.formatter ?? defaultFormatter,
+        width: rawColumn.width ?? rawColumn.maxWidth
       };
 
       if (rowGroup) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { default as TextEditor } from './editors/TextEditor';
 export { default as SortableHeaderCell } from './headerCells/SortableHeaderCell';
 export type {
   Column,
+  ParentColumn,
   CalculatedColumn,
   FormatterProps,
   SummaryFormatterProps,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,20 @@ import type { ReactElement } from 'react';
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
+export interface ParentColumn<TRow, TSummaryRow = unknown> {
+  /** The name of the column. By default it will be displayed in the header cell */
+  name: string | ReactElement;
+  /** A unique key to distinguish each column */
+  key: string;
+  /** Determines whether a column and all of its children are frozen or not */
+  frozen?: boolean;
+  /** Header renderer for each header cell */
+  parentHeaderRenderer?: React.ComponentType<ParentHeaderRendererProps<TRow, TSummaryRow>>;
+  /** Child columns grouped underneath the parent */
+  children: Omit<Column<TRow, TSummaryRow>, 'frozen'>[];
+  parentHeaderCellClass?: string;
+}
+
 export interface Column<TRow, TSummaryRow = unknown> {
   /** The name of the column. By default it will be displayed in the header cell */
   name: string | ReactElement;
@@ -53,6 +67,13 @@ export interface Column<TRow, TSummaryRow = unknown> {
   headerRenderer?: React.ComponentType<HeaderRendererProps<TRow, TSummaryRow>>;
   /** Component to be used to filter the data of the column */
   filterRenderer?: React.ComponentType<FilterRendererProps<TRow, any, TSummaryRow>>;
+}
+
+export interface CalculatedParentColumn<TRow, TSummaryRow = unknown> extends ParentColumn<TRow, TSummaryRow> {
+  idx: number;
+  frozen: boolean;
+  isLastFrozenColumn: boolean;
+  span: number;
 }
 
 export interface CalculatedColumn<TRow, TSummaryRow = unknown> extends Column<TRow, TSummaryRow> {
@@ -123,6 +144,10 @@ export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
   onSort?: (columnKey: string, direction: SortDirection) => void;
   allRowsSelected: boolean;
   onAllRowsSelectionChange: (checked: boolean) => void;
+}
+
+export interface ParentHeaderRendererProps<TRow, TSummaryRow = unknown> {
+  column: CalculatedParentColumn<TRow, TSummaryRow>;
 }
 
 interface SelectedCellPropsBase {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-import type { CalculatedColumn } from '../types';
+import type { CalculatedColumn, CalculatedParentColumn } from '../types';
 import { cell, cellFrozenClassname, cellFrozenLastClassname } from '../style';
 
 export * from './domUtils';
@@ -15,11 +15,38 @@ export function assertIsValidKeyGetter<R>(keyGetter: unknown): asserts keyGetter
 
 export function getCellStyle<R, SR>(column: CalculatedColumn<R, SR>): React.CSSProperties {
   return column.frozen
-    ? { left: `var(--frozen-left-${column.key})` }
-    : { gridColumnStart: column.idx + 1 };
+    ? {
+      left: `var(--frozen-left-${column.key})`
+    }
+    : {
+      gridColumnStart: column.idx + 1
+    };
+}
+
+export function getParentCellStyle<R, SR>(column: CalculatedParentColumn<R, SR>): React.CSSProperties {
+  const firstColumn = column.children[0];
+  return column.frozen
+    ? {
+      left: `var(--frozen-left-${firstColumn.key})`,
+      gridColumn: `span ${column.span}`
+    }
+    : {
+      gridColumnStart: column.idx + 1,
+      gridColumn: `span ${column.span}`
+    };
 }
 
 export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extraClasses: Parameters<typeof clsx>): string {
+  return clsx(
+    `rdg-cell ${cell}`, {
+      [cellFrozenClassname]: column.frozen,
+      [cellFrozenLastClassname]: column.isLastFrozenColumn
+    },
+    ...extraClasses
+  );
+}
+
+export function getParentCellClassname<R, SR>(column: CalculatedParentColumn<R, SR>, ...extraClasses: Parameters<typeof clsx>): string {
   return clsx(
     `rdg-cell ${cell}`, {
       [cellFrozenClassname]: column.frozen,

--- a/stories/demos/HeaderGroups.tsx
+++ b/stories/demos/HeaderGroups.tsx
@@ -1,0 +1,56 @@
+import { css } from '@linaria/core';
+import { useMemo } from 'react';
+import DataGrid from '../../src';
+import type { Column, FormatterProps, ParentColumn } from '../../src';
+
+type Row = undefined;
+const rows: readonly Row[] = Array(1000);
+
+function CellFormatter(props: FormatterProps<Row>) {
+  return <>{props.column.key}&times;{props.rowIdx}</>;
+}
+
+const parentClassName = css`
+  text-align: center;
+`;
+
+const childRowCount = 5;
+
+export function HeaderGroups() {
+  const columns = useMemo((): readonly (Column<Row> | ParentColumn<Row>)[] => {
+    const columns: (Column<Row> | ParentColumn<Row>)[] = [];
+
+    for (let i = 0; i < 200; i++) {
+      const children = Array(childRowCount).fill(0).map((val, j) => {
+        const key = String(i * childRowCount + j);
+        return {
+          key,
+          name: key,
+          resizable: true,
+          formatter: CellFormatter
+        };
+      });
+      const parentKey = `${i}_parent`;
+      columns.push({
+        key: parentKey,
+        name: parentKey,
+        frozen: i === 0,
+        children,
+        parentHeaderCellClass: parentClassName
+      });
+    }
+
+    return columns;
+  }, []);
+
+  return (
+    <DataGrid
+      columns={columns}
+      rows={rows}
+      rowHeight={22}
+      className="fill-grid"
+    />
+  );
+}
+
+HeaderGroups.storyName = 'Header groups';

--- a/stories/index.story.ts
+++ b/stories/index.story.ts
@@ -1,6 +1,7 @@
 export * from './demos/CommonFeatures';
 export * from './demos/AllFeatures';
 export * from './demos/MillionCells';
+export * from './demos/HeaderGroups';
 export * from './demos/NoRows';
 export * from './demos/CellActions';
 export * from './demos/TreeView';


### PR DESCRIPTION
This is an initial proposal to implement excel-like column grouping like mentioned in #765 , #1066, #1287, #458, #410, #2031

It implements a "parent" column logic where you define a wrapper column that inherits the width and positions of its children. This means that one does not have to define the column groups beforehand with widths, but most of the logic stays as it is now. The API is taken from react-table and I think this makes more sense than having it as a fixed colspan logic, which one would have to maintain outside. For us it is a MUST HAVE feature in this absolutely brilliant library so that's also why I decided to try and RFC.

Some minor cleanup probably needed regarding having separate height variables for the two headers and maybe testing it with grouping and other features together? IMHO: I wouldn't even make it work with grouping since those flows don't make sense together.

Example of how it looks:
https://media.giphy.com/media/hIG3uvfLYanhiXa18m/giphy.gif

https://user-images.githubusercontent.com/10929022/113334948-9d2cd980-9324-11eb-8ec0-be6bd9d5aae0.mp4

