### PR TITLE
Add codecov badge, switch to json reporter, add codecov.yml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,7 @@
 comment:
   layout: 'reach, diff, files'
   require_changes: true
+
+parsers:
+  javascript:
+    enable_partials: yes

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+comment:
+  layout: 'reach, diff, files'
+  require_changes: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm-badge]][npm-url]
 [![type-badge]][npm-url]
 [![size-badge]][size-url]
+[![codecov-badge]][codecov-url]
 [![ci-badge]][ci-url]
 
 [npm-badge]: https://img.shields.io/npm/v/react-data-grid
@@ -10,6 +11,8 @@
 [size-badge]: https://img.shields.io/bundlephobia/minzip/react-data-grid
 [size-url]: https://bundlephobia.com/result?p=react-data-grid
 [type-badge]: https://img.shields.io/npm/types/react-data-grid
+[codecov-badge]: https://codecov.io/gh/adazzle/react-data-grid/branch/canary/graph/badge.svg?token=cvrRSWiz0Q
+[codecov-url]: https://codecov.io/gh/adazzle/react-data-grid
 [ci-badge]: https://github.com/adazzle/react-data-grid/workflows/CI/badge.svg
 [ci-url]: https://github.com/adazzle/react-data-grid/actions
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@
 export default {
   coverageProvider: 'v8',
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/types.ts'],
-  coverageReporters: ['cobertura'],
+  coverageReporters: ['json'],
   restoreMocks: true,
   setupFiles: ['./test/setup.ts'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],


### PR DESCRIPTION
https://docs.codecov.io/docs/supported-report-formats
https://docs.codecov.io/docs/node

The codecov.yml is picked up by the action, but it doesn't seem to do anything, maybe it'll change once we merge this pr to canary?