### PR TITLE
Revert "Dependabot: set versioning-strategy to increase (#2479)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    versioning-strategy: increase
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
This reverts commit ba6b22b3a51840207e9edb015e94055746c3a8f9.

This is just too spammy, the process of getting each PR merged is way too slow, and it doesn't make sense when some dependencies are related (babel, linaria, typescript-eslint, ...).