### PR TITLE
Remove CSS autoprefixing in the storybook as well

### DIFF
--- a/.storybook/webpack.config.cjs
+++ b/.storybook/webpack.config.cjs
@@ -1,6 +1,9 @@
 'use strict';
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const stylis = require('stylis');
+
+stylis.set({ prefix: false });
 
 module.exports = function ({ config, mode }) {
   const isProd = mode === 'PRODUCTION';


### PR DESCRIPTION
Missed this part. It should match the lib's output so we can catch any issues ourselves more easily.