### PR TITLE
Add aria-readonly to readonly cells 

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -107,7 +107,7 @@ function Cell<R, SR>({
       aria-colindex={column.idx + 1} // aria-colindex is 1-based
       aria-selected={isCellSelected}
       aria-colspan={colSpan}
-      aria-readonly={isCellEditable(column, row) ? true : undefined}
+      aria-readonly={isCellEditable(column, row) || undefined}
       ref={ref}
       className={className}
       style={getCellStyle(column, colSpan)}

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -3,7 +3,7 @@ import type { RefAttributes } from 'react';
 import { css } from '@linaria/core';
 
 import { cellSelectedClassname } from './style';
-import { getCellStyle, getCellClassname } from './utils';
+import { getCellStyle, getCellClassname, isCellEditable } from './utils';
 import type { CellRendererProps } from './types';
 
 const cellCopied = css`
@@ -107,6 +107,7 @@ function Cell<R, SR>({
       aria-colindex={column.idx + 1} // aria-colindex is 1-based
       aria-selected={isCellSelected}
       aria-colspan={colSpan}
+      aria-readonly={isCellEditable(column, row) ? true : undefined}
       ref={ref}
       className={className}
       style={getCellStyle(column, colSpan)}

--- a/src/utils/selectedCellUtils.ts
+++ b/src/utils/selectedCellUtils.ts
@@ -11,9 +11,12 @@ interface IsSelectedCellEditableOpts<R, SR> {
 export function isSelectedCellEditable<R, SR>({ selectedPosition, columns, rows, isGroupRow }: IsSelectedCellEditableOpts<R, SR>): boolean {
   const column = columns[selectedPosition.idx];
   const row = rows[selectedPosition.rowIdx];
+  return !isGroupRow(row) && isCellEditable(column, row);
+}
+
+export function isCellEditable<R, SR>(column: CalculatedColumn<R, SR>, row: R): boolean {
   return column.editor != null
     && !column.rowGroup
-    && !isGroupRow(row)
     && (typeof column.editable === 'function' ? column.editable(row) : column.editable) !== false;
 }
 


### PR DESCRIPTION
https://www.w3.org/TR/wai-aria-practices-1.2/#grid_roles_states_props

> If the grid provides content editing functionality and contains cells that may have edit capabilities disabled in certain conditions, aria-readonly may be set true on cells where editing is disabled. If edit functions are disabled for all cells, aria-readonly may be set true on the grid element. Grids that do not provide editing functions do not include the aria-readonly attribute on any of their elements.