### PR TITLE
Add missing parameter type to cellRef in EditCell

### DIFF
--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -33,7 +33,7 @@ export default function EditCell<R, SR>({
 }: EditCellProps<R, SR>) {
   const [dimensions, setDimensions] = useState<{ left: number; top: number } | null>(null);
 
-  const cellRef = useCallback((node) => {
+  const cellRef = useCallback((node: HTMLDivElement | null) => {
     if (node !== null) {
       const { left, top } = node.getBoundingClientRect();
       setDimensions({ left, top });

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { ceil, floor, max, min } from '../utils';
 import type { GroupRow, GroupByDictionary, RowHeightArgs } from '../types';
 
-const RENDER_BACTCH_SIZE = 8;
+const RENDER_BATCH_SIZE = 8;
 
 interface ViewportRowsArgs<R> {
   rawRows: readonly R[];
@@ -179,11 +179,11 @@ export function useViewportRows<R>({
   const rowVisibleEndIdx = min(rows.length - 1, findRowIdx(scrollTop + clientHeight));
   const rowOverscanStartIdx = max(
     0,
-    floor((rowVisibleStartIdx - overscanThreshold) / RENDER_BACTCH_SIZE) * RENDER_BACTCH_SIZE
+    floor((rowVisibleStartIdx - overscanThreshold) / RENDER_BATCH_SIZE) * RENDER_BATCH_SIZE
   );
   const rowOverscanEndIdx = min(
     rows.length - 1,
-    ceil((rowVisibleEndIdx + overscanThreshold) / RENDER_BACTCH_SIZE) * RENDER_BACTCH_SIZE
+    ceil((rowVisibleEndIdx + overscanThreshold) / RENDER_BATCH_SIZE) * RENDER_BATCH_SIZE
   );
 
   return {


### PR DESCRIPTION
I guess TS allowed it because the type `any` got inferred by `useCallback` 🤷‍♂️ 