### PR TITLE
Rename remaining master references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,17 +56,17 @@ jobs:
         run: |
           git config --global user.email 'action@github.com'
           git config --global user.name 'GitHub Action'
-      - name: Deploy main
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git fetch origin gh-pages
-          git worktree add gh-pages gh-pages
-          git rm -r .
-          git checkout gh-pages -- canary
-          mv ../storybook-static/* .
-          git add .
-          git commit --allow-empty -m "main storybook deployment"
-          git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git
+      # - name: Deploy main
+      #   if: github.ref == 'refs/heads/main'
+      #   run: |
+      #     git fetch origin gh-pages
+      #     git worktree add gh-pages gh-pages
+      #     git rm -r .
+      #     git checkout gh-pages -- canary
+      #     mv ../storybook-static/* .
+      #     git add .
+      #     git commit --allow-empty -m "main storybook deployment"
+      #     git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git
       - name: Deploy canary
         if: github.ref == 'refs/heads/canary'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, alpha, canary]
+    branches: [main, alpha, canary]
   pull_request:
 
 jobs:
@@ -56,8 +56,8 @@ jobs:
         run: |
           git config --global user.email 'action@github.com'
           git config --global user.name 'GitHub Action'
-      - name: Deploy master
-        if: github.ref == 'refs/heads/master'
+      - name: Deploy main
+        if: github.ref == 'refs/heads/main'
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages gh-pages
@@ -65,7 +65,7 @@ jobs:
           git checkout gh-pages -- canary
           mv ../storybook-static/* .
           git add .
-          git commit --allow-empty -m "master storybook deployment"
+          git commit --allow-empty -m "main storybook deployment"
           git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git
       - name: Deploy canary
         if: github.ref == 'refs/heads/canary'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,7 +285,7 @@
   - ⚠️ `onScroll` will directly pass the UIEvent rather than the scrollLeft and scrollRight only.
   - ⚠️ The stylesheets are now automatically injected, there is no stylsheet to manually import anymore.
 
-## `master` to `alpha`
+## `main` to `alpha`
 
 - **Added:**
   - TypeScript declaration files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 For maintainers only.
 
 - `cd` to the root of the repo.
-- Checkout the branch you wish to publish. `master`, `alpha`, or `canary`
+- Checkout the branch you wish to publish. `main`, `alpha`, or `canary`
 - Make sure your local branch is up to date, no unpushed or missing commits, stash any changes.
 - Update the changelog, if necessary, and commit.
 - Login to the `adazzle` npm account if you haven't already done so:


### PR DESCRIPTION
We renamed the `master` branch to `main` a while back, but forgot to fix any references to it.