### PR TITLE
POC: Multi column sorting

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -39,7 +39,7 @@ import type {
   FillEvent,
   PasteEvent,
   CellNavigationMode,
-  SortDirection
+  SortColumn
 } from './types';
 
 interface SelectCellState extends Position {
@@ -114,9 +114,9 @@ export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
   selectedRows?: ReadonlySet<React.Key>;
   /** Function called whenever row selection is changed */
   onSelectedRowsChange?: (selectedRows: Set<React.Key>) => void;
-  sortItems?: ReadonlyMap<string, SortDirection>;
+  sortColumns?: readonly Readonly<SortColumn>[];
   /** Function called whenever grid is sorted*/
-  onSortItemsChange?: (sortItems: Map<string, SortDirection>) => void;
+  onSortColumnsChange?: (sortColumns: SortColumn[]) => void;
   filters?: Readonly<Filters>;
   onFiltersChange?: (filters: Filters) => void;
   defaultColumnOptions?: DefaultColumnOptions<R, SR>;
@@ -182,8 +182,8 @@ function DataGrid<R, SR>({
   // Feature props
   selectedRows,
   onSelectedRowsChange,
-  sortItems,
-  onSortItemsChange,
+  sortColumns,
+  onSortColumnsChange,
   filters,
   onFiltersChange,
   defaultColumnOptions,
@@ -930,8 +930,8 @@ function DataGrid<R, SR>({
         onColumnResize={handleColumnResize}
         allRowsSelected={selectedRows?.size === rawRows.length}
         onSelectedRowsChange={onSelectedRowsChange}
-        sortItems={sortItems}
-        onSortItemsChange={onSortItemsChange}
+        sortColumns={sortColumns}
+        onSortColumnsChange={onSortColumnsChange}
       />
       {enableFilterRow && (
         <FilterRow<R, SR>

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -114,12 +114,9 @@ export interface DataGridProps<R, SR = unknown> extends SharedDivProps {
   selectedRows?: ReadonlySet<React.Key>;
   /** Function called whenever row selection is changed */
   onSelectedRowsChange?: (selectedRows: Set<React.Key>) => void;
-  /** The key of the column which is currently being sorted */
-  sortColumn?: string;
-  /** The direction to sort the sortColumn*/
-  sortDirection?: SortDirection;
+  sortItems?: ReadonlyMap<string, SortDirection>;
   /** Function called whenever grid is sorted*/
-  onSort?: (columnKey: string, direction: SortDirection) => void;
+  onSortItemsChange?: (sortItems: Map<string, SortDirection>) => void;
   filters?: Readonly<Filters>;
   onFiltersChange?: (filters: Filters) => void;
   defaultColumnOptions?: DefaultColumnOptions<R, SR>;
@@ -185,9 +182,8 @@ function DataGrid<R, SR>({
   // Feature props
   selectedRows,
   onSelectedRowsChange,
-  sortColumn,
-  sortDirection,
-  onSort,
+  sortItems,
+  onSortItemsChange,
   filters,
   onFiltersChange,
   defaultColumnOptions,
@@ -934,9 +930,8 @@ function DataGrid<R, SR>({
         onColumnResize={handleColumnResize}
         allRowsSelected={selectedRows?.size === rawRows.length}
         onSelectedRowsChange={onSelectedRowsChange}
-        sortColumn={sortColumn}
-        sortDirection={sortDirection}
-        onSort={onSort}
+        sortItems={sortItems}
+        onSortItemsChange={onSortItemsChange}
       />
       {enableFilterRow && (
         <FilterRow<R, SR>

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -95,7 +95,11 @@ export default function HeaderCell<R, SR>({
       const newSortColumns = sortColumns ? [...sortColumns] : [];
       const itemIndex = newSortColumns.findIndex(item => item.columnKey === columnKey);
       if (itemIndex !== -1) {
-        newSortColumns[itemIndex] = { columnKey, direction };
+        if (direction === 'NONE') {
+          newSortColumns.splice(itemIndex, 1);
+        } else {
+          newSortColumns[itemIndex] = { columnKey, direction };
+        }
       } else {
         newSortColumns.push({ columnKey, direction });
       }

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -88,9 +88,9 @@ export default function HeaderCell<R, SR>({
 
   const sortDirection = sortItems?.get(column.key);
 
-  function onSort(columnKey: string, direction: SortDirection) {
+  function onSort(columnKey: string, direction: SortDirection, isCtrlClick: boolean) {
     if (!onSortItemsChange) return;
-    const newSortedItems = new Map();
+    const newSortedItems = new Map(isCtrlClick ? sortItems ?? [] : []);
     newSortedItems.set(columnKey, direction);
     onSortItemsChange(newSortedItems);
   }

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -31,9 +31,8 @@ function getAriaSort(sortDirection?: SortDirection) {
 }
 
 type SharedHeaderRowProps<R, SR> = Pick<HeaderRowProps<R, SR>,
-  | 'sortColumn'
-  | 'sortDirection'
-  | 'onSort'
+  | 'sortItems'
+  | 'onSortItemsChange'
   | 'allRowsSelected'
 >;
 
@@ -48,9 +47,8 @@ export default function HeaderCell<R, SR>({
   onResize,
   allRowsSelected,
   onAllRowsSelectionChange,
-  sortColumn,
-  sortDirection,
-  onSort
+  sortItems,
+  onSortItemsChange
 }: HeaderCellProps<R, SR>) {
   function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
     if (event.pointerType === 'mouse' && event.buttons !== 1) {
@@ -88,12 +86,20 @@ export default function HeaderCell<R, SR>({
     window.addEventListener('pointerup', onPointerUp);
   }
 
+  const sortDirection = sortItems?.get(column.key);
+
+  function onSort(columnKey: string, direction: SortDirection) {
+    if (!onSortItemsChange) return;
+    const newSortedItems = new Map();
+    newSortedItems.set(columnKey, direction);
+    onSortItemsChange(newSortedItems);
+  }
+
   function getCell() {
     if (column.headerRenderer) {
       return (
         <column.headerRenderer
           column={column}
-          sortColumn={sortColumn}
           sortDirection={sortDirection}
           onSort={onSort}
           allRowsSelected={allRowsSelected}
@@ -107,7 +113,6 @@ export default function HeaderCell<R, SR>({
         <SortableHeaderCell
           column={column}
           onSort={onSort}
-          sortColumn={sortColumn}
           sortDirection={sortDirection}
         >
           {column.name}
@@ -126,7 +131,7 @@ export default function HeaderCell<R, SR>({
     <div
       role="columnheader"
       aria-colindex={column.idx + 1}
-      aria-sort={sortColumn === column.key ? getAriaSort(sortDirection) : undefined}
+      aria-sort={sortDirection ? getAriaSort(sortDirection) : undefined}
       className={className}
       style={getCellStyle(column)}
       onPointerDown={column.resizable ? onPointerDown : undefined}

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -31,8 +31,8 @@ function getAriaSort(sortDirection?: SortDirection) {
 }
 
 type SharedHeaderRowProps<R, SR> = Pick<HeaderRowProps<R, SR>,
-  | 'sortItems'
-  | 'onSortItemsChange'
+  | 'sortColumns'
+  | 'onSortColumnsChange'
   | 'allRowsSelected'
 >;
 
@@ -47,8 +47,8 @@ export default function HeaderCell<R, SR>({
   onResize,
   allRowsSelected,
   onAllRowsSelectionChange,
-  sortItems,
-  onSortItemsChange
+  sortColumns,
+  onSortColumnsChange
 }: HeaderCellProps<R, SR>) {
   function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
     if (event.pointerType === 'mouse' && event.buttons !== 1) {
@@ -86,13 +86,23 @@ export default function HeaderCell<R, SR>({
     window.addEventListener('pointerup', onPointerUp);
   }
 
-  const sortDirection = sortItems?.get(column.key);
+  const sortDirection = sortColumns?.find(item => item.columnKey === column.key)?.direction;
 
   function onSort(columnKey: string, direction: SortDirection, isCtrlClick: boolean) {
-    if (!onSortItemsChange) return;
-    const newSortedItems = new Map(isCtrlClick ? sortItems ?? [] : []);
-    newSortedItems.set(columnKey, direction);
-    onSortItemsChange(newSortedItems);
+    if (!onSortColumnsChange) return;
+
+    if (isCtrlClick) {
+      const newSortColumns = sortColumns ? [...sortColumns] : [];
+      const itemIndex = newSortColumns.findIndex(item => item.columnKey === columnKey);
+      if (itemIndex !== -1) {
+        newSortColumns[itemIndex] = { columnKey, direction };
+      } else {
+        newSortColumns.push({ columnKey, direction });
+      }
+      onSortColumnsChange(newSortColumns);
+    } else {
+      onSortColumnsChange([{ columnKey, direction }]);
+    }
   }
 
   function getCell() {

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -9,9 +9,8 @@ import { headerRowClassname } from './style';
 type SharedDataGridProps<R, SR> = Pick<DataGridProps<R, SR>,
   | 'rows'
   | 'onSelectedRowsChange'
-  | 'sortColumn'
-  | 'sortDirection'
-  | 'onSort'
+  | 'sortItems'
+  | 'onSortItemsChange'
   | 'rowKeyGetter'
 >;
 
@@ -28,9 +27,8 @@ function HeaderRow<R, SR>({
   onSelectedRowsChange,
   allRowsSelected,
   onColumnResize,
-  sortColumn,
-  sortDirection,
-  onSort
+  sortItems,
+  onSortItemsChange
 }: HeaderRowProps<R, SR>) {
   const handleAllRowsSelectionChange = useCallback((checked: boolean) => {
     if (!onSelectedRowsChange) return;
@@ -55,9 +53,8 @@ function HeaderRow<R, SR>({
             onResize={onColumnResize}
             allRowsSelected={allRowsSelected}
             onAllRowsSelectionChange={handleAllRowsSelectionChange}
-            onSort={onSort}
-            sortColumn={sortColumn}
-            sortDirection={sortDirection}
+            sortItems={sortItems}
+            onSortItemsChange={onSortItemsChange}
           />
         );
       })}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -9,8 +9,8 @@ import { headerRowClassname } from './style';
 type SharedDataGridProps<R, SR> = Pick<DataGridProps<R, SR>,
   | 'rows'
   | 'onSelectedRowsChange'
-  | 'sortItems'
-  | 'onSortItemsChange'
+  | 'sortColumns'
+  | 'onSortColumnsChange'
   | 'rowKeyGetter'
 >;
 
@@ -27,8 +27,8 @@ function HeaderRow<R, SR>({
   onSelectedRowsChange,
   allRowsSelected,
   onColumnResize,
-  sortItems,
-  onSortItemsChange
+  sortColumns,
+  onSortColumnsChange
 }: HeaderRowProps<R, SR>) {
   const handleAllRowsSelectionChange = useCallback((checked: boolean) => {
     if (!onSelectedRowsChange) return;
@@ -53,8 +53,8 @@ function HeaderRow<R, SR>({
             onResize={onColumnResize}
             allRowsSelected={allRowsSelected}
             onAllRowsSelectionChange={handleAllRowsSelectionChange}
-            sortItems={sortItems}
-            onSortItemsChange={onSortItemsChange}
+            sortColumns={sortColumns}
+            onSortColumnsChange={onSortColumnsChange}
           />
         );
       })}

--- a/src/headerCells/SortableHeaderCell.tsx
+++ b/src/headerCells/SortableHeaderCell.tsx
@@ -18,12 +18,10 @@ const headerSortName = css`
 
 const headerSortNameClassname = `rdg-header-sort-name ${headerSortName}`;
 
-type SharedHeaderCellProps<R, SR> = Pick<HeaderCellProps<R, SR>,
-  | 'column'
-  | 'sortColumn'
-  | 'sortDirection'
-  | 'onSort'
->;
+interface SharedHeaderCellProps<R, SR> extends Pick<HeaderCellProps<R, SR>, 'column'> {
+  sortDirection?: SortDirection;
+  onSort?: (columnKey: string, direction: SortDirection) => void;
+}
 
 interface Props<R, SR> extends SharedHeaderCellProps<R, SR> {
   children: React.ReactNode;
@@ -32,11 +30,9 @@ interface Props<R, SR> extends SharedHeaderCellProps<R, SR> {
 export default function SortableHeaderCell<R, SR>({
   column,
   onSort,
-  sortColumn,
-  sortDirection,
+  sortDirection = 'NONE',
   children
 }: Props<R, SR>) {
-  sortDirection = sortColumn === column.key && sortDirection || 'NONE';
   let sortText = '';
   if (sortDirection === 'ASC') {
     sortText = '\u25B2';

--- a/src/headerCells/SortableHeaderCell.tsx
+++ b/src/headerCells/SortableHeaderCell.tsx
@@ -1,6 +1,6 @@
+import type { MouseEvent } from 'react';
 import { css } from '@linaria/core';
-import type { HeaderCellProps } from '../HeaderCell';
-import type { SortDirection } from '../types';
+import type { SortDirection, HeaderRendererProps } from '../types';
 
 const headerSortCell = css`
   cursor: pointer;
@@ -18,10 +18,7 @@ const headerSortName = css`
 
 const headerSortNameClassname = `rdg-header-sort-name ${headerSortName}`;
 
-interface SharedHeaderCellProps<R, SR> extends Pick<HeaderCellProps<R, SR>, 'column'> {
-  sortDirection?: SortDirection;
-  onSort?: (columnKey: string, direction: SortDirection) => void;
-}
+type SharedHeaderCellProps<R, SR> = Pick<HeaderRendererProps<R, SR>, 'column' | 'sortDirection' | 'onSort'>;
 
 interface Props<R, SR> extends SharedHeaderCellProps<R, SR> {
   children: React.ReactNode;
@@ -40,7 +37,7 @@ export default function SortableHeaderCell<R, SR>({
     sortText = '\u25BC';
   }
 
-  function onClick() {
+  function onClick(event: MouseEvent<HTMLSpanElement>) {
     if (!onSort) return;
     const { sortDescendingFirst } = column;
     let direction: SortDirection;
@@ -55,7 +52,7 @@ export default function SortableHeaderCell<R, SR>({
         direction = sortDescendingFirst ? 'DESC' : 'ASC';
         break;
     }
-    onSort(column.key, direction);
+    onSort(column.key, direction, event.ctrlKey);
   }
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,5 +23,6 @@ export type {
   FillEvent,
   PasteEvent,
   CellNavigationMode,
-  SortDirection
+  SortDirection,
+  SortColumn
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,3 +225,8 @@ export interface GroupRow<TRow> {
 
 export type CellNavigationMode = 'NONE' | 'CHANGE_ROW' | 'LOOP_OVER_ROW';
 export type SortDirection = 'ASC' | 'DESC' | 'NONE';
+
+export interface SortColumn {
+  columnKey: string;
+  direction: SortDirection;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,7 +119,7 @@ export interface EditorProps<TRow, TSummaryRow = unknown> extends SharedEditorPr
 export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   sortDirection?: SortDirection;
-  onSort?: (columnKey: string, direction: SortDirection) => void;
+  onSort?: (columnKey: string, direction: SortDirection, isCtrlClick: boolean) => void;
   allRowsSelected: boolean;
   onAllRowsSelectionChange: (checked: boolean) => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,7 +118,6 @@ export interface EditorProps<TRow, TSummaryRow = unknown> extends SharedEditorPr
 
 export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
-  sortColumn?: string;
   sortDirection?: SortDirection;
   onSort?: (columnKey: string, direction: SortDirection) => void;
   allRowsSelected: boolean;

--- a/stories/demos/ColumnsReordering.tsx
+++ b/stories/demos/ColumnsReordering.tsx
@@ -4,7 +4,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { DraggableHeaderRenderer } from './components/HeaderRenderers';
 import DataGrid from '../../src';
-import type { Column, HeaderRendererProps, SortDirection } from '../../src';
+import type { Column, HeaderRendererProps, SortColumn } from '../../src';
 
 interface Row {
   id: number;
@@ -66,7 +66,7 @@ function createColumns(): Column<Row>[] {
 export function ColumnsReordering() {
   const [rows] = useState(createRows);
   const [columns, setColumns] = useState(createColumns);
-  const [sortItems, setSortItems] = useState<ReadonlyMap<string, SortDirection>>(new Map([['task', 'NONE']]));
+  const [sortColumns, setSortItems] = useState<readonly Readonly<SortColumn>[]>([{ columnKey: 'task', direction: 'NONE' }]);
 
   const draggableColumns = useMemo(() => {
     function HeaderRenderer(props: HeaderRendererProps<Row>) {
@@ -94,35 +94,35 @@ export function ColumnsReordering() {
   }, [columns]);
 
   const sortedRows = useMemo((): readonly Row[] => {
-    if (sortItems.size === 0) return rows;
-    const [sortColumn, sortDirection] = [...sortItems][0];
+    if (sortColumns.length === 0) return rows;
+    const { columnKey, direction } = sortColumns[0];
 
-    if (sortDirection === 'NONE') return rows;
+    if (direction === 'NONE') return rows;
 
     let sortedRows: Row[] = [...rows];
 
-    switch (sortColumn) {
+    switch (columnKey) {
       case 'task':
       case 'priority':
       case 'issueType':
-        sortedRows = sortedRows.sort((a, b) => a[sortColumn].localeCompare(b[sortColumn]));
+        sortedRows = sortedRows.sort((a, b) => a[columnKey].localeCompare(b[columnKey]));
         break;
       case 'complete':
-        sortedRows = sortedRows.sort((a, b) => a[sortColumn] - b[sortColumn]);
+        sortedRows = sortedRows.sort((a, b) => a[columnKey] - b[columnKey]);
         break;
       default:
     }
 
-    return sortDirection === 'DESC' ? sortedRows.reverse() : sortedRows;
-  }, [rows, sortItems]);
+    return direction === 'DESC' ? sortedRows.reverse() : sortedRows;
+  }, [rows, sortColumns]);
 
   return (
     <DndProvider backend={HTML5Backend}>
       <DataGrid
         columns={draggableColumns}
         rows={sortedRows}
-        sortItems={sortItems}
-        onSortItemsChange={setSortItems}
+        sortColumns={sortColumns}
+        onSortColumnsChange={setSortItems}
       />
     </DndProvider>
   );

--- a/stories/demos/ColumnsReordering.tsx
+++ b/stories/demos/ColumnsReordering.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
@@ -66,11 +66,7 @@ function createColumns(): Column<Row>[] {
 export function ColumnsReordering() {
   const [rows] = useState(createRows);
   const [columns, setColumns] = useState(createColumns);
-  const [[sortColumn, sortDirection], setSort] = useState<[string, SortDirection]>(['task', 'NONE']);
-
-  const handleSort = useCallback((columnKey: string, direction: SortDirection) => {
-    setSort([columnKey, direction]);
-  }, []);
+  const [sortItems, setSortItems] = useState<ReadonlyMap<string, SortDirection>>(new Map([['task', 'NONE']]));
 
   const draggableColumns = useMemo(() => {
     function HeaderRenderer(props: HeaderRendererProps<Row>) {
@@ -98,6 +94,9 @@ export function ColumnsReordering() {
   }, [columns]);
 
   const sortedRows = useMemo((): readonly Row[] => {
+    if (sortItems.size === 0) return rows;
+    const [sortColumn, sortDirection] = [...sortItems][0];
+
     if (sortDirection === 'NONE') return rows;
 
     let sortedRows: Row[] = [...rows];
@@ -115,16 +114,15 @@ export function ColumnsReordering() {
     }
 
     return sortDirection === 'DESC' ? sortedRows.reverse() : sortedRows;
-  }, [rows, sortDirection, sortColumn]);
+  }, [rows, sortItems]);
 
   return (
     <DndProvider backend={HTML5Backend}>
       <DataGrid
         columns={draggableColumns}
         rows={sortedRows}
-        sortColumn={sortColumn}
-        sortDirection={sortDirection}
-        onSort={handleSort}
+        sortItems={sortItems}
+        onSortItemsChange={setSortItems}
       />
     </DndProvider>
   );

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -212,6 +212,30 @@ function createRows(): readonly Row[] {
   return rows;
 }
 
+function compare(row1: Row, row2: Row, columnKey: string) {
+  switch (columnKey) {
+    case 'assignee':
+    case 'title':
+    case 'client':
+    case 'area':
+    case 'country':
+    case 'contact':
+    case 'transaction':
+    case 'account':
+    case 'version':
+      return row1[columnKey].localeCompare(row2[columnKey]);
+    case 'available':
+      return row1[columnKey] === row2[columnKey] ? 0 : row1[columnKey] ? 1 : -1;
+    case 'id':
+    case 'progress':
+    case 'startTimestamp':
+    case 'endTimestamp':
+    case 'budget':
+      return row1[columnKey] - row2[columnKey];
+    default:
+      return 0;
+  }
+}
 export function CommonFeatures() {
   const [rows, setRows] = useState(createRows);
   const [sortColumns, setSortItems] = useState<readonly Readonly<SortColumn>[]>([{ columnKey: 'id', direction: 'NONE' }]);
@@ -231,38 +255,21 @@ export function CommonFeatures() {
 
   const sortedRows: readonly Row[] = useMemo(() => {
     if (sortColumns.length === 0) return rows;
-    const { columnKey, direction } = sortColumns[0];
 
-    if (direction === 'NONE') return rows;
-
-    let sortedRows: Row[] = [...rows];
-
-    switch (columnKey) {
-      case 'assignee':
-      case 'title':
-      case 'client':
-      case 'area':
-      case 'country':
-      case 'contact':
-      case 'transaction':
-      case 'account':
-      case 'version':
-        sortedRows = sortedRows.sort((a, b) => a[columnKey].localeCompare(b[columnKey]));
-        break;
-      case 'available':
-        sortedRows = sortedRows.sort((a, b) => a[columnKey] === b[columnKey] ? 0 : a[columnKey] ? 1 : -1);
-        break;
-      case 'id':
-      case 'progress':
-      case 'startTimestamp':
-      case 'endTimestamp':
-      case 'budget':
-        sortedRows = sortedRows.sort((a, b) => a[columnKey] - b[columnKey]);
-        break;
-      default:
-    }
-
-    return direction === 'DESC' ? sortedRows.reverse() : sortedRows;
+    const sortedRows: Row[] = [...rows];
+    sortedRows.sort((a, b) => {
+      let result = 0;
+      for (const { columnKey, direction } of sortColumns) {
+        if (direction === 'NONE') continue;
+        result = compare(a, b, columnKey);
+        if (result !== 0) {
+          result = direction === 'DESC' ? -result : result;
+          break;
+        }
+      }
+      return result;
+    });
+    return sortedRows;
   }, [rows, sortColumns]);
 
   return (

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import faker from 'faker';
 import DataGrid, { SelectColumn, TextEditor, SelectCellFormatter } from '../../src';
 import type { Column, SortDirection } from '../../src';
@@ -214,7 +214,7 @@ function createRows(): readonly Row[] {
 
 export function CommonFeatures() {
   const [rows, setRows] = useState(createRows);
-  const [[sortColumn, sortDirection], setSort] = useState<[string, SortDirection]>(['id', 'NONE']);
+  const [sortItems, setSortItems] = useState<ReadonlyMap<string, SortDirection>>(new Map([['id', 'NONE']]));
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
 
   const countries = useMemo(() => {
@@ -230,6 +230,9 @@ export function CommonFeatures() {
   }, [rows]);
 
   const sortedRows: readonly Row[] = useMemo(() => {
+    if (sortItems.size === 0) return rows;
+    const [sortColumn, sortDirection] = [...sortItems][0];
+
     if (sortDirection === 'NONE') return rows;
 
     let sortedRows: Row[] = [...rows];
@@ -260,11 +263,7 @@ export function CommonFeatures() {
     }
 
     return sortDirection === 'DESC' ? sortedRows.reverse() : sortedRows;
-  }, [rows, sortDirection, sortColumn]);
-
-  const handleSort = useCallback((columnKey: string, direction: SortDirection) => {
-    setSort([columnKey, direction]);
-  }, []);
+  }, [rows, sortItems]);
 
   return (
     <DataGrid
@@ -278,9 +277,8 @@ export function CommonFeatures() {
       selectedRows={selectedRows}
       onSelectedRowsChange={setSelectedRows}
       onRowsChange={setRows}
-      sortColumn={sortColumn}
-      sortDirection={sortDirection}
-      onSort={handleSort}
+      sortItems={sortItems}
+      onSortItemsChange={setSortItems}
       summaryRows={summaryRows}
       className="fill-grid"
     />

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import faker from 'faker';
 import DataGrid, { SelectColumn, TextEditor, SelectCellFormatter } from '../../src';
-import type { Column, SortDirection } from '../../src';
+import type { Column, SortColumn } from '../../src';
 import { stopPropagation } from '../../src/utils';
 import { SelectEditor } from './components/Editors/SelectEditor';
 
@@ -214,7 +214,7 @@ function createRows(): readonly Row[] {
 
 export function CommonFeatures() {
   const [rows, setRows] = useState(createRows);
-  const [sortItems, setSortItems] = useState<ReadonlyMap<string, SortDirection>>(new Map([['id', 'NONE']]));
+  const [sortColumns, setSortItems] = useState<readonly Readonly<SortColumn>[]>([{ columnKey: 'id', direction: 'NONE' }]);
   const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
 
   const countries = useMemo(() => {
@@ -230,14 +230,14 @@ export function CommonFeatures() {
   }, [rows]);
 
   const sortedRows: readonly Row[] = useMemo(() => {
-    if (sortItems.size === 0) return rows;
-    const [sortColumn, sortDirection] = [...sortItems][0];
+    if (sortColumns.length === 0) return rows;
+    const { columnKey, direction } = sortColumns[0];
 
-    if (sortDirection === 'NONE') return rows;
+    if (direction === 'NONE') return rows;
 
     let sortedRows: Row[] = [...rows];
 
-    switch (sortColumn) {
+    switch (columnKey) {
       case 'assignee':
       case 'title':
       case 'client':
@@ -247,23 +247,23 @@ export function CommonFeatures() {
       case 'transaction':
       case 'account':
       case 'version':
-        sortedRows = sortedRows.sort((a, b) => a[sortColumn].localeCompare(b[sortColumn]));
+        sortedRows = sortedRows.sort((a, b) => a[columnKey].localeCompare(b[columnKey]));
         break;
       case 'available':
-        sortedRows = sortedRows.sort((a, b) => a[sortColumn] === b[sortColumn] ? 0 : a[sortColumn] ? 1 : -1);
+        sortedRows = sortedRows.sort((a, b) => a[columnKey] === b[columnKey] ? 0 : a[columnKey] ? 1 : -1);
         break;
       case 'id':
       case 'progress':
       case 'startTimestamp':
       case 'endTimestamp':
       case 'budget':
-        sortedRows = sortedRows.sort((a, b) => a[sortColumn] - b[sortColumn]);
+        sortedRows = sortedRows.sort((a, b) => a[columnKey] - b[columnKey]);
         break;
       default:
     }
 
-    return sortDirection === 'DESC' ? sortedRows.reverse() : sortedRows;
-  }, [rows, sortItems]);
+    return direction === 'DESC' ? sortedRows.reverse() : sortedRows;
+  }, [rows, sortColumns]);
 
   return (
     <DataGrid
@@ -277,8 +277,8 @@ export function CommonFeatures() {
       selectedRows={selectedRows}
       onSelectedRowsChange={setSelectedRows}
       onRowsChange={setRows}
-      sortItems={sortItems}
-      onSortItemsChange={setSortItems}
+      sortColumns={sortColumns}
+      onSortColumnsChange={setSortItems}
       summaryRows={summaryRows}
       className="fill-grid"
     />

--- a/stories/demos/components/HeaderRenderers/DraggableHeaderRenderer.tsx
+++ b/stories/demos/components/HeaderRenderers/DraggableHeaderRenderer.tsx
@@ -13,7 +13,7 @@ interface DraggableHeaderRendererProps<R> extends HeaderRendererProps<R> {
   onColumnsReorder: (sourceKey: string, targetKey: string) => void;
 }
 
-export function DraggableHeaderRenderer<R>({ onColumnsReorder, column, sortColumn, sortDirection, onSort }: DraggableHeaderRendererProps<R>) {
+export function DraggableHeaderRenderer<R>({ onColumnsReorder, column, sortDirection, onSort }: DraggableHeaderRendererProps<R>) {
   const [{ isDragging }, drag] = useDrag({
     item: { key: column.key, type: 'COLUMN_DRAG' },
     collect: monitor => ({
@@ -45,7 +45,6 @@ export function DraggableHeaderRenderer<R>({ onColumnsReorder, column, sortColum
     >
       <SortableHeaderCell
         column={column}
-        sortColumn={sortColumn}
         sortDirection={sortDirection}
         onSort={onSort}
       >


### PR DESCRIPTION
Replace `onSort`, `sortColumn`, `sortDirection` with new `sortColumns` and `onSortColumnsChange` props

Questions:
- Should we add `enableMultiSort` prop to control multi sort?


https://www.w3.org/TR/wai-aria-practices-1.2/#gridAndTableProperties_sort

> It is important to note that ARIA does not provide a way to indicate levels of sort for data sets that have multiple sort keys. Thus, there is limited value to applying aria-sort with a value other than none to more than one column or row.