### PR TITLE
Use a ref to keep track of dragged overRowIdx

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -255,13 +255,14 @@ function DataGrid<R, SR, K extends Key>(
   );
   const [copiedCell, setCopiedCell] = useState<{ row: R; columnKey: string } | null>(null);
   const [isDragging, setDragging] = useState(false);
-  const [draggedOverRowIdx, setDraggedOverRowIdx] = useState<number | undefined>(undefined);
+  const [draggedOverRowIdx, setOverRowIdx] = useState<number | undefined>(undefined);
 
   /**
    * refs
    */
   const focusSinkRef = useRef<HTMLDivElement>(null);
   const prevSelectedPosition = useRef(selectedPosition);
+  const latestDraggedOverRowIdx = useRef(draggedOverRowIdx);
   const lastSelectedRowIdx = useRef(-1);
   const isCellFocusable = useRef(false);
 
@@ -413,6 +414,11 @@ function DataGrid<R, SR, K extends Key>(
     },
     [onColumnResize]
   );
+
+  const setDraggedOverRowIdx = useCallback((rowIdx?: number) => {
+    setOverRowIdx(rowIdx);
+    latestDraggedOverRowIdx.current = rowIdx;
+  }, []);
 
   /**
    * event handlers
@@ -906,7 +912,7 @@ function DataGrid<R, SR, K extends Key>(
             columns={columns}
             selectedPosition={selectedPosition}
             isCellEditable={isCellEditable}
-            draggedOverRowIdx={draggedOverRowIdx}
+            latestDraggedOverRowIdx={latestDraggedOverRowIdx}
             onRowsChange={onRowsChange}
             onFill={onFill}
             setDragging={setDragging}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -906,6 +906,7 @@ function DataGrid<R, SR, K extends Key>(
             columns={columns}
             selectedPosition={selectedPosition}
             isCellEditable={isCellEditable}
+            draggedOverRowIdx={draggedOverRowIdx}
             onRowsChange={onRowsChange}
             onFill={onFill}
             setDragging={setDragging}

--- a/src/DragHandle.tsx
+++ b/src/DragHandle.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from 'react';
 import { css } from '@linaria/core';
 
 import type { CalculatedColumn, FillEvent, Position } from './types';
@@ -26,7 +25,7 @@ const cellDragHandleClassname = `rdg-cell-drag-handle ${cellDragHandle}`;
 interface Props<R, SR> extends Pick<DataGridProps<R, SR>, 'rows' | 'onRowsChange'> {
   columns: readonly CalculatedColumn<R, SR>[];
   selectedPosition: SelectCellState;
-  draggedOverRowIdx: number | undefined;
+  latestDraggedOverRowIdx: React.MutableRefObject<number | undefined>;
   isCellEditable: (position: Position) => boolean;
   onFill: (event: FillEvent<R>) => R;
   setDragging: (isDragging: boolean) => void;
@@ -37,18 +36,13 @@ export default function DragHandle<R, SR>({
   rows,
   columns,
   selectedPosition,
-  draggedOverRowIdx,
+  latestDraggedOverRowIdx,
   isCellEditable,
   onRowsChange,
   onFill,
   setDragging,
   setDraggedOverRowIdx
 }: Props<R, SR>) {
-  const latestDraggedOverRowIdx = useRef(draggedOverRowIdx);
-  useEffect(() => {
-    latestDraggedOverRowIdx.current = draggedOverRowIdx;
-  });
-
   function handleMouseDown(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     if (event.buttons !== 1) return;
     setDragging(true);


### PR DESCRIPTION
Fixes react warning

![image](https://user-images.githubusercontent.com/1452717/128074720-52086407-b845-4f37-8f5d-46c9ccf00672.png)
