### PR TITLE
Support commandKey for multisort

### DIFF
--- a/src/headerCells/SortableHeaderCell.tsx
+++ b/src/headerCells/SortableHeaderCell.tsx
@@ -43,7 +43,7 @@ export default function SortableHeaderCell<R, SR>({
   children
 }: Props<R, SR>) {
   return (
-    <span className={headerSortCellClassname} onClick={(e) => onSort(e.ctrlKey)}>
+    <span className={headerSortCellClassname} onClick={(e) => onSort(e.ctrlKey || e.metaKey)}>
       <span className={headerSortNameClassname}>{children}</span>
       <span>
         {sortDirection !== undefined && (

--- a/test/multiColumnSort.test.tsx
+++ b/test/multiColumnSort.test.tsx
@@ -52,3 +52,13 @@ test('multi column sort', () => {
     { columnKey: 'direction', direction: 'ASC' }
   ]);
 });
+
+test('multi column sort with metakey', () => {
+  setup();
+  userEvent.click(getHeaderCells()[0].firstElementChild!);
+  userEvent.click(getHeaderCells()[1].firstElementChild!, { metaKey: true });
+  expect(JSON.parse(screen.getByTestId('sortColumnsValue')!.textContent!)).toStrictEqual([
+    { columnKey: 'columnKey', direction: 'ASC' },
+    { columnKey: 'direction', direction: 'ASC' }
+  ]);
+});


### PR DESCRIPTION
for Mac multi sort is not working with Ctrl key.