### PR TITLE
Update branch references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main, alpha, canary]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -67,8 +67,8 @@ jobs:
       #     git add .
       #     git commit --allow-empty -m "main storybook deployment"
       #     git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git
-      - name: Deploy canary
-        if: github.ref == 'refs/heads/canary'
+      - name: Deploy main
+        if: github.ref == 'refs/heads/main'
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages gh-pages
@@ -76,5 +76,5 @@ jobs:
           git rm -r --ignore-unmatch canary
           mv ../storybook-static canary
           git add canary
-          git commit --allow-empty -m "canary storybook deployment"
+          git commit --allow-empty -m "beta storybook deployment"
           git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,24 +3,21 @@
 For maintainers only.
 
 - `cd` to the root of the repo.
-- Checkout the branch you wish to publish. `main`, `alpha`, or `canary`
+- Checkout the `main` branch.
 - Make sure your local branch is up to date, no unpushed or missing commits, stash any changes.
 - Update the changelog, if necessary, and commit.
 - Login to the `adazzle` npm account if you haven't already done so:
   - `npm login`
   - You can use `npm whoami` to check who you are logged in as.
 - Bump the version and publish on npm:
-  - To release a new stable version:
+  <!-- - To release a new stable version:
     - `npm version [major | minor | patch] -m "Publish %s"`
-    - `npm publish`
-  - To release a new `alpha` version:
-    - `npm version prerelease --preid=alpha -m "Publish %s"`
-    - `npm publish --tag alpha`
-  - To release a new `canary` version:
-    - `npm version prerelease --preid=canary -m "Publish %s"`
-    - `npm publish --tag canary`
+    - `npm publish` -->
+  - To release a new `beta` version:
+    - `npm version prerelease --preid=beta -m "Publish %s"`
+    - `npm publish --tag beta`
   - Relevant docs:
-    - https://docs.npmjs.com/cli/version
-    - https://docs.npmjs.com/cli/publish
-    - https://docs.npmjs.com/misc/scripts
+    - https://docs.npmjs.com/cli/v7/commands/npm-version
+    - https://docs.npmjs.com/cli/v7/commands/npm-publish
+    - https://docs.npmjs.com/cli/v7/using-npm/scripts
     - https://git-scm.com/docs/git-push

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [size-badge]: https://img.shields.io/bundlephobia/minzip/react-data-grid
 [size-url]: https://bundlephobia.com/result?p=react-data-grid
 [type-badge]: https://img.shields.io/npm/types/react-data-grid
-[codecov-badge]: https://codecov.io/gh/adazzle/react-data-grid/branch/canary/graph/badge.svg?token=cvrRSWiz0Q
+[codecov-badge]: https://codecov.io/gh/adazzle/react-data-grid/branch/main/graph/badge.svg?token=cvrRSWiz0Q
 [codecov-url]: https://codecov.io/gh/adazzle/react-data-grid
 [ci-badge]: https://github.com/adazzle/react-data-grid/workflows/CI/badge.svg
 [ci-url]: https://github.com/adazzle/react-data-grid/actions


### PR DESCRIPTION
For now we'll keep deploying the storybook under `/canary/`.