### PR TITLE
Dependabot: set versioning-strategy to increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    versioning-strategy: increase
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Let's see if this will also open PRs for minor/patch versions.
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy