### PR TITLE
SortableHeaderCell: show sort arrow with svg

### DIFF
--- a/src/formatters/ToggleGroupFormatter.tsx
+++ b/src/formatters/ToggleGroupFormatter.tsx
@@ -46,7 +46,7 @@ export function ToggleGroupFormatter<R, SR>({
       onKeyDown={handleKeyDown}
     >
       {groupKey}
-      <svg viewBox="0 0 14 8" width="14" height="8" className={caretClassname}>
+      <svg viewBox="0 0 14 8" width="14" height="8" className={caretClassname} aria-hidden>
         <path d={d} />
       </svg>
     </span>

--- a/src/headerCells/SortableHeaderCell.tsx
+++ b/src/headerCells/SortableHeaderCell.tsx
@@ -1,5 +1,6 @@
 import { css } from '@linaria/core';
 import type { HeaderRendererProps } from '../types';
+
 const headerSortCell = css`
   cursor: pointer;
   display: flex;
@@ -16,10 +17,21 @@ const headerSortName = css`
 
 const headerSortNameClassname = `rdg-header-sort-name ${headerSortName}`;
 
+const arrow = css`
+  fill: currentColor;
+
+  > path {
+    transition: d 0.1s;
+  }
+`;
+
+const arrowClassname = `rdg-sort-arrow ${arrow}`;
+
 type SharedHeaderCellProps<R, SR> = Pick<
   HeaderRendererProps<R, SR>,
   'sortDirection' | 'onSort' | 'priority'
 >;
+
 interface Props<R, SR> extends SharedHeaderCellProps<R, SR> {
   children: React.ReactNode;
 }
@@ -30,18 +42,15 @@ export default function SortableHeaderCell<R, SR>({
   priority,
   children
 }: Props<R, SR>) {
-  let sortText = '';
-  if (sortDirection === 'ASC') {
-    sortText = '\u25B2';
-  } else if (sortDirection === 'DESC') {
-    sortText = '\u25BC';
-  }
-
   return (
     <span className={headerSortCellClassname} onClick={(e) => onSort(e.ctrlKey)}>
       <span className={headerSortNameClassname}>{children}</span>
       <span>
-        {sortText}
+        {sortDirection !== undefined && (
+          <svg viewBox="0 0 12 8" width="12" height="8" className={arrowClassname}>
+            <path d={sortDirection === 'ASC' ? 'M0 8 6 0 12 8' : 'M0 0 6 8 12 0'} />
+          </svg>
+        )}
         {priority}
       </span>
     </span>

--- a/src/headerCells/SortableHeaderCell.tsx
+++ b/src/headerCells/SortableHeaderCell.tsx
@@ -47,7 +47,7 @@ export default function SortableHeaderCell<R, SR>({
       <span className={headerSortNameClassname}>{children}</span>
       <span>
         {sortDirection !== undefined && (
-          <svg viewBox="0 0 12 8" width="12" height="8" className={arrowClassname}>
+          <svg viewBox="0 0 12 8" width="12" height="8" className={arrowClassname} aria-hidden>
             <path d={sortDirection === 'ASC' ? 'M0 8 6 0 12 8' : 'M0 0 6 8 12 0'} />
           </svg>
         )}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/567105/123653004-b1e61400-d824-11eb-98a0-e19c8f596cfc.png)

After
![image](https://user-images.githubusercontent.com/567105/123652993-ae528d00-d824-11eb-9b03-5cf980e320ec.png)

We can animate it, tweak it however we want, and it'll be consistent across platforms/fonts.