### PR TITLE
Rolling rows

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -980,7 +980,7 @@ function DataGrid<R, SR, K extends Key>(
             aria-posinset={row.posInSet + 1} // aria-posinset is 1-based
             aria-rowindex={headerRowsCount + startRowIndex + 1} // aria-rowindex is 1 based
             aria-selected={isSelectable ? isGroupRowSelected : undefined}
-            key={idx}
+            key={row.id}
             id={row.id}
             groupKey={row.groupKey}
             viewportColumns={viewportColumns}
@@ -1015,7 +1015,7 @@ function DataGrid<R, SR, K extends Key>(
         <RowRenderer
           aria-rowindex={headerRowsCount + (hasGroups ? startRowIndex : rowIdx) + 1} // aria-rowindex is 1 based
           aria-selected={isSelectable ? isRowSelected : undefined}
-          key={idx}
+          key={key}
           rowIdx={rowIdx}
           row={row}
           viewportColumns={viewportColumns}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -962,7 +962,11 @@ function DataGrid<R, SR, K extends Key>(
   function getViewportRows() {
     const rowElements = [];
     let startRowIndex = 0;
-    for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
+    const length = rowOverscanEndIdx - rowOverscanStartIdx;
+    const offset = rowOverscanEndIdx % length;
+    const startOffset = (length - offset) % length;
+    for (let idx = 0; idx < length; idx++) {
+      const rowIdx = ((startOffset + idx) % length) + rowOverscanStartIdx;
       const row = rows[rowIdx];
       const top = getRowTop(rowIdx) + headerRowHeight;
       if (isGroupRow(row)) {
@@ -976,7 +980,7 @@ function DataGrid<R, SR, K extends Key>(
             aria-posinset={row.posInSet + 1} // aria-posinset is 1-based
             aria-rowindex={headerRowsCount + startRowIndex + 1} // aria-rowindex is 1 based
             aria-selected={isSelectable ? isGroupRowSelected : undefined}
-            key={row.id}
+            key={idx}
             id={row.id}
             groupKey={row.groupKey}
             viewportColumns={viewportColumns}
@@ -1011,7 +1015,7 @@ function DataGrid<R, SR, K extends Key>(
         <RowRenderer
           aria-rowindex={headerRowsCount + (hasGroups ? startRowIndex : rowIdx) + 1} // aria-rowindex is 1 based
           aria-selected={isSelectable ? isRowSelected : undefined}
-          key={key}
+          key={idx}
           rowIdx={rowIdx}
           row={row}
           viewportColumns={viewportColumns}

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -1,4 +1,4 @@
-import { memo, forwardRef, useEffect } from 'react';
+import { memo, forwardRef } from 'react';
 import type { RefAttributes, CSSProperties } from 'react';
 import clsx from 'clsx';
 
@@ -46,13 +46,6 @@ function Row<R, SR>(
     rowClass?.(row),
     className
   );
-
-  useEffect(() => {
-    console.log('mount!');
-    return () => {
-      console.log('unmount!');
-    };
-  }, []);
 
   const cells = [];
 

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -1,4 +1,4 @@
-import { memo, forwardRef } from 'react';
+import { memo, forwardRef, useEffect } from 'react';
 import type { RefAttributes, CSSProperties } from 'react';
 import clsx from 'clsx';
 
@@ -46,6 +46,13 @@ function Row<R, SR>(
     rowClass?.(row),
     className
   );
+
+  useEffect(() => {
+    console.log('mount!');
+    return () => {
+      console.log('unmount!');
+    };
+  }, []);
 
   const cells = [];
 

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -2,8 +2,6 @@ import { useMemo } from 'react';
 import { ceil, floor, max, min } from '../utils';
 import type { GroupRow, GroupByDictionary, RowHeightArgs } from '../types';
 
-const RENDER_BATCH_SIZE = 8;
-
 interface ViewportRowsArgs<R> {
   rawRows: readonly R[];
   rowHeight: number | ((args: RowHeightArgs<R>) => number);
@@ -176,14 +174,12 @@ export function useViewportRows<R>({
 
   const overscanThreshold = 4;
   const rowVisibleStartIdx = findRowIdx(scrollTop);
-  const rowVisibleEndIdx = min(rows.length - 1, findRowIdx(scrollTop + clientHeight));
-  const rowOverscanStartIdx = max(
-    0,
-    floor((rowVisibleStartIdx - overscanThreshold) / RENDER_BATCH_SIZE) * RENDER_BATCH_SIZE
-  );
+  // TODO: replace 35 by minimum dynamic row height
+  const maxVisibleRowsCount = ceil(clientHeight / (typeof rowHeight === 'number' ? rowHeight : 35));
+  const rowOverscanStartIdx = max(0, rowVisibleStartIdx - overscanThreshold);
   const rowOverscanEndIdx = min(
     rows.length - 1,
-    ceil((rowVisibleEndIdx + overscanThreshold) / RENDER_BATCH_SIZE) * RENDER_BATCH_SIZE
+    rowVisibleStartIdx + maxVisibleRowsCount + overscanThreshold
   );
 
   return {

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -172,15 +172,21 @@ export function useViewportRows<R>({
     };
   }
 
-  const overscanThreshold = 4;
-  const rowVisibleStartIdx = findRowIdx(scrollTop);
+  const overscanThreshold = 2;
   // TODO: replace 35 by minimum dynamic row height
-  const maxVisibleRowsCount = ceil(clientHeight / (typeof rowHeight === 'number' ? rowHeight : 35));
-  const rowOverscanStartIdx = max(0, rowVisibleStartIdx - overscanThreshold);
-  const rowOverscanEndIdx = min(
-    rows.length - 1,
-    rowVisibleStartIdx + maxVisibleRowsCount + overscanThreshold
-  );
+  const visibleRowsCount =
+    ceil(clientHeight / (typeof rowHeight === 'number' ? rowHeight : 35)) + overscanThreshold * 2;
+  const rowVisibleStartIdx = findRowIdx(scrollTop);
+  const maxEndIdx = rows.length;
+
+  let rowOverscanStartIdx = max(0, rowVisibleStartIdx - overscanThreshold);
+  let rowOverscanEndIdx;
+  if (rowOverscanStartIdx + visibleRowsCount > maxEndIdx) {
+    rowOverscanStartIdx = max(0, maxEndIdx - visibleRowsCount);
+    rowOverscanEndIdx = maxEndIdx;
+  } else {
+    rowOverscanEndIdx = rowOverscanStartIdx + visibleRowsCount;
+  }
 
   return {
     rowOverscanStartIdx,


### PR DESCRIPTION
Closes #2443

The idea is to always keep the same amount of rendered rows, and re-use them instead of unmounting them as we scroll.

For example: we initially render rows `1, 2, 3, 4`, and as we scroll we then render rows `5, 6, 3, 4`. Rows `1` and `2` have been reused to render rows `5` and `6`, that way we do not unmount the rows and cells, we only re-render them.
This should provide a performance benefit as we remove and create less DOM elements, though we should run some JS profiling to confirm that.

Concerns:
- Does this affect accessibility?
- We use `idx` for `key` props now instead of relying on row keys, can this be an issue?