### PR TITLE
Add column.colSpan prop

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -44,6 +44,7 @@ const cellDragHandleClassname = `rdg-cell-drag-handle ${cellDragHandle}`;
 function Cell<R, SR>({
   className,
   column,
+  colSpan,
   isCellSelected,
   isCopied,
   isDraggedOver,
@@ -105,9 +106,10 @@ function Cell<R, SR>({
       role="gridcell"
       aria-colindex={column.idx + 1} // aria-colindex is 1-based
       aria-selected={isCellSelected}
+      aria-colspan={colSpan}
       ref={ref}
       className={className}
-      style={getCellStyle(column)}
+      style={getCellStyle(column, colSpan)}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -813,6 +813,7 @@ function DataGrid<R, SR>({
   }
 
   function getColSpanPosition(nextPosition: Position) {
+    if (!isCellWithinBounds(nextPosition)) return nextPosition;
     const row = rows[nextPosition.rowIdx];
     if (isGroupRow(row)) return nextPosition;
     // If a cell within the colspan range is selected then move to the

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -294,6 +294,8 @@ function DataGrid<R, SR>({
     columns,
     colOverscanStartIdx,
     colOverscanEndIdx,
+    rowOverscanStartIdx,
+    rowOverscanEndIdx,
     rows,
     isGroupRow
   });

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -808,6 +808,7 @@ function DataGrid<R, SR>({
         mode: 'EDIT',
         idx: selectedPosition.idx,
         onKeyDown: handleKeyDown,
+        prevIdx: prevSelectedPosition.current.idx,
         editorProps: {
           editorPortalTarget,
           rowHeight,
@@ -821,6 +822,7 @@ function DataGrid<R, SR>({
     return {
       mode: 'SELECT',
       idx: selectedPosition.idx,
+      prevIdx: prevSelectedPosition.current.idx,
       onFocus: handleFocus,
       onKeyDown: handleKeyDown,
       dragHandleProps: enableCellDragAndDrop && isCellEditable(selectedPosition)

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -23,8 +23,7 @@ import {
   isSelectedCellEditable,
   canExitGrid,
   isCtrlKeyHeldDown,
-  isDefaultCellInput,
-  getColSpan
+  isDefaultCellInput
 } from './utils';
 
 import type {
@@ -804,35 +803,19 @@ function DataGrid<R, SR>({
     event.preventDefault();
 
     const ctrlKey = isCtrlKeyHeldDown(event);
-    let nextPosition = getNextPosition(key, ctrlKey, shiftKey);
-    nextPosition = getNextSelectedCellPosition({
+    const nextPosition = getNextSelectedCellPosition({
       columns,
-      rowsCount: rows.length,
+      colSpanColumns,
+      rows,
+      lastFrozenColumnIndex,
       cellNavigationMode: mode,
-      nextPosition
+      currentPosition: selectedPosition,
+      nextPosition: getNextPosition(key, ctrlKey, shiftKey),
+      isCellWithinBounds,
+      isGroupRow
     });
-    nextPosition = getColSpanPosition(nextPosition);
 
     selectCell(nextPosition);
-  }
-
-  function getColSpanPosition(nextPosition: Position) {
-    if (!isCellWithinBounds(nextPosition)) return nextPosition;
-    const row = rows[nextPosition.rowIdx];
-    if (isGroupRow(row)) return nextPosition;
-    // If a cell within the colspan range is selected then move to the
-    // previous or the next cell depending on the navigation direction
-    for (const column of colSpanColumns) {
-      const colIdx = column.idx;
-      if (colIdx > nextPosition.idx) break;
-      const colSpan = getColSpan<R, SR>(column, lastFrozenColumnIndex, { type: 'ROW', row });
-      if (colSpan && nextPosition.idx > column.idx && nextPosition.idx < colSpan + column.idx) {
-        nextPosition.idx = column.idx + (nextPosition.idx - selectedPosition.idx > 0 ? colSpan : 0);
-        break;
-      }
-    }
-
-    return nextPosition;
   }
 
   function getDraggedOverCellIdx(currentRowIdx: number): number | undefined {

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -801,13 +801,13 @@ function DataGrid<R, SR>({
 
     const ctrlKey = isCtrlKeyHeldDown(event);
     let nextPosition = getNextPosition(key, ctrlKey, shiftKey);
-    nextPosition = getColSpanPosition(nextPosition);
     nextPosition = getNextSelectedCellPosition({
       columns,
       rowsCount: rows.length,
       cellNavigationMode: mode,
       nextPosition
     });
+    nextPosition = getColSpanPosition(nextPosition);
 
     selectCell(nextPosition);
   }

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -297,6 +297,7 @@ function DataGrid<R, SR>({
     rowOverscanStartIdx,
     rowOverscanEndIdx,
     rows,
+    summaryRows,
     isGroupRow
   });
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -296,6 +296,7 @@ function DataGrid<R, SR>({
     colSpanColumns,
     colOverscanStartIdx,
     colOverscanEndIdx,
+    lastFrozenColumnIndex,
     rowOverscanStartIdx,
     rowOverscanEndIdx,
     rows,
@@ -824,7 +825,7 @@ function DataGrid<R, SR>({
     for (const column of colSpanColumns) {
       const colIdx = column.idx;
       if (colIdx > nextPosition.idx) break;
-      const colSpan = getColSpan<R, SR>(column, columns, { type: 'ROW', row });
+      const colSpan = getColSpan<R, SR>(column, lastFrozenColumnIndex, { type: 'ROW', row });
       if (colSpan && nextPosition.idx > column.idx && nextPosition.idx < colSpan + column.idx) {
         nextPosition.idx = column.idx + (nextPosition.idx - selectedPosition.idx > 0 ? colSpan : 0);
         break;
@@ -932,6 +933,7 @@ function DataGrid<R, SR>({
           copiedCellIdx={copiedCell !== null && copiedCell.row === row ? columns.findIndex(c => c.key === copiedCell.columnKey) : undefined}
           draggedOverCellIdx={getDraggedOverCellIdx(rowIdx)}
           setDraggedOverRowIdx={isDragging ? setDraggedOverRowIdx : undefined}
+          lastFrozenColumnIndex={lastFrozenColumnIndex}
           selectedCellProps={getSelectedCellProps(rowIdx)}
           onRowChange={handleFormatterRowChangeWrapper}
           selectCell={selectCellWrapper}
@@ -986,6 +988,7 @@ function DataGrid<R, SR>({
         sortColumn={sortColumn}
         sortDirection={sortDirection}
         onSort={onSort}
+        lastFrozenColumnIndex={lastFrozenColumnIndex}
       />
       {enableFilterRow && (
         <FilterRow<R, SR>
@@ -1013,6 +1016,7 @@ function DataGrid<R, SR>({
               row={row}
               bottom={summaryRowHeight * (summaryRows.length - 1 - rowIdx)}
               viewportColumns={viewportColumns}
+              lastFrozenColumnIndex={lastFrozenColumnIndex}
             />
           ))}
         </>

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -261,6 +261,7 @@ function DataGrid<R, SR>({
 
   const {
     columns,
+    colSpanColumns,
     colOverscanStartIdx,
     colOverscanEndIdx,
     layoutCssVars,
@@ -292,6 +293,7 @@ function DataGrid<R, SR>({
 
   const viewportColumns = useViewportColumns({
     columns,
+    colSpanColumns,
     colOverscanStartIdx,
     colOverscanEndIdx,
     rowOverscanStartIdx,
@@ -818,8 +820,9 @@ function DataGrid<R, SR>({
     if (isGroupRow(row)) return nextPosition;
     // If a cell within the colspan range is selected then move to the
     // previous or the next cell depending on the navigation direction
-    for (let colIdx = 0; colIdx <= nextPosition.idx; colIdx++) {
-      const column = columns[colIdx];
+    for (const column of colSpanColumns) {
+      const colIdx = column.idx;
+      if (colIdx > nextPosition.idx) break;
       const colSpan = getColSpan<R, SR>(column, columns, { type: 'ROW', row });
       if (colSpan && nextPosition.idx > column.idx && nextPosition.idx < colSpan + column.idx) {
         nextPosition.idx = column.idx + (nextPosition.idx - selectedPosition.idx > 0 ? colSpan : 0);

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -10,7 +10,7 @@ import type { RefAttributes } from 'react';
 import clsx from 'clsx';
 
 import { rootClassname, viewportDraggingClassname, focusSinkClassname } from './style';
-import { useGridDimensions, useViewportColumns, useViewportRows, useLatestFunc } from './hooks';
+import { useGridDimensions, useCalculatedColumns, useViewportColumns, useViewportRows, useLatestFunc } from './hooks';
 import HeaderRow from './HeaderRow';
 import FilterRow from './FilterRow';
 import Row from './Row';
@@ -258,7 +258,17 @@ function DataGrid<R, SR>({
   const clientHeight = gridHeight - totalHeaderHeight - summaryRowsCount * summaryRowHeight;
   const isSelectable = selectedRows !== undefined && onSelectedRowsChange !== undefined;
 
-  const { columns, viewportColumns, layoutCssVars, columnMetrics, totalColumnWidth, lastFrozenColumnIndex, totalFrozenColumnWidth, groupBy } = useViewportColumns({
+  const {
+    columns,
+    colOverscanStartIdx,
+    colOverscanEndIdx,
+    layoutCssVars,
+    columnMetrics,
+    totalColumnWidth,
+    lastFrozenColumnIndex,
+    totalFrozenColumnWidth,
+    groupBy
+  } = useCalculatedColumns({
     rawColumns,
     columnWidths,
     scrollLeft,
@@ -277,6 +287,14 @@ function DataGrid<R, SR>({
     scrollTop,
     expandedGroupIds,
     enableVirtualization
+  });
+
+  const viewportColumns = useViewportColumns({
+    columns,
+    colOverscanStartIdx,
+    colOverscanEndIdx,
+    rows,
+    isGroupRow
   });
 
   const hasGroups = groupBy.length > 0 && typeof rowGrouper === 'function';

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -300,6 +300,7 @@ function DataGrid<R, SR>({
     rowOverscanEndIdx,
     rows,
     summaryRows,
+    enableFilterRow,
     isGroupRow
   });
 

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -16,6 +16,7 @@ type SharedCellRendererProps<R, SR> = Pick<CellRendererProps<R, SR>,
   | 'rowIdx'
   | 'row'
   | 'column'
+  | 'colSpan'
 >;
 
 interface EditCellProps<R, SR> extends SharedCellRendererProps<R, SR>, Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
@@ -25,6 +26,7 @@ interface EditCellProps<R, SR> extends SharedCellRendererProps<R, SR>, Omit<Reac
 export default function EditCell<R, SR>({
   className,
   column,
+  colSpan,
   row,
   rowIdx,
   editorProps,
@@ -73,7 +75,7 @@ export default function EditCell<R, SR>({
       aria-selected
       ref={cellRef}
       className={className}
-      style={getCellStyle(column)}
+      style={getCellStyle(column, colSpan)}
       {...props}
     >
       {getCellContent()}

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -39,12 +39,14 @@ type SharedHeaderRowProps<R, SR> = Pick<HeaderRowProps<R, SR>,
 
 export interface HeaderCellProps<R, SR> extends SharedHeaderRowProps<R, SR> {
   column: CalculatedColumn<R, SR>;
+  colSpan?: number;
   onResize: (column: CalculatedColumn<R, SR>, width: number) => void;
   onAllRowsSelectionChange: (checked: boolean) => void;
 }
 
 export default function HeaderCell<R, SR>({
   column,
+  colSpan,
   onResize,
   allRowsSelected,
   onAllRowsSelectionChange,
@@ -128,7 +130,7 @@ export default function HeaderCell<R, SR>({
       aria-colindex={column.idx + 1}
       aria-sort={sortColumn === column.key ? getAriaSort(sortDirection) : undefined}
       className={className}
-      style={getCellStyle(column)}
+      style={getCellStyle(column, colSpan)}
       onPointerDown={column.resizable ? onPointerDown : undefined}
     >
       {getCell()}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -2,7 +2,7 @@ import { useCallback, memo } from 'react';
 
 import HeaderCell from './HeaderCell';
 import type { CalculatedColumn } from './types';
-import { assertIsValidKeyGetter } from './utils';
+import { assertIsValidKeyGetter, getColSpan } from './utils';
 import type { DataGridProps } from './DataGrid';
 import { headerRowClassname } from './style';
 
@@ -41,6 +41,7 @@ function HeaderRow<R, SR>({
     onSelectedRowsChange(newSelectedRows);
   }, [onSelectedRowsChange, rows, rowKeyGetter]);
 
+  let colSpan: number| undefined;
   return (
     <div
       role="row"
@@ -48,10 +49,17 @@ function HeaderRow<R, SR>({
       className={headerRowClassname}
     >
       {columns.map(column => {
+        if (colSpan && colSpan > 1) {
+          colSpan--;
+          return null;
+        }
+        colSpan = getColSpan(column, columns, { type: 'HEADER' });
+
         return (
           <HeaderCell<R, SR>
             key={column.key}
             column={column}
+            colSpan={colSpan}
             onResize={onColumnResize}
             allRowsSelected={allRowsSelected}
             onAllRowsSelectionChange={handleAllRowsSelectionChange}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -41,34 +41,36 @@ function HeaderRow<R, SR>({
     onSelectedRowsChange(newSelectedRows);
   }, [onSelectedRowsChange, rows, rowKeyGetter]);
 
-  let colSpan: number| undefined;
+  const cells = [];
+  for (let index = 0; index < columns.length; index++) {
+    const column = columns[index];
+    const colSpan = getColSpan(column, columns, { type: 'HEADER' });
+    if (colSpan && colSpan > 1) {
+      index += colSpan - 1;
+    }
+
+    cells.push(
+      <HeaderCell<R, SR>
+        key={column.key}
+        column={column}
+        colSpan={colSpan}
+        onResize={onColumnResize}
+        allRowsSelected={allRowsSelected}
+        onAllRowsSelectionChange={handleAllRowsSelectionChange}
+        onSort={onSort}
+        sortColumn={sortColumn}
+        sortDirection={sortDirection}
+      />
+    );
+  }
+
   return (
     <div
       role="row"
       aria-rowindex={1} // aria-rowindex is 1 based
       className={headerRowClassname}
     >
-      {columns.map(column => {
-        if (colSpan && colSpan > 1) {
-          colSpan--;
-          return null;
-        }
-        colSpan = getColSpan(column, columns, { type: 'HEADER' });
-
-        return (
-          <HeaderCell<R, SR>
-            key={column.key}
-            column={column}
-            colSpan={colSpan}
-            onResize={onColumnResize}
-            allRowsSelected={allRowsSelected}
-            onAllRowsSelectionChange={handleAllRowsSelectionChange}
-            onSort={onSort}
-            sortColumn={sortColumn}
-            sortDirection={sortDirection}
-          />
-        );
-      })}
+      {cells}
     </div>
   );
 }

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -45,7 +45,7 @@ function HeaderRow<R, SR>({
   for (let index = 0; index < columns.length; index++) {
     const column = columns[index];
     const colSpan = getColSpan(column, columns, { type: 'HEADER' });
-    if (colSpan && colSpan > 1) {
+    if (colSpan !== undefined) {
       index += colSpan - 1;
     }
 

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -19,6 +19,7 @@ export interface HeaderRowProps<R, SR> extends SharedDataGridProps<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
   allRowsSelected: boolean;
   onColumnResize: (column: CalculatedColumn<R, SR>, width: number) => void;
+  lastFrozenColumnIndex: number;
 }
 
 function HeaderRow<R, SR>({
@@ -30,7 +31,8 @@ function HeaderRow<R, SR>({
   onColumnResize,
   sortColumn,
   sortDirection,
-  onSort
+  onSort,
+  lastFrozenColumnIndex
 }: HeaderRowProps<R, SR>) {
   const handleAllRowsSelectionChange = useCallback((checked: boolean) => {
     if (!onSelectedRowsChange) return;
@@ -44,7 +46,7 @@ function HeaderRow<R, SR>({
   const cells = [];
   for (let index = 0; index < columns.length; index++) {
     const column = columns[index];
-    const colSpan = getColSpan(column, columns, { type: 'HEADER' });
+    const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'HEADER' });
     if (colSpan !== undefined) {
       index += colSpan - 1;
     }

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -63,6 +63,8 @@ function Row<R, SR = unknown>({
         if (colSpan && colSpan > 1) {
           colSpan--;
           if (isCellSelected) {
+            // If a cell within the colspan range is selected then move to the
+            // previous or the next cell depending on the navigation direction
             const { prevIdx } = selectedCellProps!;
             selectCell({
               rowIdx,

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -47,6 +47,20 @@ function Row<R, SR = unknown>({
   let colSpan: number| undefined;
   let colSpanIdx: number | undefined;
 
+  function areColSpanColumnsCompatible(startIdx: number, colSpan: number) {
+    const isFrozen = viewportColumns[startIdx].frozen;
+    for (
+      let index = 1;
+      index < colSpan && startIdx + index < viewportColumns.length;
+      index++
+    ) {
+      if (viewportColumns[startIdx + index].frozen !== isFrozen) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   return (
     <div
       role="row"
@@ -75,6 +89,10 @@ function Row<R, SR = unknown>({
         }
         colSpan = typeof column.colSpan === 'function' ? column.colSpan(row, 'ROW') : column.colSpan;
         colSpanIdx = column.idx;
+        if (colSpan && !areColSpanColumnsCompatible(colSpanIdx, colSpan)) {
+          // ignore colSpan if it spans over frozen and regular columns
+          colSpan = undefined;
+        }
 
         if (selectedCellProps?.mode === 'EDIT' && isCellSelected) {
           return (

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -44,6 +44,8 @@ function Row<R, SR = unknown>({
     className
   );
 
+  let colSpan: number| undefined;
+
   return (
     <div
       role="row"
@@ -56,6 +58,12 @@ function Row<R, SR = unknown>({
       {...props}
     >
       {viewportColumns.map(column => {
+        if (colSpan && colSpan > 1) {
+          colSpan--;
+          return null;
+        }
+        colSpan = typeof column.colSpan === 'function' ? column.colSpan({ row, rowType: 'ROW' }) : column.colSpan;
+
         const isCellSelected = selectedCellProps?.idx === column.idx;
         if (selectedCellProps?.mode === 'EDIT' && isCellSelected) {
           return (
@@ -63,6 +71,7 @@ function Row<R, SR = unknown>({
               key={column.key}
               rowIdx={rowIdx}
               column={column}
+              colSpan={colSpan}
               row={row}
               onKeyDown={selectedCellProps.onKeyDown}
               editorProps={selectedCellProps.editorProps}
@@ -75,6 +84,7 @@ function Row<R, SR = unknown>({
             key={column.key}
             rowIdx={rowIdx}
             column={column}
+            colSpan={colSpan}
             row={row}
             isCopied={copiedCellIdx === column.idx}
             isDraggedOver={draggedOverCellIdx === column.idx}

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -51,16 +51,6 @@ function Row<R, SR = unknown>({
     const colSpan = getColSpan(column, viewportColumns, { type: 'ROW', row });
     if (colSpan !== undefined) {
       index += colSpan - 1;
-      // If a cell within the colspan range is selected then move to the
-      // previous or the next cell depending on the navigation direction
-      const isColSpanCellSelected = selectedCellProps && selectedCellProps.idx > column.idx && selectedCellProps.idx < column.idx + colSpan;
-      if (isColSpanCellSelected) {
-        const { prevIdx } = selectedCellProps!;
-        selectCell({
-          rowIdx,
-          idx: column.idx + (column.idx - prevIdx >= 0 ? colSpan : 0)
-        });
-      }
     }
 
     const isCellSelected = selectedCellProps?.idx === column.idx;

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -15,6 +15,7 @@ function Row<R, SR = unknown>({
   isRowSelected,
   copiedCellIdx,
   draggedOverCellIdx,
+  lastFrozenColumnIndex,
   row,
   viewportColumns,
   selectedCellProps,
@@ -48,7 +49,7 @@ function Row<R, SR = unknown>({
   const cells = [];
   for (let index = 0; index < viewportColumns.length; index++) {
     const column = viewportColumns[index];
-    const colSpan = getColSpan(column, viewportColumns, { type: 'ROW', row });
+    const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'ROW', row });
     if (colSpan !== undefined) {
       index += colSpan - 1;
     }

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -44,7 +44,8 @@ function Row<R, SR = unknown>({
     className
   );
 
-  let colSpan: number | undefined;
+  let colSpan: number| undefined;
+  let colSpanIdx: number | undefined;
 
   return (
     <div
@@ -58,13 +59,21 @@ function Row<R, SR = unknown>({
       {...props}
     >
       {viewportColumns.map(column => {
+        const isCellSelected = selectedCellProps?.idx === column.idx;
         if (colSpan && colSpan > 1) {
           colSpan--;
+          if (isCellSelected) {
+            const { prevIdx } = selectedCellProps!;
+            selectCell({
+              rowIdx,
+              idx: colSpanIdx! + (column.idx - prevIdx > 0 ? colSpan + 1 : 0)
+            });
+          }
           return null;
         }
         colSpan = typeof column.colSpan === 'function' ? column.colSpan(row, 'ROW') : column.colSpan;
+        colSpanIdx = column.idx;
 
-        const isCellSelected = selectedCellProps?.idx === column.idx;
         if (selectedCellProps?.mode === 'EDIT' && isCellSelected) {
           return (
             <EditCell<R, SR>

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -44,7 +44,7 @@ function Row<R, SR = unknown>({
     className
   );
 
-  let colSpan: number| undefined;
+  let colSpan: number | undefined;
 
   return (
     <div
@@ -62,7 +62,7 @@ function Row<R, SR = unknown>({
           colSpan--;
           return null;
         }
-        colSpan = typeof column.colSpan === 'function' ? column.colSpan({ row, rowType: 'ROW' }) : column.colSpan;
+        colSpan = typeof column.colSpan === 'function' ? column.colSpan(row, 'ROW') : column.colSpan;
 
         const isCellSelected = selectedCellProps?.idx === column.idx;
         if (selectedCellProps?.mode === 'EDIT' && isCellSelected) {

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -49,7 +49,7 @@ function Row<R, SR = unknown>({
   for (let index = 0; index < viewportColumns.length; index++) {
     const column = viewportColumns[index];
     const colSpan = getColSpan(column, viewportColumns, { type: 'ROW', row });
-    if (colSpan && colSpan > 1) {
+    if (colSpan !== undefined) {
       index += colSpan - 1;
       // If a cell within the colspan range is selected then move to the
       // previous or the next cell depending on the navigation direction

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -3,6 +3,7 @@ import type { RefAttributes } from 'react';
 import clsx from 'clsx';
 
 import { groupRowSelectedClassname, rowClassname, rowSelectedClassname } from './style';
+import { getColSpan } from './utils';
 import Cell from './Cell';
 import EditCell from './EditCell';
 import type { RowRendererProps, SelectedCellProps } from './types';
@@ -47,20 +48,6 @@ function Row<R, SR = unknown>({
   let colSpan: number| undefined;
   let colSpanIdx: number | undefined;
 
-  function areColSpanColumnsCompatible(startIdx: number, colSpan: number) {
-    const isFrozen = viewportColumns[startIdx].frozen;
-    for (
-      let index = 1;
-      index < colSpan && startIdx + index < viewportColumns.length;
-      index++
-    ) {
-      if (viewportColumns[startIdx + index].frozen !== isFrozen) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   return (
     <div
       role="row"
@@ -87,12 +74,8 @@ function Row<R, SR = unknown>({
           }
           return null;
         }
-        colSpan = typeof column.colSpan === 'function' ? column.colSpan(row, 'ROW') : column.colSpan;
+        colSpan = getColSpan(column, viewportColumns, { type: 'ROW', row });
         colSpanIdx = column.idx;
-        if (colSpan && !areColSpanColumnsCompatible(colSpanIdx, colSpan)) {
-          // ignore colSpan if it spans over frozen and regular columns
-          colSpan = undefined;
-        }
 
         if (selectedCellProps?.mode === 'EDIT' && isCellSelected) {
           return (

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { getCellStyle, getCellClassname } from './utils';
 import type { CellRendererProps } from './types';
 
-type SharedCellRendererProps<R, SR> = Pick<CellRendererProps<R, SR>, 'column'>;
+type SharedCellRendererProps<R, SR> = Pick<CellRendererProps<R, SR>, 'column' | 'colSpan'>;
 
 interface SummaryCellProps<R, SR> extends SharedCellRendererProps<R, SR> {
   row: SR;
@@ -11,6 +11,7 @@ interface SummaryCellProps<R, SR> extends SharedCellRendererProps<R, SR> {
 
 function SummaryCell<R, SR>({
   column,
+  colSpan,
   row
 }: SummaryCellProps<R, SR>) {
   const { summaryFormatter: SummaryFormatter, summaryCellClass } = column;
@@ -23,7 +24,7 @@ function SummaryCell<R, SR>({
       role="gridcell"
       aria-colindex={column.idx + 1}
       className={className}
-      style={getCellStyle(column)}
+      style={getCellStyle(column, colSpan)}
     >
       {SummaryFormatter && <SummaryFormatter column={column} row={row} />}
     </div>

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -13,6 +13,7 @@ interface SummaryRowProps<R, SR> extends SharedRowRendererProps<R, SR> {
   'aria-rowindex': number;
   row: SR;
   bottom: number;
+  lastFrozenColumnIndex: number;
 }
 
 function SummaryRow<R, SR>({
@@ -20,12 +21,13 @@ function SummaryRow<R, SR>({
   row,
   viewportColumns,
   bottom,
+  lastFrozenColumnIndex,
   'aria-rowindex': ariaRowIndex
 }: SummaryRowProps<R, SR>) {
   const cells = [];
   for (let index = 0; index < viewportColumns.length; index++) {
     const column = viewportColumns[index];
-    const colSpan = getColSpan(column, viewportColumns, { type: 'HEADER' });
+    const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'HEADER' });
     if (colSpan !== undefined) {
       index += colSpan - 1;
     }

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -22,7 +22,23 @@ function SummaryRow<R, SR>({
   bottom,
   'aria-rowindex': ariaRowIndex
 }: SummaryRowProps<R, SR>) {
-  let colSpan: number| undefined;
+  const cells = [];
+  for (let index = 0; index < viewportColumns.length; index++) {
+    const column = viewportColumns[index];
+    const colSpan = getColSpan(column, viewportColumns, { type: 'HEADER' });
+    if (colSpan && colSpan > 1) {
+      index += colSpan - 1;
+    }
+
+    cells.push(
+      <SummaryCell<R, SR>
+        key={column.key}
+        column={column}
+        colSpan={colSpan}
+        row={row}
+      />
+    );
+  }
 
   return (
     <div
@@ -31,21 +47,7 @@ function SummaryRow<R, SR>({
       className={`${rowClassname} rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'} ${summaryRowClassname}`}
       style={{ bottom }}
     >
-      {viewportColumns.map(column => {
-        if (colSpan && colSpan > 1) {
-          colSpan--;
-          return null;
-        }
-        colSpan = getColSpan(column, viewportColumns, { type: 'SUMMARY', row });
-        return (
-          <SummaryCell<R, SR>
-            key={column.key}
-            column={column}
-            colSpan={colSpan}
-            row={row}
-          />
-        );
-      })}
+      {cells}
     </div>
   );
 }

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -26,7 +26,7 @@ function SummaryRow<R, SR>({
   for (let index = 0; index < viewportColumns.length; index++) {
     const column = viewportColumns[index];
     const colSpan = getColSpan(column, viewportColumns, { type: 'HEADER' });
-    if (colSpan && colSpan > 1) {
+    if (colSpan !== undefined) {
       index += colSpan - 1;
     }
 

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { rowClassname, summaryRowClassname } from './style';
+import { getColSpan } from './utils';
 import SummaryCell from './SummaryCell';
 import type { RowRendererProps } from './types';
 
@@ -21,6 +22,8 @@ function SummaryRow<R, SR>({
   bottom,
   'aria-rowindex': ariaRowIndex
 }: SummaryRowProps<R, SR>) {
+  let colSpan: number| undefined;
+
   return (
     <div
       role="row"
@@ -28,13 +31,21 @@ function SummaryRow<R, SR>({
       className={`${rowClassname} rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'} ${summaryRowClassname}`}
       style={{ bottom }}
     >
-      {viewportColumns.map(column => (
-        <SummaryCell<R, SR>
-          key={column.key}
-          column={column}
-          row={row}
-        />
-      ))}
+      {viewportColumns.map(column => {
+        if (colSpan && colSpan > 1) {
+          colSpan--;
+          return null;
+        }
+        colSpan = getColSpan(column, viewportColumns, { type: 'SUMMARY', row });
+        return (
+          <SummaryCell<R, SR>
+            key={column.key}
+            column={column}
+            colSpan={colSpan}
+            row={row}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useCalculatedColumns';
 export * from './useClickOutside';
 export * from './useGridDimensions';
 export * from './useViewportColumns';

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -1,0 +1,252 @@
+import { useMemo } from 'react';
+
+import type { CalculatedColumn, Column, ColumnMetric } from '../types';
+import type { DataGridProps } from '../DataGrid';
+import { ValueFormatter, ToggleGroupFormatter } from '../formatters';
+import { SELECT_COLUMN_KEY } from '../Columns';
+
+interface CalculatedColumnsArgs<R, SR> extends Pick<DataGridProps<R, SR>, 'defaultColumnOptions'> {
+  rawColumns: readonly Column<R, SR>[];
+  rawGroupBy?: readonly string[];
+  viewportWidth: number;
+  scrollLeft: number;
+  columnWidths: ReadonlyMap<string, number>;
+  enableVirtualization: boolean;
+}
+
+export function useCalculatedColumns<R, SR>({
+  rawColumns,
+  columnWidths,
+  viewportWidth,
+  scrollLeft,
+  defaultColumnOptions,
+  rawGroupBy,
+  enableVirtualization
+}: CalculatedColumnsArgs<R, SR>) {
+  const minColumnWidth = defaultColumnOptions?.minWidth ?? 80;
+  const defaultFormatter = defaultColumnOptions?.formatter ?? ValueFormatter;
+  const defaultSortable = defaultColumnOptions?.sortable ?? false;
+  const defaultResizable = defaultColumnOptions?.resizable ?? false;
+
+  const { columns, lastFrozenColumnIndex, groupBy } = useMemo(() => {
+    // Filter rawGroupBy and ignore keys that do not match the columns prop
+    const groupBy: string[] = [];
+    let lastFrozenColumnIndex = -1;
+
+    const columns = rawColumns.map(rawColumn => {
+      const rowGroup = rawGroupBy?.includes(rawColumn.key) ?? false;
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const frozen = rowGroup || rawColumn.frozen || false;
+
+      const column: CalculatedColumn<R, SR> = {
+        ...rawColumn,
+        idx: 0,
+        frozen,
+        isLastFrozenColumn: false,
+        rowGroup,
+        sortable: rawColumn.sortable ?? defaultSortable,
+        resizable: rawColumn.resizable ?? defaultResizable,
+        formatter: rawColumn.formatter ?? defaultFormatter
+      };
+
+      if (rowGroup) {
+        column.groupFormatter ??= ToggleGroupFormatter;
+      }
+
+      if (frozen) {
+        lastFrozenColumnIndex++;
+      }
+
+      return column;
+    });
+
+    columns.sort(({ key: aKey, frozen: frozenA }, { key: bKey, frozen: frozenB }) => {
+      // Sort select column first:
+      if (aKey === SELECT_COLUMN_KEY) return -1;
+      if (bKey === SELECT_COLUMN_KEY) return 1;
+
+      // Sort grouped columns second, following the groupBy order:
+      if (rawGroupBy?.includes(aKey)) {
+        if (rawGroupBy.includes(bKey)) {
+          return rawGroupBy.indexOf(aKey) - rawGroupBy.indexOf(bKey);
+        }
+        return -1;
+      }
+      if (rawGroupBy?.includes(bKey)) return 1;
+
+      // Sort frozen columns third:
+      if (frozenA) {
+        if (frozenB) return 0;
+        return -1;
+      }
+      if (frozenB) return 1;
+
+      // Sort other columns last:
+      return 0;
+    });
+
+    columns.forEach((column, idx) => {
+      column.idx = idx;
+
+      if (column.rowGroup) {
+        groupBy.push(column.key);
+      }
+    });
+
+    if (lastFrozenColumnIndex !== -1) {
+      columns[lastFrozenColumnIndex].isLastFrozenColumn = true;
+    }
+
+    return {
+      columns,
+      lastFrozenColumnIndex,
+      groupBy
+    };
+  }, [rawColumns, defaultFormatter, defaultResizable, defaultSortable, rawGroupBy]);
+
+  const { layoutCssVars, totalColumnWidth, totalFrozenColumnWidth, columnMetrics } = useMemo(() => {
+    const columnMetrics = new Map<CalculatedColumn<R, SR>, ColumnMetric>();
+    let left = 0;
+    let totalColumnWidth = 0;
+    let totalFrozenColumnWidth = 0;
+    let templateColumns = '';
+    let allocatedWidth = 0;
+    let unassignedColumnsCount = 0;
+
+    for (const column of columns) {
+      let width = getSpecifiedWidth(column, columnWidths, viewportWidth);
+
+      if (width === undefined) {
+        unassignedColumnsCount++;
+      } else {
+        width = clampColumnWidth(width, column, minColumnWidth);
+        allocatedWidth += width;
+        columnMetrics.set(column, { width, left: 0 });
+      }
+    }
+
+    const unallocatedWidth = viewportWidth - allocatedWidth;
+    const unallocatedColumnWidth = unallocatedWidth / unassignedColumnsCount;
+
+    for (const column of columns) {
+      let width;
+      if (columnMetrics.has(column)) {
+        const columnMetric = columnMetrics.get(column)!;
+        columnMetric.left = left;
+        ({ width } = columnMetric);
+      } else {
+        width = clampColumnWidth(unallocatedColumnWidth, column, minColumnWidth);
+        columnMetrics.set(column, { width, left });
+      }
+      totalColumnWidth += width;
+      left += width;
+      templateColumns += `${width}px `;
+    }
+
+    if (lastFrozenColumnIndex !== -1) {
+      const columnMetric = columnMetrics.get(columns[lastFrozenColumnIndex])!;
+      totalFrozenColumnWidth = columnMetric.left + columnMetric.width;
+    }
+
+    const layoutCssVars: Record<string, string> = {
+      '--template-columns': templateColumns
+    };
+
+    for (let i = 0; i <= lastFrozenColumnIndex; i++) {
+      const column = columns[i];
+      layoutCssVars[`--frozen-left-${column.key}`] = `${columnMetrics.get(column)!.left}px`;
+    }
+
+    return { layoutCssVars, totalColumnWidth, totalFrozenColumnWidth, columnMetrics };
+  }, [columnWidths, columns, viewportWidth, minColumnWidth, lastFrozenColumnIndex]);
+
+  const [colOverscanStartIdx, colOverscanEndIdx] = useMemo((): [number, number] => {
+    if (!enableVirtualization) {
+      return [0, columns.length - 1];
+    }
+    // get the viewport's left side and right side positions for non-frozen columns
+    const viewportLeft = scrollLeft + totalFrozenColumnWidth;
+    const viewportRight = scrollLeft + viewportWidth;
+    // get first and last non-frozen column indexes
+    const lastColIdx = columns.length - 1;
+    const firstUnfrozenColumnIdx = Math.min(lastFrozenColumnIndex + 1, lastColIdx);
+
+    // skip rendering non-frozen columns if the frozen columns cover the entire viewport
+    if (viewportLeft >= viewportRight) {
+      return [firstUnfrozenColumnIdx, firstUnfrozenColumnIdx];
+    }
+
+    // get the first visible non-frozen column index
+    let colVisibleStartIdx = firstUnfrozenColumnIdx;
+    while (colVisibleStartIdx < lastColIdx) {
+      const { left, width } = columnMetrics.get(columns[colVisibleStartIdx])!;
+      // if the right side of the columnn is beyond the left side of the available viewport,
+      // then it is the first column that's at least partially visible
+      if (left + width > viewportLeft) {
+        break;
+      }
+      colVisibleStartIdx++;
+    }
+
+    // get the last visible non-frozen column index
+    let colVisibleEndIdx = colVisibleStartIdx;
+    while (colVisibleEndIdx < lastColIdx) {
+      const { left, width } = columnMetrics.get(columns[colVisibleEndIdx])!;
+      // if the right side of the column is beyond or equal to the right side of the available viewport,
+      // then it the last column that's at least partially visible, as the previous column's right side is not beyond the viewport.
+      if (left + width >= viewportRight) {
+        break;
+      }
+      colVisibleEndIdx++;
+    }
+
+    const colOverscanStartIdx = Math.max(firstUnfrozenColumnIdx, colVisibleStartIdx - 1);
+    const colOverscanEndIdx = Math.min(lastColIdx, colVisibleEndIdx + 1);
+
+    return [colOverscanStartIdx, colOverscanEndIdx];
+  }, [columnMetrics, columns, lastFrozenColumnIndex, scrollLeft, totalFrozenColumnWidth, viewportWidth, enableVirtualization]);
+
+  return {
+    columns,
+    colOverscanStartIdx,
+    colOverscanEndIdx,
+    layoutCssVars,
+    columnMetrics,
+    totalColumnWidth,
+    lastFrozenColumnIndex,
+    totalFrozenColumnWidth,
+    groupBy
+  };
+}
+
+function getSpecifiedWidth<R, SR>(
+  { key, width }: Column<R, SR>,
+  columnWidths: ReadonlyMap<string, number>,
+  viewportWidth: number
+): number | undefined {
+  if (columnWidths.has(key)) {
+    // Use the resized width if available
+    return columnWidths.get(key);
+  }
+  if (typeof width === 'number') {
+    return width;
+  }
+  if (typeof width === 'string' && /^\d+%$/.test(width)) {
+    return Math.floor(viewportWidth * parseInt(width, 10) / 100);
+  }
+  return undefined;
+}
+
+function clampColumnWidth<R, SR>(
+  width: number,
+  { minWidth, maxWidth }: Column<R, SR>,
+  minColumnWidth: number
+): number {
+  width = Math.max(width, minWidth ?? minColumnWidth);
+
+  if (typeof maxWidth === 'number') {
+    return Math.min(width, maxWidth);
+  }
+
+  return width;
+}

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -28,7 +28,7 @@ export function useCalculatedColumns<R, SR>({
   const defaultSortable = defaultColumnOptions?.sortable ?? false;
   const defaultResizable = defaultColumnOptions?.resizable ?? false;
 
-  const { columns, lastFrozenColumnIndex, groupBy } = useMemo(() => {
+  const { columns, colSpanColumns, lastFrozenColumnIndex, groupBy } = useMemo(() => {
     // Filter rawGroupBy and ignore keys that do not match the columns prop
     const groupBy: string[] = [];
     let lastFrozenColumnIndex = -1;
@@ -85,11 +85,16 @@ export function useCalculatedColumns<R, SR>({
       return 0;
     });
 
+    const colSpanColumns: CalculatedColumn<R, SR>[] = [];
     columns.forEach((column, idx) => {
       column.idx = idx;
 
       if (column.rowGroup) {
         groupBy.push(column.key);
+      }
+
+      if (column.colSpan) {
+        colSpanColumns.push(column);
       }
     });
 
@@ -99,6 +104,7 @@ export function useCalculatedColumns<R, SR>({
 
     return {
       columns,
+      colSpanColumns,
       lastFrozenColumnIndex,
       groupBy
     };
@@ -129,7 +135,7 @@ export function useCalculatedColumns<R, SR>({
     const unallocatedColumnWidth = unallocatedWidth / unassignedColumnsCount;
 
     for (const column of columns) {
-      let width;
+      let width: number;
       if (columnMetrics.has(column)) {
         const columnMetric = columnMetrics.get(column)!;
         columnMetric.left = left;
@@ -208,6 +214,7 @@ export function useCalculatedColumns<R, SR>({
 
   return {
     columns,
+    colSpanColumns,
     colOverscanStartIdx,
     colOverscanEndIdx,
     layoutCssVars,

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -93,7 +93,7 @@ export function useCalculatedColumns<R, SR>({
         groupBy.push(column.key);
       }
 
-      if (column.colSpan) {
+      if (column.colSpan !== undefined) {
         colSpanColumns.push(column);
       }
     });

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -36,28 +36,24 @@ export function useViewportColumns<R, SR>({
       }
     };
 
-    // check header
     for (let colIdx = 0; colIdx < colOverscanStartIdx; colIdx++) {
+      // check header
       const column = columns[colIdx];
       const colSpan = getColSpan(column, columns, { type: 'HEADER' });
       updateStartIdx(colIdx, colSpan);
-    }
 
-    // check viewport
-    for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
-      const row = rows[rowIdx];
-      if (isGroupRow(row)) continue;
-      for (let colIdx = 0; colIdx < colOverscanStartIdx; colIdx++) {
+      // check viewport
+      for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
+        const row = rows[rowIdx];
+        if (isGroupRow(row)) continue;
         const column = columns[colIdx];
         const colSpan = getColSpan(column, columns, { type: 'ROW', row });
         updateStartIdx(colIdx, colSpan);
       }
-    }
 
-    // check summary rows
-    if (summaryRows) {
-      for (const row of summaryRows) {
-        for (let colIdx = 0; colIdx < colOverscanStartIdx; colIdx++) {
+      // check summary rows
+      if (summaryRows) {
+        for (const row of summaryRows) {
           const column = columns[colIdx];
           const colSpan = getColSpan(column, columns, { type: 'SUMMARY', row });
           updateStartIdx(colIdx, colSpan);

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -34,8 +34,7 @@ export function useViewportColumns<R, SR>({
 
     const updateStartIdx = (colIdx: number, colSpan: number | undefined) => {
       if (!colSpan) return;
-      const newStartIdx = colIdx + colSpan;
-      if (newStartIdx > colOverscanStartIdx && colIdx < startIdx) {
+      if ((colIdx + colSpan) > colOverscanStartIdx && colIdx < startIdx) {
         startIdx = colIdx;
       }
     };

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -37,8 +37,7 @@ export function useViewportColumns<R, SR>({
     let startIdx = colOverscanStartIdx;
 
     const updateStartIdx = (colIdx: number, colSpan: number | undefined) => {
-      if (!colSpan) return false;
-      if ((colIdx + colSpan) > colOverscanStartIdx && colIdx < startIdx) {
+      if (colSpan !== undefined && (colIdx + colSpan) > colOverscanStartIdx) {
         startIdx = colIdx;
         return true;
       }

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -7,26 +7,42 @@ interface ViewportColumnsArgs<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
   colOverscanStartIdx: number;
   colOverscanEndIdx: number;
+  rowOverscanStartIdx: number;
+  rowOverscanEndIdx: number;
   rows: readonly (R | GroupRow<R>)[];
   isGroupRow: (row: R | GroupRow<R>) => row is GroupRow<R>;
 }
 
-export function useViewportColumns<R, SR>({ columns, colOverscanStartIdx, colOverscanEndIdx, rows, isGroupRow }: ViewportColumnsArgs<R, SR>) {
-  return useMemo((): readonly CalculatedColumn<R, SR>[] => {
+export function useViewportColumns<R, SR>({
+  columns,
+  colOverscanStartIdx,
+  colOverscanEndIdx,
+  rowOverscanStartIdx,
+  rowOverscanEndIdx,
+  rows,
+  isGroupRow
+}: ViewportColumnsArgs<R, SR>) {
+  const startIdx = useMemo(() => {
     let startIdx = colOverscanStartIdx;
     // find the column that spans over a column within the visible columns range and adjust colOverscanStartIdx
-    for (const row of rows) {
+    for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
+      const row = rows[rowIdx];
       if (isGroupRow(row)) continue;
-      for (let colIdx = 0; colIdx <= colOverscanStartIdx; colIdx++) {
+      for (let colIdx = 0; colIdx < colOverscanStartIdx; colIdx++) {
         const column = columns[colIdx];
-        const colSpan = getColSpan<R, SR>(column, columns, { type: 'ROW', row });
+        const colSpan = getColSpan(column, columns, { type: 'ROW', row });
         if (!colSpan) continue;
-        if ((colSpan + column.idx - 1) > startIdx) {
-          startIdx = column.idx;
+        const newStartIdx = colIdx + colSpan;
+        if (newStartIdx > colOverscanStartIdx && colIdx < startIdx) {
+          startIdx = colIdx;
         }
       }
     }
 
+    return startIdx;
+  }, [colOverscanStartIdx, columns, isGroupRow, rowOverscanEndIdx, rowOverscanStartIdx, rows]);
+
+  return useMemo((): readonly CalculatedColumn<R, SR>[] => {
     const viewportColumns: CalculatedColumn<R, SR>[] = [];
     for (let colIdx = 0; colIdx <= colOverscanEndIdx; colIdx++) {
       const column = columns[colIdx];
@@ -36,5 +52,5 @@ export function useViewportColumns<R, SR>({ columns, colOverscanStartIdx, colOve
     }
 
     return viewportColumns;
-  }, [colOverscanEndIdx, colOverscanStartIdx, columns, isGroupRow, rows]);
+  }, [startIdx, colOverscanEndIdx, columns]);
 }

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -42,7 +42,7 @@ export function useViewportColumns<R, SR>({
     for (const column of colSpanColumns) {
       // check header row
       const colIdx = column.idx;
-      if (colIdx >= colOverscanStartIdx) break;
+      if (colIdx >= startIdx) break;
       updateStartIdx(colIdx, getColSpan(column, columns, { type: 'HEADER' }));
 
       // check filter row

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -67,7 +67,7 @@ export function useViewportColumns<R, SR>({
     }
 
     return startIdx;
-  }, [colOverscanStartIdx, colSpanColumns, columns, enableFilterRow, isGroupRow, rowOverscanEndIdx, rowOverscanStartIdx, rows, summaryRows]);
+  }, [rowOverscanStartIdx, rowOverscanEndIdx, rows, summaryRows, colOverscanStartIdx, columns, colSpanColumns, isGroupRow, enableFilterRow]);
 
   return useMemo((): readonly CalculatedColumn<R, SR>[] => {
     const viewportColumns: CalculatedColumn<R, SR>[] = [];

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -10,6 +10,7 @@ interface ViewportColumnsArgs<R, SR> {
   summaryRows: readonly SR[] | undefined;
   colOverscanStartIdx: number;
   colOverscanEndIdx: number;
+  lastFrozenColumnIndex: number;
   rowOverscanStartIdx: number;
   rowOverscanEndIdx: number;
   enableFilterRow: boolean;
@@ -23,6 +24,7 @@ export function useViewportColumns<R, SR>({
   summaryRows,
   colOverscanStartIdx,
   colOverscanEndIdx,
+  lastFrozenColumnIndex,
   rowOverscanStartIdx,
   rowOverscanEndIdx,
   enableFilterRow,
@@ -47,28 +49,28 @@ export function useViewportColumns<R, SR>({
       // check header row
       const colIdx = column.idx;
       if (colIdx >= startIdx) break;
-      if (updateStartIdx(colIdx, getColSpan(column, columns, { type: 'HEADER' }))) break;
+      if (updateStartIdx(colIdx, getColSpan(column, lastFrozenColumnIndex, { type: 'HEADER' }))) break;
 
       // check filter row
-      if (enableFilterRow && updateStartIdx(colIdx, getColSpan(column, columns, { type: 'FILTER' }))) break;
+      if (enableFilterRow && updateStartIdx(colIdx, getColSpan(column, lastFrozenColumnIndex, { type: 'FILTER' }))) break;
 
       // check viewport rows
       for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
         const row = rows[rowIdx];
         if (isGroupRow(row)) continue;
-        if (updateStartIdx(colIdx, getColSpan(column, columns, { type: 'ROW', row }))) break;
+        if (updateStartIdx(colIdx, getColSpan(column, lastFrozenColumnIndex, { type: 'ROW', row }))) break;
       }
 
       // check summary rows
       if (summaryRows !== undefined) {
         for (const row of summaryRows) {
-          if (updateStartIdx(colIdx, getColSpan(column, columns, { type: 'SUMMARY', row }))) break;
+          if (updateStartIdx(colIdx, getColSpan(column, lastFrozenColumnIndex, { type: 'SUMMARY', row }))) break;
         }
       }
     }
 
     return startIdx;
-  }, [rowOverscanStartIdx, rowOverscanEndIdx, rows, summaryRows, colOverscanStartIdx, columns, colSpanColumns, isGroupRow, enableFilterRow]);
+  }, [rowOverscanStartIdx, rowOverscanEndIdx, rows, summaryRows, colOverscanStartIdx, lastFrozenColumnIndex, colSpanColumns, isGroupRow, enableFilterRow]);
 
   return useMemo((): readonly CalculatedColumn<R, SR>[] => {
     const viewportColumns: CalculatedColumn<R, SR>[] = [];

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -35,34 +35,34 @@ export function useViewportColumns<R, SR>({
     let startIdx = colOverscanStartIdx;
 
     const updateStartIdx = (colIdx: number, colSpan: number | undefined) => {
-      if (!colSpan) return;
+      if (!colSpan) return false;
       if ((colIdx + colSpan) > colOverscanStartIdx && colIdx < startIdx) {
         startIdx = colIdx;
+        return true;
       }
+      return false;
     };
 
     for (const column of colSpanColumns) {
       // check header row
       const colIdx = column.idx;
       if (colIdx >= startIdx) break;
-      updateStartIdx(colIdx, getColSpan(column, columns, { type: 'HEADER' }));
+      if (updateStartIdx(colIdx, getColSpan(column, columns, { type: 'HEADER' }))) break;
 
       // check filter row
-      if (enableFilterRow) {
-        updateStartIdx(colIdx, getColSpan(column, columns, { type: 'FILTER' }));
-      }
+      if (enableFilterRow && updateStartIdx(colIdx, getColSpan(column, columns, { type: 'FILTER' }))) break;
 
       // check viewport rows
       for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
         const row = rows[rowIdx];
         if (isGroupRow(row)) continue;
-        updateStartIdx(colIdx, getColSpan(column, columns, { type: 'ROW', row }));
+        if (updateStartIdx(colIdx, getColSpan(column, columns, { type: 'ROW', row }))) break;
       }
 
       // check summary rows
       if (summaryRows !== undefined) {
         for (const row of summaryRows) {
-          updateStartIdx(colIdx, getColSpan(column, columns, { type: 'SUMMARY', row }));
+          if (updateStartIdx(colIdx, getColSpan(column, columns, { type: 'SUMMARY', row }))) break;
         }
       }
     }

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -59,7 +59,7 @@ export function useViewportColumns<R, SR>({
       }
 
       // check summary rows
-      if (summaryRows) {
+      if (summaryRows !== undefined) {
         for (const row of summaryRows) {
           updateStartIdx(colIdx, getColSpan(column, columns, { type: 'SUMMARY', row }));
         }

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -30,6 +30,8 @@ export function useViewportColumns<R, SR>({
 }: ViewportColumnsArgs<R, SR>) {
   // find the column that spans over a column within the visible columns range and adjust colOverscanStartIdx
   const startIdx = useMemo(() => {
+    if (colOverscanStartIdx === 0) return 0;
+
     let startIdx = colOverscanStartIdx;
 
     const updateStartIdx = (colIdx: number, colSpan: number | undefined) => {

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -5,6 +5,7 @@ import type { CalculatedColumn, GroupRow } from '../types';
 
 interface ViewportColumnsArgs<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
+  colSpanColumns: readonly CalculatedColumn<R, SR>[];
   rows: readonly (R | GroupRow<R>)[];
   summaryRows: readonly SR[] | undefined;
   colOverscanStartIdx: number;
@@ -16,6 +17,7 @@ interface ViewportColumnsArgs<R, SR> {
 
 export function useViewportColumns<R, SR>({
   columns,
+  colSpanColumns,
   rows,
   summaryRows,
   colOverscanStartIdx,
@@ -36,9 +38,10 @@ export function useViewportColumns<R, SR>({
       }
     };
 
-    for (let colIdx = 0; colIdx < colOverscanStartIdx; colIdx++) {
+    for (const column of colSpanColumns) {
       // check header
-      const column = columns[colIdx];
+      const colIdx = column.idx;
+      if (colIdx >= colOverscanStartIdx) break;
       const colSpan = getColSpan(column, columns, { type: 'HEADER' });
       updateStartIdx(colIdx, colSpan);
 
@@ -62,7 +65,7 @@ export function useViewportColumns<R, SR>({
     }
 
     return startIdx;
-  }, [colOverscanStartIdx, columns, isGroupRow, rowOverscanEndIdx, rowOverscanStartIdx, rows, summaryRows]);
+  }, [colOverscanStartIdx, colSpanColumns, columns, isGroupRow, rowOverscanEndIdx, rowOverscanStartIdx, rows, summaryRows]);
 
   return useMemo((): readonly CalculatedColumn<R, SR>[] => {
     const viewportColumns: CalculatedColumn<R, SR>[] = [];

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -1,254 +1,40 @@
 import { useMemo } from 'react';
 
-import type { CalculatedColumn, Column, ColumnMetric } from '../types';
-import type { DataGridProps } from '../DataGrid';
-import { ValueFormatter, ToggleGroupFormatter } from '../formatters';
-import { SELECT_COLUMN_KEY } from '../Columns';
+import { getColSpan } from '../utils';
+import type { CalculatedColumn, GroupRow } from '../types';
 
-interface ViewportColumnsArgs<R, SR> extends Pick<DataGridProps<R, SR>, 'defaultColumnOptions'> {
-  rawColumns: readonly Column<R, SR>[];
-  rawGroupBy?: readonly string[];
-  viewportWidth: number;
-  scrollLeft: number;
-  columnWidths: ReadonlyMap<string, number>;
-  enableVirtualization: boolean;
+interface ViewportColumnsArgs<R, SR> {
+  columns: readonly CalculatedColumn<R, SR>[];
+  colOverscanStartIdx: number;
+  colOverscanEndIdx: number;
+  rows: readonly (R | GroupRow<R>)[];
+  isGroupRow: (row: R | GroupRow<R>) => row is GroupRow<R>;
 }
 
-export function useViewportColumns<R, SR>({
-  rawColumns,
-  columnWidths,
-  viewportWidth,
-  scrollLeft,
-  defaultColumnOptions,
-  rawGroupBy,
-  enableVirtualization
-}: ViewportColumnsArgs<R, SR>) {
-  const minColumnWidth = defaultColumnOptions?.minWidth ?? 80;
-  const defaultFormatter = defaultColumnOptions?.formatter ?? ValueFormatter;
-  const defaultSortable = defaultColumnOptions?.sortable ?? false;
-  const defaultResizable = defaultColumnOptions?.resizable ?? false;
-
-  const { columns, lastFrozenColumnIndex, groupBy } = useMemo(() => {
-    // Filter rawGroupBy and ignore keys that do not match the columns prop
-    const groupBy: string[] = [];
-    let lastFrozenColumnIndex = -1;
-
-    const columns = rawColumns.map(rawColumn => {
-      const rowGroup = rawGroupBy?.includes(rawColumn.key) ?? false;
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      const frozen = rowGroup || rawColumn.frozen || false;
-
-      const column: CalculatedColumn<R, SR> = {
-        ...rawColumn,
-        idx: 0,
-        frozen,
-        isLastFrozenColumn: false,
-        rowGroup,
-        sortable: rawColumn.sortable ?? defaultSortable,
-        resizable: rawColumn.resizable ?? defaultResizable,
-        formatter: rawColumn.formatter ?? defaultFormatter
-      };
-
-      if (rowGroup) {
-        column.groupFormatter ??= ToggleGroupFormatter;
-      }
-
-      if (frozen) {
-        lastFrozenColumnIndex++;
-      }
-
-      return column;
-    });
-
-    columns.sort(({ key: aKey, frozen: frozenA }, { key: bKey, frozen: frozenB }) => {
-      // Sort select column first:
-      if (aKey === SELECT_COLUMN_KEY) return -1;
-      if (bKey === SELECT_COLUMN_KEY) return 1;
-
-      // Sort grouped columns second, following the groupBy order:
-      if (rawGroupBy?.includes(aKey)) {
-        if (rawGroupBy.includes(bKey)) {
-          return rawGroupBy.indexOf(aKey) - rawGroupBy.indexOf(bKey);
+export function useViewportColumns<R, SR>({ columns, colOverscanStartIdx, colOverscanEndIdx, rows, isGroupRow }: ViewportColumnsArgs<R, SR>) {
+  return useMemo((): readonly CalculatedColumn<R, SR>[] => {
+    let startIdx = colOverscanStartIdx;
+    // find the column that spans over a column within the visible columns range and adjust colOverscanStartIdx
+    for (const row of rows) {
+      if (isGroupRow(row)) continue;
+      for (let colIdx = 0; colIdx <= colOverscanStartIdx; colIdx++) {
+        const column = columns[colIdx];
+        const colSpan = getColSpan<R, SR>(column, columns, { type: 'ROW', row });
+        if (!colSpan) continue;
+        if ((colSpan + column.idx - 1) > startIdx) {
+          startIdx = column.idx;
         }
-        return -1;
-      }
-      if (rawGroupBy?.includes(bKey)) return 1;
-
-      // Sort frozen columns third:
-      if (frozenA) {
-        if (frozenB) return 0;
-        return -1;
-      }
-      if (frozenB) return 1;
-
-      // Sort other columns last:
-      return 0;
-    });
-
-    columns.forEach((column, idx) => {
-      column.idx = idx;
-
-      if (column.rowGroup) {
-        groupBy.push(column.key);
-      }
-    });
-
-    if (lastFrozenColumnIndex !== -1) {
-      columns[lastFrozenColumnIndex].isLastFrozenColumn = true;
-    }
-
-    return {
-      columns,
-      lastFrozenColumnIndex,
-      groupBy
-    };
-  }, [rawColumns, defaultFormatter, defaultResizable, defaultSortable, rawGroupBy]);
-
-  const { layoutCssVars, totalColumnWidth, totalFrozenColumnWidth, columnMetrics } = useMemo(() => {
-    const columnMetrics = new Map<CalculatedColumn<R, SR>, ColumnMetric>();
-    let left = 0;
-    let totalColumnWidth = 0;
-    let totalFrozenColumnWidth = 0;
-    let templateColumns = '';
-    let allocatedWidth = 0;
-    let unassignedColumnsCount = 0;
-
-    for (const column of columns) {
-      let width = getSpecifiedWidth(column, columnWidths, viewportWidth);
-
-      if (width === undefined) {
-        unassignedColumnsCount++;
-      } else {
-        width = clampColumnWidth(width, column, minColumnWidth);
-        allocatedWidth += width;
-        columnMetrics.set(column, { width, left: 0 });
       }
     }
 
-    const unallocatedWidth = viewportWidth - allocatedWidth;
-    const unallocatedColumnWidth = unallocatedWidth / unassignedColumnsCount;
-
-    for (const column of columns) {
-      let width;
-      if (columnMetrics.has(column)) {
-        const columnMetric = columnMetrics.get(column)!;
-        columnMetric.left = left;
-        ({ width } = columnMetric);
-      } else {
-        width = clampColumnWidth(unallocatedColumnWidth, column, minColumnWidth);
-        columnMetrics.set(column, { width, left });
-      }
-      totalColumnWidth += width;
-      left += width;
-      templateColumns += `${width}px `;
-    }
-
-    if (lastFrozenColumnIndex !== -1) {
-      const columnMetric = columnMetrics.get(columns[lastFrozenColumnIndex])!;
-      totalFrozenColumnWidth = columnMetric.left + columnMetric.width;
-    }
-
-    const layoutCssVars: Record<string, string> = {
-      '--template-columns': templateColumns
-    };
-
-    for (let i = 0; i <= lastFrozenColumnIndex; i++) {
-      const column = columns[i];
-      layoutCssVars[`--frozen-left-${column.key}`] = `${columnMetrics.get(column)!.left}px`;
-    }
-
-    return { layoutCssVars, totalColumnWidth, totalFrozenColumnWidth, columnMetrics };
-  }, [columnWidths, columns, viewportWidth, minColumnWidth, lastFrozenColumnIndex]);
-
-  const [colOverscanStartIdx, colOverscanEndIdx] = useMemo((): [number, number] => {
-    if (!enableVirtualization) {
-      return [0, columns.length - 1];
-    }
-    // get the viewport's left side and right side positions for non-frozen columns
-    const viewportLeft = scrollLeft + totalFrozenColumnWidth;
-    const viewportRight = scrollLeft + viewportWidth;
-    // get first and last non-frozen column indexes
-    const lastColIdx = columns.length - 1;
-    const firstUnfrozenColumnIdx = Math.min(lastFrozenColumnIndex + 1, lastColIdx);
-
-    // skip rendering non-frozen columns if the frozen columns cover the entire viewport
-    if (viewportLeft >= viewportRight) {
-      return [firstUnfrozenColumnIdx, firstUnfrozenColumnIdx];
-    }
-
-    // get the first visible non-frozen column index
-    let colVisibleStartIdx = firstUnfrozenColumnIdx;
-    while (colVisibleStartIdx < lastColIdx) {
-      const { left, width } = columnMetrics.get(columns[colVisibleStartIdx])!;
-      // if the right side of the columnn is beyond the left side of the available viewport,
-      // then it is the first column that's at least partially visible
-      if (left + width > viewportLeft) {
-        break;
-      }
-      colVisibleStartIdx++;
-    }
-
-    // get the last visible non-frozen column index
-    let colVisibleEndIdx = colVisibleStartIdx;
-    while (colVisibleEndIdx < lastColIdx) {
-      const { left, width } = columnMetrics.get(columns[colVisibleEndIdx])!;
-      // if the right side of the column is beyond or equal to the right side of the available viewport,
-      // then it the last column that's at least partially visible, as the previous column's right side is not beyond the viewport.
-      if (left + width >= viewportRight) {
-        break;
-      }
-      colVisibleEndIdx++;
-    }
-
-    const colOverscanStartIdx = Math.max(firstUnfrozenColumnIdx, colVisibleStartIdx - 1);
-    const colOverscanEndIdx = Math.min(lastColIdx, colVisibleEndIdx + 1);
-
-    return [colOverscanStartIdx, colOverscanEndIdx];
-  }, [columnMetrics, columns, lastFrozenColumnIndex, scrollLeft, totalFrozenColumnWidth, viewportWidth, enableVirtualization]);
-
-  const viewportColumns = useMemo((): readonly CalculatedColumn<R, SR>[] => {
     const viewportColumns: CalculatedColumn<R, SR>[] = [];
     for (let colIdx = 0; colIdx <= colOverscanEndIdx; colIdx++) {
       const column = columns[colIdx];
 
-      if (colIdx < colOverscanStartIdx && !column.frozen) continue;
+      if (colIdx < startIdx && !column.frozen) continue;
       viewportColumns.push(column);
     }
 
     return viewportColumns;
-  }, [colOverscanEndIdx, colOverscanStartIdx, columns]);
-
-  return { columns, viewportColumns, layoutCssVars, columnMetrics, totalColumnWidth, lastFrozenColumnIndex, totalFrozenColumnWidth, groupBy };
-}
-
-function getSpecifiedWidth<R, SR>(
-  { key, width }: Column<R, SR>,
-  columnWidths: ReadonlyMap<string, number>,
-  viewportWidth: number
-): number | undefined {
-  if (columnWidths.has(key)) {
-    // Use the resized width if available
-    return columnWidths.get(key);
-  }
-  if (typeof width === 'number') {
-    return width;
-  }
-  if (typeof width === 'string' && /^\d+%$/.test(width)) {
-    return Math.floor(viewportWidth * parseInt(width, 10) / 100);
-  }
-  return undefined;
-}
-
-function clampColumnWidth<R, SR>(
-  width: number,
-  { minWidth, maxWidth }: Column<R, SR>,
-  minColumnWidth: number
-): number {
-  width = Math.max(width, minWidth ?? minColumnWidth);
-
-  if (typeof maxWidth === 'number') {
-    return Math.min(width, maxWidth);
-  }
-
-  return width;
+  }, [colOverscanEndIdx, colOverscanStartIdx, columns, isGroupRow, rows]);
 }

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -50,9 +50,9 @@ export function useViewportRows<R>({
     return groupRows(rawRows, groupBy, 0);
   }, [groupBy, rowGrouper, rawRows]);
 
-  const [rows, allGroupRows] = useMemo(() => {
+  const [rows, isGroupRow] = useMemo(() => {
     const allGroupRows = new Set<unknown>();
-    if (!groupedRows) return [rawRows, allGroupRows];
+    if (!groupedRows) return [rawRows, isGroupRow];
 
     const flattenedRows: Array<R | GroupRow<R>> = [];
     const expandGroup = (rows: GroupByDictionary<R> | readonly R[], parentId: string | undefined, level: number): void => {
@@ -87,10 +87,13 @@ export function useViewportRows<R>({
     };
 
     expandGroup(groupedRows, undefined, 0);
-    return [flattenedRows, allGroupRows];
+    return [flattenedRows, isGroupRow];
+
+    function isGroupRow(row: R | GroupRow<R>): row is GroupRow<R> {
+      return allGroupRows.has(row);
+    }
   }, [expandedGroupIds, groupedRows, rawRows]);
 
-  const isGroupRow = <R>(row: unknown): row is GroupRow<R> => allGroupRows.has(row);
 
   if (!enableVirtualization) {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,5 +23,6 @@ export type {
   FillEvent,
   PasteEvent,
   CellNavigationMode,
-  SortDirection
+  SortDirection,
+  ColSpanArgs
 } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,5 @@ export type {
   FillEvent,
   PasteEvent,
   CellNavigationMode,
-  SortDirection,
-  RowType
+  SortDirection
 } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,5 +23,6 @@ export type {
   FillEvent,
   PasteEvent,
   CellNavigationMode,
-  SortDirection
+  SortDirection,
+  RowType
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
   groupFormatter?: React.ComponentType<GroupFormatterProps<TRow, TSummaryRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((row: TRow) => boolean);
-  colSpan?: number | ((row: TRow, rowType: RowType) => number | undefined);
+  colSpan?: number | ((params: ColSpanParams<TRow, TSummaryRow>) => number | undefined);
   /** Determines whether column is frozen or not */
   frozen?: boolean;
   /** Enable resizing of a column */
@@ -229,4 +229,16 @@ export interface GroupRow<TRow> {
 
 export type CellNavigationMode = 'NONE' | 'CHANGE_ROW' | 'LOOP_OVER_ROW';
 export type SortDirection = 'ASC' | 'DESC' | 'NONE';
-export type RowType = 'HEADER' | 'FILTER' | 'ROW' | 'GROUP' | 'SUMMARY';
+
+export type ColSpanParams<R, SR> = {
+  type: 'HEADER' | 'FILTER';
+} | {
+  type: 'ROW';
+  row: R;
+} | {
+  type: 'GROUP';
+  row: GroupRow<R>;
+} | {
+  type: 'SUMMARY';
+  row: SR;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
   groupFormatter?: React.ComponentType<GroupFormatterProps<TRow, TSummaryRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((row: TRow) => boolean);
+  colSpan?: number | (({ row, rowType }: { row: TRow; rowType: RowType }) => number | undefined) ;
   /** Determines whether column is frozen or not */
   frozen?: boolean;
   /** Enable resizing of a column */
@@ -144,6 +145,7 @@ export interface SelectedCellProps extends SelectedCellPropsBase {
 export interface CellRendererProps<TRow, TSummaryRow = unknown> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
   rowIdx: number;
   column: CalculatedColumn<TRow, TSummaryRow>;
+  colSpan?: number;
   row: TRow;
   isCopied: boolean;
   isDraggedOver: boolean;
@@ -226,3 +228,4 @@ export interface GroupRow<TRow> {
 
 export type CellNavigationMode = 'NONE' | 'CHANGE_ROW' | 'LOOP_OVER_ROW';
 export type SortDirection = 'ASC' | 'DESC' | 'NONE';
+export type RowType = 'HEADER' | 'FILTER' | 'ROW' | 'GROUP' | 'SUMMARY';

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
   groupFormatter?: React.ComponentType<GroupFormatterProps<TRow, TSummaryRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((row: TRow) => boolean);
-  colSpan?: number | (({ row, rowType }: { row: TRow; rowType: RowType }) => number | undefined) ;
+  colSpan?: number | ((row: TRow, rowType: RowType) => number | undefined);
   /** Determines whether column is frozen or not */
   frozen?: boolean;
   /** Enable resizing of a column */

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,7 @@ export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
 
 interface SelectedCellPropsBase {
   idx: number;
+  prevIdx: number;
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,7 +128,6 @@ export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
 
 interface SelectedCellPropsBase {
   idx: number;
-  prevIdx: number;
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
   groupFormatter?: React.ComponentType<GroupFormatterProps<TRow, TSummaryRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((row: TRow) => boolean);
-  colSpan?: number | ((params: ColSpanArgs<TRow, TSummaryRow>) => number | undefined);
+  colSpan?: ((args: ColSpanArgs<TRow, TSummaryRow>) => number | undefined);
   /** Determines whether column is frozen or not */
   frozen?: boolean;
   /** Enable resizing of a column */

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,9 +236,6 @@ export type ColSpanParams<R, SR> = {
   type: 'ROW';
   row: R;
 } | {
-  type: 'GROUP';
-  row: GroupRow<R>;
-} | {
   type: 'SUMMARY';
   row: SR;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
   groupFormatter?: React.ComponentType<GroupFormatterProps<TRow, TSummaryRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((row: TRow) => boolean);
-  colSpan?: number | ((params: ColSpanParams<TRow, TSummaryRow>) => number | undefined);
+  colSpan?: number | ((params: ColSpanArgs<TRow, TSummaryRow>) => number | undefined);
   /** Determines whether column is frozen or not */
   frozen?: boolean;
   /** Enable resizing of a column */
@@ -230,7 +230,7 @@ export interface GroupRow<TRow> {
 export type CellNavigationMode = 'NONE' | 'CHANGE_ROW' | 'LOOP_OVER_ROW';
 export type SortDirection = 'ASC' | 'DESC' | 'NONE';
 
-export type ColSpanParams<R, SR> = {
+export type ColSpanArgs<R, SR> = {
   type: 'HEADER' | 'FILTER';
 } | {
   type: 'ROW';

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown> extends Omit<Reac
   rowIdx: number;
   copiedCellIdx?: number;
   draggedOverCellIdx?: number;
+  lastFrozenColumnIndex: number;
   isRowSelected: boolean;
   top: number;
   selectedCellProps?: EditCellProps<TRow> | SelectedCellProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
   groupFormatter?: React.ComponentType<GroupFormatterProps<TRow, TSummaryRow>>;
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   editable?: boolean | ((row: TRow) => boolean);
-  colSpan?: ((args: ColSpanArgs<TRow, TSummaryRow>) => number | undefined);
+  colSpan?: (args: ColSpanArgs<TRow, TSummaryRow>) => number | undefined;
   /** Determines whether column is frozen or not */
   frozen?: boolean;
   /** Enable resizing of a column */

--- a/src/utils/colSpanUtils.ts
+++ b/src/utils/colSpanUtils.ts
@@ -1,7 +1,7 @@
 import type { CalculatedColumn, ColSpanArgs } from '../types';
 
 export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, lastFrozenColumnIndex: number, args: ColSpanArgs<R, SR>) {
-  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
+  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : null;
   if (
     Number.isInteger(colSpan)
     && colSpan! > 1

--- a/src/utils/colSpanUtils.ts
+++ b/src/utils/colSpanUtils.ts
@@ -1,7 +1,7 @@
 import type { CalculatedColumn, ColSpanArgs } from '../types';
 
 export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, lastFrozenColumnIndex: number, args: ColSpanArgs<R, SR>) {
-  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : null;
+  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : 1;
   if (
     Number.isInteger(colSpan)
     && colSpan! > 1

--- a/src/utils/colSpanUtils.ts
+++ b/src/utils/colSpanUtils.ts
@@ -1,0 +1,14 @@
+import type { CalculatedColumn, ColSpanArgs } from '../types';
+
+export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, lastFrozenColumnIndex: number, args: ColSpanArgs<R, SR>) {
+  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
+  if (
+    Number.isInteger(colSpan)
+    && colSpan! > 1
+    // ignore colSpan if it spans over both frozen and regular columns
+    && (!column.frozen || (column.idx + colSpan! - 1) <= lastFrozenColumnIndex)
+  ) {
+    return colSpan;
+  }
+  return undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,10 +13,13 @@ export function assertIsValidKeyGetter<R>(keyGetter: unknown): asserts keyGetter
   }
 }
 
-export function getCellStyle<R, SR>(column: CalculatedColumn<R, SR>): React.CSSProperties {
+export function getCellStyle<R, SR>(column: CalculatedColumn<R, SR>, colSpan?: number): React.CSSProperties {
   return column.frozen
     ? { left: `var(--frozen-left-${column.key})` }
-    : { gridColumnStart: column.idx + 1 };
+    : {
+      gridColumnStart: column.idx + 1,
+      gridColumnEnd: colSpan ? `span ${colSpan}` : undefined
+    };
 }
 
 export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extraClasses: Parameters<typeof clsx>): string {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
 
-import type { CalculatedColumn, ColSpanArgs } from '../types';
+import type { CalculatedColumn } from '../types';
 import { cellClassname, cellFrozenClassname, cellFrozenLastClassname } from '../style';
 
+export * from './colSpanUtils';
 export * from './domUtils';
 export * from './keyboardUtils';
 export * from './selectedCellUtils';
@@ -29,17 +30,4 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
     },
     ...extraClasses
   );
-}
-
-export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, lastFrozenColumnIndex: number, args: ColSpanArgs<R, SR>) {
-  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
-  if (
-    Number.isInteger(colSpan)
-    && colSpan! > 1
-    // ignore colSpan if it spans over both frozen and regular columns
-    && (!column.frozen || (column.idx + colSpan! - 1) <= lastFrozenColumnIndex)
-  ) {
-    return colSpan;
-  }
-  return undefined;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,9 +34,8 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
 export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], args: ColSpanArgs<R, SR>) {
   const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
   if (
-    colSpan
-    && colSpan > 1
-    && Number.isInteger(colSpan)
+    Number.isInteger(colSpan)
+    && (colSpan as number) > 1
     // ignore colSpan if it spans over both frozen and regular columns
     && !areColSpanColumnsCompatible(column, viewportColumns, colSpan)
   ) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 import clsx from 'clsx';
 
-import type { CalculatedColumn, ColSpanParams } from '../types';
+import type { CalculatedColumn, ColSpanArgs } from '../types';
 import { cellClassname, cellFrozenClassname, cellFrozenLastClassname } from '../style';
 
 export * from './domUtils';
@@ -36,17 +36,19 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
   );
 }
 
-export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], params: ColSpanParams<R, SR>) {
-  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(params) : column.colSpan;
-  if (colSpan && !areColSpanColumnsCompatible(viewportColumns, column.idx, colSpan)) {
+export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], args: ColSpanArgs<R, SR>) {
+  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
+  if (colSpan && !areColSpanColumnsCompatible(column, viewportColumns, colSpan)) {
     // ignore colSpan if it spans over frozen and regular columns
     return undefined;
   }
   return colSpan;
 }
 
-function areColSpanColumnsCompatible<R, SR>(viewportColumns: readonly CalculatedColumn<R, SR>[], startIdx: number, colSpan: number) {
-  const isFrozen = viewportColumns[startIdx].frozen;
+function areColSpanColumnsCompatible<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], colSpan: number) {
+  const isFrozen = column.frozen;
+  if (!isFrozen) return true;
+  const startIdx = column.idx - viewportColumns[0].idx;
   for (
     let index = 1;
     index < colSpan && startIdx + index < viewportColumns.length;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,7 +16,7 @@ export function assertIsValidKeyGetter<R>(keyGetter: unknown): asserts keyGetter
 export function getCellStyle<R, SR>(column: CalculatedColumn<R, SR>, colSpan?: number): React.CSSProperties {
   return {
     gridColumnStart: column.idx + 1,
-    gridColumnEnd: colSpan ? `span ${colSpan}` : undefined,
+    gridColumnEnd: colSpan !== undefined ? `span ${colSpan}` : undefined,
     left: column.frozen ? `var(--frozen-left-${column.key})` : undefined
   };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import type { CSSProperties } from 'react';
 import clsx from 'clsx';
 
 import type { CalculatedColumn, ColSpanArgs } from '../types';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import clsx from 'clsx';
 
 import type { CalculatedColumn } from '../types';
@@ -14,12 +15,15 @@ export function assertIsValidKeyGetter<R>(keyGetter: unknown): asserts keyGetter
 }
 
 export function getCellStyle<R, SR>(column: CalculatedColumn<R, SR>, colSpan?: number): React.CSSProperties {
-  return column.frozen
-    ? { left: `var(--frozen-left-${column.key})` }
-    : {
-      gridColumnStart: column.idx + 1,
-      gridColumnEnd: colSpan ? `span ${colSpan}` : undefined
-    };
+  const style: CSSProperties = {
+    gridColumnStart: column.idx + 1,
+    gridColumnEnd: colSpan ? `span ${colSpan}` : undefined
+  };
+  if (column.frozen) {
+    style.left = `var(--frozen-left-${column.key})`;
+  }
+
+  return style;
 }
 
 export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extraClasses: Parameters<typeof clsx>): string {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 import clsx from 'clsx';
 
-import type { CalculatedColumn } from '../types';
+import type { CalculatedColumn, ColSpanParams } from '../types';
 import { cellClassname, cellFrozenClassname, cellFrozenLastClassname } from '../style';
 
 export * from './domUtils';
@@ -34,4 +34,27 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
     },
     ...extraClasses
   );
+}
+
+export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], params: ColSpanParams<R, SR>) {
+  const colSpan = typeof column.colSpan === 'function' ? column.colSpan(params) : column.colSpan;
+  if (colSpan && !areColSpanColumnsCompatible(viewportColumns, column.idx, colSpan)) {
+    // ignore colSpan if it spans over frozen and regular columns
+    return undefined;
+  }
+  return colSpan;
+}
+
+function areColSpanColumnsCompatible<R, SR>(viewportColumns: readonly CalculatedColumn<R, SR>[], startIdx: number, colSpan: number) {
+  const isFrozen = viewportColumns[startIdx].frozen;
+  for (
+    let index = 1;
+    index < colSpan && startIdx + index < viewportColumns.length;
+    index++
+  ) {
+    if (viewportColumns[startIdx + index].frozen !== isFrozen) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,15 +15,11 @@ export function assertIsValidKeyGetter<R>(keyGetter: unknown): asserts keyGetter
 }
 
 export function getCellStyle<R, SR>(column: CalculatedColumn<R, SR>, colSpan?: number): React.CSSProperties {
-  const style: CSSProperties = {
+  return {
     gridColumnStart: column.idx + 1,
-    gridColumnEnd: colSpan ? `span ${colSpan}` : undefined
+    gridColumnEnd: colSpan ? `span ${colSpan}` : undefined,
+    left: column.frozen ? `var(--frozen-left-${column.key})` : undefined
   };
-  if (column.frozen) {
-    style.left = `var(--frozen-left-${column.key})`;
-  }
-
-  return style;
 }
 
 export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extraClasses: Parameters<typeof clsx>): string {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,9 +35,9 @@ export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColum
   const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
   if (
     Number.isInteger(colSpan)
-    && (colSpan as number) > 1
+    && colSpan! > 1
     // ignore colSpan if it spans over both frozen and regular columns
-    && !areColSpanColumnsCompatible(column, viewportColumns, colSpan)
+    && !areColSpanColumnsCompatible(column, viewportColumns, colSpan!)
   ) {
     return undefined;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,31 +31,15 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
   );
 }
 
-export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], args: ColSpanArgs<R, SR>) {
+export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, lastFrozenColumnIndex: number, args: ColSpanArgs<R, SR>) {
   const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
   if (
     Number.isInteger(colSpan)
     && colSpan! > 1
     // ignore colSpan if it spans over both frozen and regular columns
-    && !areColSpanColumnsCompatible(column, viewportColumns, colSpan!)
+    && (!column.frozen || (column.idx + colSpan! - 1) <= lastFrozenColumnIndex)
   ) {
-    return undefined;
+    return colSpan;
   }
-  return colSpan;
-}
-
-function areColSpanColumnsCompatible<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], colSpan: number) {
-  const isFrozen = column.frozen;
-  if (!isFrozen) return true;
-  const startIdx = column.idx - viewportColumns[0].idx;
-  for (
-    let index = 1;
-    index < colSpan && startIdx + index < viewportColumns.length;
-    index++
-  ) {
-    if (viewportColumns[startIdx + index].frozen !== isFrozen) {
-      return false;
-    }
-  }
-  return true;
+  return undefined;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,8 +33,13 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
 
 export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], args: ColSpanArgs<R, SR>) {
   const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
-  if (colSpan && !areColSpanColumnsCompatible(column, viewportColumns, colSpan)) {
+  if (
+    colSpan
+    && colSpan > 1
+    && Number.isInteger(colSpan)
     // ignore colSpan if it spans over both frozen and regular columns
+    && !areColSpanColumnsCompatible(column, viewportColumns, colSpan)
+  ) {
     return undefined;
   }
   return colSpan;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,7 +35,7 @@ export function getCellClassname<R, SR>(column: CalculatedColumn<R, SR>, ...extr
 export function getColSpan<R, SR>(column: CalculatedColumn<R, SR>, viewportColumns: readonly CalculatedColumn<R, SR>[], args: ColSpanArgs<R, SR>) {
   const colSpan = typeof column.colSpan === 'function' ? column.colSpan(args) : column.colSpan;
   if (colSpan && !areColSpanColumnsCompatible(column, viewportColumns, colSpan)) {
-    // ignore colSpan if it spans over frozen and regular columns
+    // ignore colSpan if it spans over both frozen and regular columns
     return undefined;
   }
   return colSpan;

--- a/src/utils/selectedCellUtils.ts
+++ b/src/utils/selectedCellUtils.ts
@@ -86,9 +86,9 @@ export function getNextSelectedCellPosition<R, SR>({
   if (isGroupRow(row)) return position;
   // If a cell within the colspan range is selected then move to the
   // previous or the next cell depending on the navigation direction
+  const posIdx = position.idx;
   for (const column of colSpanColumns) {
     const colIdx = column.idx;
-    const posIdx = position.idx;
     if (colIdx > posIdx) break;
     const colSpan = getColSpan<R, SR>(column, lastFrozenColumnIndex, { type: 'ROW', row });
     if (colSpan && posIdx > colIdx && posIdx < colSpan + colIdx) {

--- a/src/utils/selectedCellUtils.ts
+++ b/src/utils/selectedCellUtils.ts
@@ -88,10 +88,11 @@ export function getNextSelectedCellPosition<R, SR>({
   // previous or the next cell depending on the navigation direction
   for (const column of colSpanColumns) {
     const colIdx = column.idx;
-    if (colIdx > position.idx) break;
+    const posIdx = position.idx;
+    if (colIdx > posIdx) break;
     const colSpan = getColSpan<R, SR>(column, lastFrozenColumnIndex, { type: 'ROW', row });
-    if (colSpan && position.idx > column.idx && position.idx < colSpan + column.idx) {
-      position.idx = column.idx + (position.idx - currentPosition.idx > 0 ? colSpan : 0);
+    if (colSpan && posIdx > colIdx && posIdx < colSpan + colIdx) {
+      position.idx = colIdx + (posIdx - currentPosition.idx > 0 ? colSpan : 0);
       break;
     }
   }

--- a/stories/demos/ColumnSpanning.tsx
+++ b/stories/demos/ColumnSpanning.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import { css } from '@linaria/core';
+
+import DataGrid from '../../src';
+import type { Column, FormatterProps } from '../../src';
+
+type Row = number;
+const rows: readonly Row[] = [...Array(100).keys()];
+
+const colSpanClassname = css`
+  background-color: #ffb300;
+  text-align: center;
+`;
+
+function CellFormatter(props: FormatterProps<Row>) {
+  return <>{props.column.key}&times;{props.rowIdx}</>;
+}
+
+export function ColumnSpanning() {
+  const columns = useMemo((): readonly Column<Row>[] => {
+    const columns: Column<Row>[] = [];
+
+    for (let i = 0; i < 30; i++) {
+      const key = String(i);
+      columns.push({
+        key,
+        name: key,
+        frozen: i < 5,
+        resizable: true,
+        formatter: CellFormatter,
+        colSpan(args) {
+          if (args.type === 'ROW') {
+            if (key === '2' && args.row === 2) return 2;
+            if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
+            if (key === '0' && args.row === 5) return 5;
+            if (key === '6' && args.row < 8) return 2;
+          }
+          if (args.type === 'HEADER' && key === '8') {
+            return 3;
+          }
+          return undefined;
+        },
+        cellClass(row) {
+          if (
+            (key === '0' && row === 5)
+            || (key === '2' && row === 2)
+            || (key === '6' && row < 8)
+          ) {
+            return colSpanClassname;
+          }
+          return undefined;
+        }
+      });
+    }
+
+    return columns;
+  }, []);
+
+  return (
+    <DataGrid
+      columns={columns}
+      rows={rows}
+      rowHeight={22}
+      className="fill-grid"
+    />
+  );
+}
+
+ColumnSpanning.storyName = 'Column Spanning';

--- a/stories/demos/ColumnSpanning.tsx
+++ b/stories/demos/ColumnSpanning.tsx
@@ -34,6 +34,7 @@ export function ColumnSpanning() {
             if (key === '2' && args.row === 2) return 3;
             if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
             if (key === '0' && args.row === 5) return 5;
+            if (key === '27' && args.row === 8) return 3;
             if (key === '6' && args.row < 8) return 2;
           }
           if (args.type === 'HEADER' && key === '8') {
@@ -45,6 +46,7 @@ export function ColumnSpanning() {
           if (
             (key === '0' && row === 5)
             || (key === '2' && row === 2)
+            || (key === '27' && row === 8)
             || (key === '6' && row < 8)
           ) {
             return colSpanClassname;

--- a/stories/demos/ColumnSpanning.tsx
+++ b/stories/demos/ColumnSpanning.tsx
@@ -31,7 +31,7 @@ export function ColumnSpanning() {
         formatter: CellFormatter,
         colSpan(args) {
           if (args.type === 'ROW') {
-            if (key === '2' && args.row === 2) return 2;
+            if (key === '2' && args.row === 2) return 3;
             if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
             if (key === '0' && args.row === 5) return 5;
             if (key === '6' && args.row < 8) return 2;

--- a/stories/demos/ColumnSpanning.tsx
+++ b/stories/demos/ColumnSpanning.tsx
@@ -9,6 +9,7 @@ const rows: readonly Row[] = [...Array(100).keys()];
 
 const colSpanClassname = css`
   background-color: #ffb300;
+  color: black;
   text-align: center;
 `;
 

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -80,11 +80,15 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       name: 'Client',
       width: 220,
       editor: TextEditor,
-      colSpan(row, rowType) {
-        if (rowType !== 'ROW') return undefined;
-        if (row.id === 2) return 4;
-        if (row.id === 4) return 2;
-        if (row.id === 6) return 3;
+      colSpan(p) {
+        if (p.type === 'ROW') {
+          if (p.row.id === 2) return 4;
+          if (p.row.id === 4) return 2;
+          if (p.row.id === 6) return 3;
+        }
+        if (p.type === 'SUMMARY') {
+          return 12;
+        }
         return undefined;
       }
     },
@@ -135,8 +139,12 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
     },
     {
       key: 'startTimestamp',
-      name: 'Start date',
+      name: 'Date Range',
       width: 100,
+      colSpan(p) {
+        if (p.type !== 'HEADER') return undefined;
+        return 2;
+      },
       formatter(props) {
         return <TimestampFormatter timestamp={props.row.startTimestamp} />;
       }

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -81,7 +81,11 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       width: 220,
       editor: TextEditor,
       colSpan(row, rowType) {
-        return rowType === 'ROW' && row.id === 2 ? 4 : undefined;
+        if (rowType !== 'ROW') return undefined;
+        if (row.id === 2) return 4;
+        if (row.id === 4) return 2;
+        if (row.id === 6) return 3;
+        return undefined;
       }
     },
     {

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -98,12 +98,9 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       cellClass(row) {
         return colSpanRowIds.includes(row.id) ? missingClientClassname : undefined;
       },
-      colSpan(props) {
-        if (props.type === 'ROW' && colSpanRowIds.includes(props.row.id)) {
+      colSpan(args) {
+        if (args.type === 'ROW' && colSpanRowIds.includes(args.row.id)) {
           return 4;
-        }
-        if (props.type === 'SUMMARY') {
-          return 12;
         }
         return undefined;
       }
@@ -157,8 +154,8 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       key: 'startTimestamp',
       name: 'Date Range',
       width: 100,
-      colSpan(p) {
-        if (p.type !== 'HEADER') return undefined;
+      colSpan({ type }) {
+        if (type !== 'HEADER') return undefined;
         return 2;
       },
       formatter(props) {

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -81,7 +81,7 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       width: 220,
       editor: TextEditor,
       colSpan(row, rowType) {
-        return rowType === 'ROW' && row.id === 2 ? 2 : undefined;
+        return rowType === 'ROW' && row.id === 2 ? 4 : undefined;
       }
     },
     {

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -79,7 +79,10 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       key: 'client',
       name: 'Client',
       width: 220,
-      editor: TextEditor
+      editor: TextEditor,
+      colSpan({ row, rowType }) {
+        return rowType === 'ROW' && row.id === 2 ? 2 : undefined;
+      }
     },
     {
       key: 'area',

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -13,6 +13,10 @@ const toolbarClassname = css`
   margin-bottom: 8px;
 `;
 
+const missingClientClassname = css`
+  background-color: #ffb300
+`;
+
 
 const dateFormatter = new Intl.DateTimeFormat(navigator.language);
 const currencyFormatter = new Intl.NumberFormat(navigator.language, {
@@ -52,6 +56,8 @@ interface Row {
   available: boolean;
 }
 
+const colSpanRowIds: number[] = [2, 4, 6];
+
 function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
   return [
     SelectColumn,
@@ -79,14 +85,24 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       key: 'client',
       name: 'Client',
       width: 220,
-      editor: TextEditor,
-      colSpan(p) {
-        if (p.type === 'ROW') {
-          if (p.row.id === 2) return 4;
-          if (p.row.id === 4) return 2;
-          if (p.row.id === 6) return 3;
+      formatter(props) {
+        if (colSpanRowIds.includes(props.row.id)) {
+          return <>Missing Client</>;
         }
-        if (p.type === 'SUMMARY') {
+        return <>{props.row.client}</>;
+      },
+      editable(row) {
+        return !colSpanRowIds.includes(row.id);
+      },
+      editor: TextEditor,
+      cellClass(row) {
+        return colSpanRowIds.includes(row.id) ? missingClientClassname : undefined;
+      },
+      colSpan(props) {
+        if (props.type === 'ROW' && colSpanRowIds.includes(props.row.id)) {
+          return 4;
+        }
+        if (props.type === 'SUMMARY') {
           return 12;
         }
         return undefined;

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -13,10 +13,6 @@ const toolbarClassname = css`
   margin-bottom: 8px;
 `;
 
-const missingClientClassname = css`
-  background-color: #ffb300
-`;
-
 
 const dateFormatter = new Intl.DateTimeFormat(navigator.language);
 const currencyFormatter = new Intl.NumberFormat(navigator.language, {
@@ -56,8 +52,6 @@ interface Row {
   available: boolean;
 }
 
-const colSpanRowIds: number[] = [2, 4, 6];
-
 function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
   return [
     SelectColumn,
@@ -85,25 +79,7 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       key: 'client',
       name: 'Client',
       width: 220,
-      formatter(props) {
-        if (colSpanRowIds.includes(props.row.id)) {
-          return <>Missing Client</>;
-        }
-        return <>{props.row.client}</>;
-      },
-      editable(row) {
-        return !colSpanRowIds.includes(row.id);
-      },
-      editor: TextEditor,
-      cellClass(row) {
-        return colSpanRowIds.includes(row.id) ? missingClientClassname : undefined;
-      },
-      colSpan(args) {
-        if (args.type === 'ROW' && colSpanRowIds.includes(args.row.id)) {
-          return 4;
-        }
-        return undefined;
-      }
+      editor: TextEditor
     },
     {
       key: 'area',
@@ -152,12 +128,8 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
     },
     {
       key: 'startTimestamp',
-      name: 'Date Range',
+      name: 'Start date',
       width: 100,
-      colSpan({ type }) {
-        if (type !== 'HEADER') return undefined;
-        return 2;
-      },
       formatter(props) {
         return <TimestampFormatter timestamp={props.row.startTimestamp} />;
       }

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -80,7 +80,7 @@ function getColumns(countries: string[]): readonly Column<Row, SummaryRow>[] {
       name: 'Client',
       width: 220,
       editor: TextEditor,
-      colSpan({ row, rowType }) {
+      colSpan(row, rowType) {
         return rowType === 'ROW' && row.id === 2 ? 2 : undefined;
       }
     },

--- a/stories/index.story.ts
+++ b/stories/index.story.ts
@@ -8,6 +8,7 @@ export * from './demos/ContextMenu';
 export * from './demos/ScrollToRow';
 export * from './demos/CellNavigation';
 export * from './demos/HeaderFilters';
+export * from './demos/ColumnSpanning';
 export * from './demos/ColumnsReordering';
 export * from './demos/RowsReordering';
 export * from './demos/Grouping';

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -111,7 +111,7 @@ describe('colSpan', () => {
     function testSelectedCell(expectedRowIdx: number, expectedColIdx: number) {
       const selectedCell = getSelectedCell();
       expect(selectedCell).toHaveAttribute('aria-colindex', `${expectedColIdx + 1}`);
-      expect(selectedCell.parentElement).toHaveAttribute('aria-rowindex', `${expectedRowIdx + 2}`); // +1 to account for the header row
+      expect(selectedCell.parentElement!).toHaveAttribute('aria-rowindex', `${expectedRowIdx + 2}`); // +1 to account for the header row
     }
   });
 });

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -111,7 +111,7 @@ describe('colSpan', () => {
     function testSelectedCell(expectedRowIdx: number, expectedColIdx: number) {
       const selectedCell = getSelectedCell();
       expect(selectedCell).toHaveAttribute('aria-colindex', `${expectedColIdx + 1}`);
-      expect(selectedCell.parentElement!).toHaveAttribute('aria-rowindex', `${expectedRowIdx + 2}`); // +1 to account for the header row
+      expect(selectedCell!.parentElement).toHaveAttribute('aria-rowindex', `${expectedRowIdx + 2}`); // +1 to account for the header row
     }
   });
 });

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -8,7 +8,7 @@ describe('colSpan', () => {
   function setupColSpanGrid() {
     const columns: Column<Row>[] = [];
     type Row = number;
-    const rows: readonly Row[] = [...Array(30).keys()];
+    const rows: readonly Row[] = [...Array(10).keys()];
 
     for (let i = 0; i < 15; i++) {
       const key = String(i);

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -1,4 +1,3 @@
-import { within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { Column } from '../../src';

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -20,6 +20,7 @@ describe('colSpan', () => {
             if (key === '2' && args.row === 2) return 3;
             if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
             if (key === '0' && args.row === 5) return 5;
+            if (key === '12' && args.row === 8) return 3;
             if (key === '6' && args.row < 8) return 2;
           }
           if (args.type === 'HEADER' && key === '8') {
@@ -94,7 +95,19 @@ describe('colSpan', () => {
     testSelectedCell(5, 0);
     userEvent.type(document.activeElement!, '{arrowright}');
     testSelectedCell(5, 5);
-
+    userEvent.tab({ shift: true });
+    userEvent.tab({ shift: true });
+    testSelectedCell(4, 14);
+    userEvent.tab();
+    testSelectedCell(5, 0);
+    userEvent.click(getCellsAtRowIndex(8)[11]);
+    testSelectedCell(8, 11);
+    userEvent.tab();
+    testSelectedCell(8, 12);
+    userEvent.tab();
+    testSelectedCell(9, 0);
+    userEvent.tab({ shift: true });
+    testSelectedCell(8, 12);
 
     function testSelectedCell(expectedRowIdx: number, expectedColIdx: number) {
       const selectedCell = getSelectedCell();

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -1,77 +1,117 @@
 import { within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import type { Column } from '../../src';
-import { setup, getRows, getHeaderCells } from '../utils';
+import { setup, getRows, getHeaderCells, getSelectedCell } from '../utils';
 
-test('colSpan correctly merge cells', () => {
-  const columns: Column<Row>[] = [];
-  type Row = number;
-  const rows: readonly Row[] = [...Array(30).keys()];
+describe('colSpan', () => {
+  function setupColSpanGrid() {
+    const columns: Column<Row>[] = [];
+    type Row = number;
+    const rows: readonly Row[] = [...Array(30).keys()];
 
-  for (let i = 0; i < 15; i++) {
-    const key = String(i);
-    columns.push({
-      key,
-      name: key,
-      frozen: i < 5,
-      colSpan(args) {
-        if (args.type === 'ROW') {
-          if (key === '2' && args.row === 2) return 3;
-          if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
-          if (key === '0' && args.row === 5) return 5;
-          if (key === '6' && args.row < 8) return 2;
+    for (let i = 0; i < 15; i++) {
+      const key = String(i);
+      columns.push({
+        key,
+        name: key,
+        frozen: i < 5,
+        colSpan(args) {
+          if (args.type === 'ROW') {
+            if (key === '2' && args.row === 2) return 3;
+            if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
+            if (key === '0' && args.row === 5) return 5;
+            if (key === '6' && args.row < 8) return 2;
+          }
+          if (args.type === 'HEADER' && key === '8') {
+            return 3;
+          }
+          return undefined;
+        },
+        cellClass(row) {
+          if (
+            (key === '0' && row === 5)
+              || (key === '2' && row === 2)
+              || (key === '6' && row < 8)
+          ) {
+            return 'col-span';
+          }
+          return undefined;
         }
-        if (args.type === 'HEADER' && key === '8') {
-          return 3;
-        }
-        return undefined;
-      },
-      cellClass(row) {
-        if (
-          (key === '0' && row === 5)
-            || (key === '2' && row === 2)
-            || (key === '6' && row < 8)
-        ) {
-          return 'col-span';
-        }
-        return undefined;
-      }
-    });
+      });
+    }
+    setup({ columns, rows });
   }
-  setup({ columns, rows });
-  // header
-  expect(getHeaderCells()).toHaveLength(13);
 
-  // rows
-  const gridRows = getRows();
-  const getCells = (rowIdx: number) => within(gridRows[rowIdx]).getAllByRole('gridcell');
-  expect(getCells(1)).toHaveLength(14);
-  // 7th-8th cells are merged
-  expect(getCells(1)[6]).toHaveAttribute('aria-colindex', '7');
-  expect(getCells(1)[7]).toHaveAttribute('aria-colindex', '9');
-  expect(getCells(1)[6]).toHaveStyle({
-    'grid-column-start': '7',
-    'grid-column-end': 'span 2'
+  it('should merges cells', () => {
+    setupColSpanGrid();
+    // header
+    expect(getHeaderCells()).toHaveLength(13);
+
+    // rows
+    const gridRows = getRows();
+    const getCells = (rowIdx: number) => within(gridRows[rowIdx]).getAllByRole('gridcell');
+    expect(getCells(1)).toHaveLength(14);
+    // 7th-8th cells are merged
+    expect(getCells(1)[6]).toHaveAttribute('aria-colindex', '7');
+    expect(getCells(1)[7]).toHaveAttribute('aria-colindex', '9');
+    expect(getCells(1)[6]).toHaveStyle({
+      'grid-column-start': '7',
+      'grid-column-end': 'span 2'
+    });
+
+    // 3rd-5th, 7th-8th cells are merged
+    expect(getCells(2)).toHaveLength(12);
+    expect(getCells(2)[2]).toHaveAttribute('aria-colindex', '3');
+    expect(getCells(2)[3]).toHaveAttribute('aria-colindex', '6');
+    expect(getCells(2)[2]).toHaveStyle({
+      'grid-column-start': '3',
+      'grid-column-end': 'span 3'
+    });
+
+    expect(getCells(2)[4]).toHaveAttribute('aria-colindex', '7');
+    expect(getCells(2)[5]).toHaveAttribute('aria-colindex', '9');
+    expect(getCells(2)[4]).toHaveStyle({
+      'grid-column-start': '7',
+      'grid-column-end': 'span 2'
+    });
+
+    expect(getCells(4)).toHaveLength(14); // colSpan 6 won't work as there are 5 frozen columns
+    expect(getCells(5)).toHaveLength(10);
   });
 
-  // 3rd-5th, 7th-8th cells are merged
-  expect(getCells(2)).toHaveLength(12);
-  expect(getCells(2)[2]).toHaveAttribute('aria-colindex', '3');
-  expect(getCells(2)[3]).toHaveAttribute('aria-colindex', '6');
-  expect(getCells(2)[2]).toHaveStyle({
-    'grid-column-start': '3',
-    'grid-column-end': 'span 3'
+  it('should navigate between merged cells', () => {
+    setupColSpanGrid();
+    userEvent.click(within(getRows()[1]).getAllByRole('gridcell')[1]);
+    testSelectedCell(1, 1);
+    userEvent.type(document.activeElement!, '{arrowright}');
+    testSelectedCell(1, 2);
+    userEvent.type(document.activeElement!, '{arrowright}');
+    testSelectedCell(1, 3);
+    userEvent.type(document.activeElement!, '{arrowdown}');
+    testSelectedCell(2, 2);
+    userEvent.type(document.activeElement!, '{arrowleft}');
+    testSelectedCell(2, 1);
+    userEvent.type(document.activeElement!, '{arrowright}');
+    testSelectedCell(2, 2);
+    userEvent.type(document.activeElement!, '{arrowright}');
+    testSelectedCell(2, 5);
+    userEvent.type(document.activeElement!, '{arrowleft}');
+    testSelectedCell(2, 2);
+    userEvent.type(document.activeElement!, '{arrowdown}');
+    testSelectedCell(3, 2);
+    userEvent.type(document.activeElement!, '{arrowdown}{arrowdown}');
+    testSelectedCell(5, 0);
+    userEvent.type(document.activeElement!, '{arrowLeft}');
+    testSelectedCell(5, 0);
+    userEvent.type(document.activeElement!, '{arrowright}');
+    testSelectedCell(5, 5);
+
+
+    function testSelectedCell(expectedRowIdx: number, expectedColIdx: number) {
+      const selectedCell = getSelectedCell();
+      expect(selectedCell).toHaveAttribute('aria-colindex', `${expectedColIdx + 1}`);
+      expect(selectedCell.parentElement).toHaveAttribute('aria-rowindex', `${expectedRowIdx + 2}`); // +1 to account for the header row
+    }
   });
-
-  expect(getCells(2)[4]).toHaveAttribute('aria-colindex', '7');
-  expect(getCells(2)[5]).toHaveAttribute('aria-colindex', '9');
-  expect(getCells(2)[4]).toHaveStyle({
-    'grid-column-start': '7',
-    'grid-column-end': 'span 2'
-  });
-
-  expect(getCells(4)).toHaveLength(14); // colSpan 6 won't work as there are 5 frozen columns
-  expect(getCells(5)).toHaveLength(10);
-
-  // TODO: scroll and test
 });

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -2,7 +2,7 @@ import { within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { Column } from '../../src';
-import { setup, getRows, getHeaderCells, getSelectedCell } from '../utils';
+import { setup, getCellsAtRowIndex, getHeaderCells, getSelectedCell } from '../utils';
 
 describe('colSpan', () => {
   function setupColSpanGrid() {
@@ -39,40 +39,39 @@ describe('colSpan', () => {
     expect(getHeaderCells()).toHaveLength(13);
 
     // rows
-    const gridRows = getRows();
-    const getCells = (rowIdx: number) => within(gridRows[rowIdx]).getAllByRole('gridcell');
-    expect(getCells(1)).toHaveLength(14);
+    const row1 = getCellsAtRowIndex(1);
+    expect(row1).toHaveLength(14);
     // 7th-8th cells are merged
-    expect(getCells(1)[6]).toHaveAttribute('aria-colindex', '7');
-    expect(getCells(1)[7]).toHaveAttribute('aria-colindex', '9');
-    expect(getCells(1)[6]).toHaveStyle({
+    expect(row1[6]).toHaveAttribute('aria-colindex', '7');
+    expect(row1[7]).toHaveAttribute('aria-colindex', '9');
+    expect(row1[6]).toHaveStyle({
       'grid-column-start': '7',
       'grid-column-end': 'span 2'
     });
 
     // 3rd-5th, 7th-8th cells are merged
-    expect(getCells(2)).toHaveLength(12);
-    expect(getCells(2)[2]).toHaveAttribute('aria-colindex', '3');
-    expect(getCells(2)[3]).toHaveAttribute('aria-colindex', '6');
-    expect(getCells(2)[2]).toHaveStyle({
+    const row2 = getCellsAtRowIndex(2);
+    expect(row2).toHaveLength(12);
+    expect(row2[2]).toHaveAttribute('aria-colindex', '3');
+    expect(row2[2]).toHaveStyle({
       'grid-column-start': '3',
       'grid-column-end': 'span 3'
     });
-
-    expect(getCells(2)[4]).toHaveAttribute('aria-colindex', '7');
-    expect(getCells(2)[5]).toHaveAttribute('aria-colindex', '9');
-    expect(getCells(2)[4]).toHaveStyle({
+    expect(row2[3]).toHaveAttribute('aria-colindex', '6');
+    expect(row2[4]).toHaveAttribute('aria-colindex', '7');
+    expect(row2[4]).toHaveStyle({
       'grid-column-start': '7',
       'grid-column-end': 'span 2'
     });
+    expect(row2[5]).toHaveAttribute('aria-colindex', '9');
 
-    expect(getCells(4)).toHaveLength(14); // colSpan 6 won't work as there are 5 frozen columns
-    expect(getCells(5)).toHaveLength(10);
+    expect(getCellsAtRowIndex(4)).toHaveLength(14); // colSpan 6 won't work as there are 5 frozen columns
+    expect(getCellsAtRowIndex(5)).toHaveLength(10);
   });
 
   it('should navigate between merged cells', () => {
     setupColSpanGrid();
-    userEvent.click(within(getRows()[1]).getAllByRole('gridcell')[1]);
+    userEvent.click(getCellsAtRowIndex(1)[1]);
     testSelectedCell(1, 1);
     userEvent.type(document.activeElement!, '{arrowright}');
     testSelectedCell(1, 2);

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -1,0 +1,77 @@
+import { within } from '@testing-library/react';
+
+import type { Column } from '../../src';
+import { setup, getRows, getHeaderCells } from '../utils';
+
+test('colSpan correctly merge cells', () => {
+  const columns: Column<Row>[] = [];
+  type Row = number;
+  const rows: readonly Row[] = [...Array(30).keys()];
+
+  for (let i = 0; i < 15; i++) {
+    const key = String(i);
+    columns.push({
+      key,
+      name: key,
+      frozen: i < 5,
+      colSpan(args) {
+        if (args.type === 'ROW') {
+          if (key === '2' && args.row === 2) return 3;
+          if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
+          if (key === '0' && args.row === 5) return 5;
+          if (key === '6' && args.row < 8) return 2;
+        }
+        if (args.type === 'HEADER' && key === '8') {
+          return 3;
+        }
+        return undefined;
+      },
+      cellClass(row) {
+        if (
+          (key === '0' && row === 5)
+            || (key === '2' && row === 2)
+            || (key === '6' && row < 8)
+        ) {
+          return 'col-span';
+        }
+        return undefined;
+      }
+    });
+  }
+  setup({ columns, rows });
+  // header
+  expect(getHeaderCells()).toHaveLength(13);
+
+  // rows
+  const gridRows = getRows();
+  const getCells = (rowIdx: number) => within(gridRows[rowIdx]).getAllByRole('gridcell');
+  expect(getCells(1)).toHaveLength(14);
+  // 7th-8th cells are merged
+  expect(getCells(1)[6]).toHaveAttribute('aria-colindex', '7');
+  expect(getCells(1)[7]).toHaveAttribute('aria-colindex', '9');
+  expect(getCells(1)[6]).toHaveStyle({
+    'grid-column-start': '7',
+    'grid-column-end': 'span 2'
+  });
+
+  // 3rd-5th, 7th-8th cells are merged
+  expect(getCells(2)).toHaveLength(12);
+  expect(getCells(2)[2]).toHaveAttribute('aria-colindex', '3');
+  expect(getCells(2)[3]).toHaveAttribute('aria-colindex', '6');
+  expect(getCells(2)[2]).toHaveStyle({
+    'grid-column-start': '3',
+    'grid-column-end': 'span 3'
+  });
+
+  expect(getCells(2)[4]).toHaveAttribute('aria-colindex', '7');
+  expect(getCells(2)[5]).toHaveAttribute('aria-colindex', '9');
+  expect(getCells(2)[4]).toHaveStyle({
+    'grid-column-start': '7',
+    'grid-column-end': 'span 2'
+  });
+
+  expect(getCells(4)).toHaveLength(14); // colSpan 6 won't work as there are 5 frozen columns
+  expect(getCells(5)).toHaveLength(10);
+
+  // TODO: scroll and test
+});

--- a/test/column/colSpan.test.ts
+++ b/test/column/colSpan.test.ts
@@ -27,16 +27,6 @@ describe('colSpan', () => {
             return 3;
           }
           return undefined;
-        },
-        cellClass(row) {
-          if (
-            (key === '0' && row === 5)
-              || (key === '2' && row === 2)
-              || (key === '6' && row < 8)
-          ) {
-            return 'col-span';
-          }
-          return undefined;
         }
       });
     }

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import DataGrid from '../src/';
 import type { DataGridProps } from '../src/';
 
@@ -13,6 +13,10 @@ export function setup<R, SR>(props: DataGridProps<R, SR>) {
 
 export function getRows() {
   return screen.getAllByRole('row').slice(1);
+}
+
+export function getCellsAtRowIndex(rowIdx: number) {
+  return within(getRows()[rowIdx]).getAllByRole('gridcell');
 }
 
 export function getCells() {


### PR DESCRIPTION
```
colSpan?: (args: ColSpanArgs<TRow, TSummaryRow>) => number | undefined;

export type ColSpanArgs<R, SR> = {
  type: 'HEADER' | 'FILTER';
} | {
  type: 'ROW';
  row: R;
} | {
  type: 'SUMMARY';
  row: SR;
};

```

It can be used as 

```
colSpan(args) {
  if (args.type === 'ROW') {
    if (key === '2' && args.row === 2) return 3;
    if (key === '4' && args.row === 4) return 6; // Will not work as colspan includes both frozen and regular columns
    if (key === '0' && args.row === 5) return 5;
    if (key === '27' && args.row === 8) return 3;
    if (key === '6' && args.row < 8) return 2;
  }
  if (args.type === 'HEADER' && key === '8') {
    return 3;
  }
  return undefined;
},
```