### PR TITLE
Add onRowDoubleClick prop

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -50,6 +50,7 @@ function Cell<R, SR>({
   rowIdx,
   dragHandleProps,
   onRowClick,
+  onRowDoubleClick,
   onRowChange,
   selectCell,
   ...props
@@ -70,7 +71,7 @@ function Cell<R, SR>({
 
   function handleClick() {
     selectCellWrapper(column.editorOptions?.editOnClick);
-    onRowClick?.(rowIdx, row, column);
+    onRowClick?.(row, column);
   }
 
   function handleContextMenu() {
@@ -79,6 +80,7 @@ function Cell<R, SR>({
 
   function handleDoubleClick() {
     selectCellWrapper(true);
+    onRowDoubleClick?.(row, column);
   }
 
   function handleRowChange(newRow: R) {

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -145,7 +145,9 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * Event props
    */
   /** Function called whenever a row is clicked */
-  onRowClick?: ((rowIdx: number, row: R, column: CalculatedColumn<R, SR>) => void) | null;
+  onRowClick?: ((row: R, column: CalculatedColumn<R, SR>) => void) | null;
+  /** Function called whenever a row is double clicked */
+  onRowDoubleClick?: ((row: R, column: CalculatedColumn<R, SR>) => void) | null;
   /** Called when the grid is scrolled */
   onScroll?: ((event: React.UIEvent<HTMLDivElement>) => void) | null;
   /** Called when a column is resized */
@@ -201,6 +203,7 @@ function DataGrid<R, SR, K extends Key>(
     emptyRowsRenderer: EmptyRowsRenderer,
     // Event props
     onRowClick,
+    onRowDoubleClick,
     onScroll,
     onColumnResize,
     onSelectedCellChange,
@@ -1017,6 +1020,7 @@ function DataGrid<R, SR, K extends Key>(
           viewportColumns={viewportColumns}
           isRowSelected={isRowSelected}
           onRowClick={onRowClick}
+          onRowDoubleClick={onRowDoubleClick}
           rowClass={rowClass}
           top={top}
           height={getRowHeight(rowIdx)}

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -21,6 +21,7 @@ function Row<R, SR>(
     viewportColumns,
     selectedCellProps,
     onRowClick,
+    onRowDoubleClick,
     rowClass,
     setDraggedOverRowIdx,
     onMouseEnter,
@@ -87,6 +88,7 @@ function Row<R, SR>(
         onFocus={isCellSelected ? (selectedCellProps as SelectedCellProps).onFocus : undefined}
         onKeyDown={isCellSelected ? selectedCellProps!.onKeyDown : undefined}
         onRowClick={onRowClick}
+        onRowDoubleClick={onRowDoubleClick}
         onRowChange={onRowChange}
         selectCell={selectCell}
       />

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,11 @@ export interface SelectedCellProps extends SelectedCellPropsBase {
 export type SelectCellFn = (position: Position, enableEditor?: boolean | null) => void;
 
 export interface CellRendererProps<TRow, TSummaryRow>
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
+  extends Pick<
+      RowRendererProps<TRow, TSummaryRow>,
+      'onRowChange' | 'onRowClick' | 'onRowDoubleClick' | 'selectCell'
+    >,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
   rowIdx: number;
   column: CalculatedColumn<TRow, TSummaryRow>;
   colSpan: number | undefined;
@@ -145,12 +149,6 @@ export interface CellRendererProps<TRow, TSummaryRow>
   dragHandleProps:
     | Pick<React.HTMLAttributes<HTMLDivElement>, 'onMouseDown' | 'onDoubleClick'>
     | undefined;
-  onRowChange: (rowIdx: number, newRow: TRow) => void;
-  onRowClick:
-    | ((rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void)
-    | undefined
-    | null;
-  selectCell: SelectCellFn;
 }
 
 export interface RowRendererProps<TRow, TSummaryRow = unknown>
@@ -166,8 +164,9 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
   height: number;
   selectedCellProps: EditCellProps<TRow> | SelectedCellProps | undefined;
   onRowChange: (rowIdx: number, row: TRow) => void;
-  onRowClick:
-    | ((rowIdx: number, row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void)
+  onRowClick: ((row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void) | undefined | null;
+  onRowDoubleClick:
+    | ((row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => void)
     | undefined
     | null;
   rowClass: ((row: TRow) => string | undefined | null) | undefined | null;


### PR DESCRIPTION
Fixes #2344

- [x] Add `onRowDoubleClick` prop
- [x] Remove `rowIdx` param from `onRowClick`. `rowIdx` prop will be removed from from cell components in https://github.com/adazzle/react-data-grid/pull/2464