### PR TITLE
Linaria: disable autoprefixing

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -5,11 +5,7 @@
       "bugfixes": true,
       "shippedProposals": true,
       "corejs": 3,
-      "useBuiltIns": "entry",
-      "include": [
-        "@babel/proposal-nullish-coalescing-operator",
-        "@babel/proposal-optional-chaining"
-      ]
+      "useBuiltIns": "entry"
     }],
     ["@babel/react", { "runtime": "automatic" }],
     "@babel/typescript",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,10 @@ import linaria from '@linaria/rollup';
 import postcss from 'rollup-plugin-postcss';
 import { babel } from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import stylis from 'stylis';
 import pkg from './package.json';
 
+stylis.set({ prefix: false });
 const extensions = ['.ts', '.tsx'];
 
 export default {


### PR DESCRIPTION
https://github.com/callstack/linaria/issues/57#issuecomment-469611837

Linaria/Stylis add a LOT of prefixed css properties, when we don't need any of them, so I disabled them. I don't think we need any prefixes anymore nowadays. And if we do I'd rather we manage it ourselves. Prefixes is a thing of the past and browsers don't add new ones anymore.
The css properties in the devtools will be less polluted now.
We don't even have any prefixes in our codebase anymore afaict.

Build output example:
![image](https://user-images.githubusercontent.com/567105/115732045-8b68b000-a37f-11eb-8c75-cebfd504ed36.png)
![image](https://user-images.githubusercontent.com/567105/115732198-adfac900-a37f-11eb-841f-b613409b5adb.png)
![image](https://user-images.githubusercontent.com/567105/115732268-bb17b800-a37f-11eb-9815-7be179ca667d.png)
