### PR TITLE
rm Cell export and RowRendererProps.cellRenderer

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo } from 'react';
+import { memo } from 'react';
 import type { RefAttributes } from 'react';
 import { css } from '@linaria/core';
 
@@ -40,27 +40,24 @@ const cellDragHandle = css`
 
 const cellDragHandleClassname = `rdg-cell-drag-handle ${cellDragHandle}`;
 
-function Cell<R, SR>(
-  {
-    className,
-    column,
-    colSpan,
-    isCellSelected,
-    isCopied,
-    isDraggedOver,
-    row,
-    rowIdx,
-    dragHandleProps,
-    onRowClick,
-    onClick,
-    onDoubleClick,
-    onContextMenu,
-    onRowChange,
-    selectCell,
-    ...props
-  }: CellRendererProps<R, SR>,
-  ref: React.Ref<HTMLDivElement>
-) {
+function Cell<R, SR>({
+  className,
+  column,
+  colSpan,
+  isCellSelected,
+  isCopied,
+  isDraggedOver,
+  row,
+  rowIdx,
+  dragHandleProps,
+  onRowClick,
+  onClick,
+  onDoubleClick,
+  onContextMenu,
+  onRowChange,
+  selectCell,
+  ...props
+}: CellRendererProps<R, SR>) {
   const { cellClass } = column;
   className = getCellClassname(
     column,
@@ -103,7 +100,6 @@ function Cell<R, SR>(
       aria-selected={isCellSelected}
       aria-colspan={colSpan}
       aria-readonly={!isCellEditable(column, row) || undefined}
-      ref={ref}
       className={className}
       style={getCellStyle(column, colSpan)}
       onClick={handleClick}
@@ -127,6 +123,6 @@ function Cell<R, SR>(
   );
 }
 
-export default memo(forwardRef(Cell)) as <R, SR>(
+export default memo(Cell) as <R, SR>(
   props: CellRendererProps<R, SR> & RefAttributes<HTMLDivElement>
 ) => JSX.Element;

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -41,7 +41,6 @@ const cellDragHandle = css`
 const cellDragHandleClassname = `rdg-cell-drag-handle ${cellDragHandle}`;
 
 function Cell<R, SR>({
-  className,
   column,
   colSpan,
   isCellSelected,
@@ -51,42 +50,35 @@ function Cell<R, SR>({
   rowIdx,
   dragHandleProps,
   onRowClick,
-  onClick,
-  onDoubleClick,
-  onContextMenu,
   onRowChange,
   selectCell,
   ...props
 }: CellRendererProps<R, SR>) {
   const { cellClass } = column;
-  className = getCellClassname(
+  const className = getCellClassname(
     column,
     {
       [cellCopiedClassname]: isCopied,
       [cellDraggedOverClassname]: isDraggedOver
     },
-    typeof cellClass === 'function' ? cellClass(row) : cellClass,
-    className
+    typeof cellClass === 'function' ? cellClass(row) : cellClass
   );
 
   function selectCellWrapper(openEditor?: boolean | null) {
     selectCell({ idx: column.idx, rowIdx }, openEditor);
   }
 
-  function handleClick(event: React.MouseEvent<HTMLDivElement>) {
+  function handleClick() {
     selectCellWrapper(column.editorOptions?.editOnClick);
     onRowClick?.(rowIdx, row, column);
-    onClick?.(event);
   }
 
-  function handleContextMenu(event: React.MouseEvent<HTMLDivElement>) {
+  function handleContextMenu() {
     selectCellWrapper();
-    onContextMenu?.(event);
   }
 
-  function handleDoubleClick(event: React.MouseEvent<HTMLDivElement>) {
+  function handleDoubleClick() {
     selectCellWrapper(true);
-    onDoubleClick?.(event);
   }
 
   function handleRowChange(newRow: R) {

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -11,7 +11,6 @@ import { RowSelectionProvider } from './hooks';
 
 function Row<R, SR>(
   {
-    cellRenderer,
     className,
     rowIdx,
     isRowSelected,
@@ -48,7 +47,6 @@ function Row<R, SR>(
     className
   );
 
-  const CellRenderer = cellRenderer ?? Cell;
   const cells = [];
 
   for (let index = 0; index < viewportColumns.length; index++) {
@@ -74,7 +72,7 @@ function Row<R, SR>(
     }
 
     cells.push(
-      <CellRenderer
+      <Cell
         key={column.key}
         rowIdx={rowIdx}
         column={column}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export { default } from './DataGrid';
 export type { DataGridProps, DataGridHandle } from './DataGrid';
-export { default as Cell } from './Cell';
 export { default as Row } from './Row';
 export * from './Columns';
 export * from './formatters';

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,6 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
   viewportColumns: readonly CalculatedColumn<TRow, TSummaryRow>[];
   row: TRow;
-  cellRenderer?: React.ComponentType<CellRendererProps<TRow, TSummaryRow>> | null;
   rowIdx: number;
   copiedCellIdx: number | undefined;
   draggedOverCellIdx: number | undefined;


### PR DESCRIPTION
I'm not 100% sure we should do it, but we don't use it ourselves, and it's better than abusing custom renderers just to add class names.
We can revert this in any case.