### PR TITLE
Allow optional DataGrid props to be null

### DIFF
--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -19,7 +19,7 @@ const cellResizable = css`
 
 const cellResizableClassname = `rdg-cell-resizable ${cellResizable}`;
 
-function getAriaSort(sortDirection: SortDirection | undefined) {
+function getAriaSort(sortDirection: SortDirection | undefined | null) {
   switch (sortDirection) {
     case 'ASC':
       return 'ascending';
@@ -31,7 +31,7 @@ function getAriaSort(sortDirection: SortDirection | undefined) {
 }
 
 type SharedHeaderRowProps<R, SR> = Pick<
-  HeaderRowProps<R, SR>,
+  HeaderRowProps<R, SR, React.Key>,
   'sortColumn' | 'sortDirection' | 'onSort' | 'allRowsSelected'
 >;
 

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -6,19 +6,19 @@ import { assertIsValidKeyGetter, getColSpan } from './utils';
 import type { DataGridProps } from './DataGrid';
 import { headerRowClassname } from './style';
 
-type SharedDataGridProps<R, SR> = Pick<
-  DataGridProps<R, SR>,
+type SharedDataGridProps<R, SR, K extends React.Key> = Pick<
+  DataGridProps<R, SR, K>,
   'rows' | 'onSelectedRowsChange' | 'sortColumn' | 'sortDirection' | 'onSort' | 'rowKeyGetter'
 >;
 
-export interface HeaderRowProps<R, SR> extends SharedDataGridProps<R, SR> {
+export interface HeaderRowProps<R, SR, K extends React.Key> extends SharedDataGridProps<R, SR, K> {
   columns: readonly CalculatedColumn<R, SR>[];
   allRowsSelected: boolean;
   onColumnResize: (column: CalculatedColumn<R, SR>, width: number) => void;
   lastFrozenColumnIndex: number;
 }
 
-function HeaderRow<R, SR>({
+function HeaderRow<R, SR, K extends React.Key>({
   columns,
   rows,
   rowKeyGetter,
@@ -29,14 +29,14 @@ function HeaderRow<R, SR>({
   sortDirection,
   onSort,
   lastFrozenColumnIndex
-}: HeaderRowProps<R, SR>) {
+}: HeaderRowProps<R, SR, K>) {
   const handleAllRowsSelectionChange = useCallback(
     (checked: boolean) => {
       if (!onSelectedRowsChange) return;
 
-      assertIsValidKeyGetter(rowKeyGetter);
+      assertIsValidKeyGetter<R, K>(rowKeyGetter);
 
-      const newSelectedRows = new Set<React.Key>(checked ? rows.map(rowKeyGetter) : undefined);
+      const newSelectedRows = new Set<K>(checked ? rows.map(rowKeyGetter) : undefined);
       onSelectedRowsChange(newSelectedRows);
     },
     [onSelectedRowsChange, rows, rowKeyGetter]
@@ -76,4 +76,6 @@ function HeaderRow<R, SR>({
   );
 }
 
-export default memo(HeaderRow) as <R, SR>(props: HeaderRowProps<R, SR>) => JSX.Element;
+export default memo(HeaderRow) as <R, SR, K extends React.Key>(
+  props: HeaderRowProps<R, SR, K>
+) => JSX.Element;

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -8,7 +8,7 @@ import { floor, max, min } from '../utils';
 
 interface CalculatedColumnsArgs<R, SR> extends Pick<DataGridProps<R, SR>, 'defaultColumnOptions'> {
   rawColumns: readonly Column<R, SR>[];
-  rawGroupBy: readonly string[] | undefined;
+  rawGroupBy: readonly string[] | undefined | null;
   viewportWidth: number;
   scrollLeft: number;
   columnWidths: ReadonlyMap<string, number>;

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -7,7 +7,7 @@ interface ViewportColumnsArgs<R, SR> {
   columns: readonly CalculatedColumn<R, SR>[];
   colSpanColumns: readonly CalculatedColumn<R, SR>[];
   rows: readonly (R | GroupRow<R>)[];
-  summaryRows: readonly SR[] | undefined;
+  summaryRows: readonly SR[] | undefined | null;
   colOverscanStartIdx: number;
   colOverscanEndIdx: number;
   lastFrozenColumnIndex: number;
@@ -72,7 +72,7 @@ export function useViewportColumns<R, SR>({
       }
 
       // check summary rows
-      if (summaryRows !== undefined) {
+      if (summaryRows != null) {
         for (const row of summaryRows) {
           if (
             updateStartIdx(

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -10,8 +10,11 @@ interface ViewportRowsArgs<R> {
   clientHeight: number;
   scrollTop: number;
   groupBy: readonly string[];
-  rowGrouper: ((rows: readonly R[], columnKey: string) => Record<string, readonly R[]>) | undefined;
-  expandedGroupIds: ReadonlySet<unknown> | undefined;
+  rowGrouper:
+    | ((rows: readonly R[], columnKey: string) => Record<string, readonly R[]>)
+    | undefined
+    | null;
+  expandedGroupIds: ReadonlySet<unknown> | undefined | null;
   enableVirtualization: boolean;
 }
 
@@ -31,7 +34,7 @@ export function useViewportRows<R>({
   enableVirtualization
 }: ViewportRowsArgs<R>) {
   const [groupedRows, rowsCount] = useMemo(() => {
-    if (groupBy.length === 0 || !rowGrouper) return [undefined, rawRows.length];
+    if (groupBy.length === 0 || rowGrouper == null) return [undefined, rawRows.length];
 
     const groupRows = (
       rows: readonly R[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,9 +116,9 @@ export interface EditorProps<TRow, TSummaryRow = unknown> extends SharedEditorPr
 
 export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
-  sortColumn: string | undefined;
-  sortDirection: SortDirection | undefined;
-  onSort: ((columnKey: string, direction: SortDirection) => void) | undefined;
+  sortColumn: string | undefined | null;
+  sortDirection: SortDirection | undefined | null;
+  onSort: ((columnKey: string, direction: SortDirection) => void) | undefined | null;
   allRowsSelected: boolean;
   onAllRowsSelectionChange: (checked: boolean) => void;
 }
@@ -156,7 +156,8 @@ export interface CellRendererProps<TRow, TSummaryRow = unknown>
   onRowChange: (rowIdx: number, newRow: TRow) => void;
   onRowClick:
     | ((rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void)
-    | undefined;
+    | undefined
+    | null;
   selectCell: (position: Position, enableEditor?: boolean) => void;
 }
 
@@ -176,8 +177,9 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
   onRowChange: (rowIdx: number, row: TRow) => void;
   onRowClick:
     | ((rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void)
-    | undefined;
-  rowClass: ((row: TRow) => string | undefined) | undefined;
+    | undefined
+    | null;
+  rowClass: ((row: TRow) => string | undefined | null) | undefined | null;
   setDraggedOverRowIdx: ((overRowIdx: number) => void) | undefined;
   selectCell: (position: Position, enableEditor?: boolean) => void;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,9 +10,9 @@ export * from './selectedCellUtils';
 
 export const { min, max, floor, ceil, sign } = Math;
 
-export function assertIsValidKeyGetter<R>(
+export function assertIsValidKeyGetter<R, K extends React.Key>(
   keyGetter: unknown
-): asserts keyGetter is (row: R) => React.Key {
+): asserts keyGetter is (row: R) => K {
   if (typeof keyGetter !== 'function') {
     throw new Error('Please specify the rowKeyGetter prop to use selection');
   }

--- a/stories/demos/AllFeatures.tsx
+++ b/stories/demos/AllFeatures.tsx
@@ -203,7 +203,7 @@ function loadMoreRows(newRowsCount: number, length: number): Promise<Row[]> {
 
 export function AllFeatures() {
   const [rows, setRows] = useState(() => createRows(2000));
-  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
+  const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
   const [isLoading, setIsLoading] = useState(false);
 
   function handleFill({ columnKey, sourceRow, targetRows }: FillEvent<Row>): Row[] {

--- a/stories/demos/CommonFeatures.tsx
+++ b/stories/demos/CommonFeatures.tsx
@@ -221,7 +221,7 @@ function createRows(): readonly Row[] {
 export function CommonFeatures() {
   const [rows, setRows] = useState(createRows);
   const [[sortColumn, sortDirection], setSort] = useState<[string, SortDirection]>(['id', 'NONE']);
-  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
+  const [selectedRows, setSelectedRows] = useState<ReadonlySet<number>>(() => new Set());
 
   const countries = useMemo(() => {
     return [...new Set(rows.map((r) => r.country))].sort(new Intl.Collator().compare);

--- a/stories/demos/Grouping.tsx
+++ b/stories/demos/Grouping.tsx
@@ -162,7 +162,7 @@ const options: OptionsType<Option> = [
 
 export function Grouping() {
   const [rows] = useState(createRows);
-  const [selectedRows, setSelectedRows] = useState(() => new Set<React.Key>());
+  const [selectedRows, setSelectedRows] = useState<ReadonlySet<number>>(() => new Set());
   const [selectedOptions, setSelectedOptions] = useState<ValueType<Option, true>>([
     options[0],
     options[1]

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from '@testing-library/react';
 import DataGrid from '../src/';
 import type { DataGridProps } from '../src/';
 
-export function setup<R, SR>(props: DataGridProps<R, SR>) {
+export function setup<R, SR, K extends React.Key>(props: DataGridProps<R, SR, K>) {
   return render(
     <StrictMode>
       <DataGrid {...props} />


### PR DESCRIPTION
Allowing `null` for optional props means this pattern won't be necessary anymore:
```tsx
<DataGrid optionalProp={maybeNull ?? undefined} />
```
`??`, `??=`, `?.`, and `!= null` makes this trivial thankfully.
Only downside I found was with default function params, `param = default` doesn't replace `null`s.
Non-ts users should get fewer surprises as well.

I've also fixed some missed spots with the new `K` generic.

`Column` props, and maybe other props will be done in separate PRs.