### PR TITLE
Select row on Shift + Space

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -632,7 +632,7 @@ function DataGrid<R, SR, K extends Key>(
     if (!isCellWithinBounds(selectedPosition) || selectedPosition.idx === -1) return;
     const row = rows[selectedPosition.rowIdx];
     if (isGroupRow(row)) return;
-    const { key } = event;
+    const { key, shiftKey } = event;
 
     if (selectedPosition.mode === 'EDIT') {
       if (key === 'Enter') {
@@ -640,6 +640,16 @@ function DataGrid<R, SR, K extends Key>(
         commitEditorChanges();
         closeEditor();
       }
+      return;
+    }
+
+    // Select the row on Shift + Space
+    if (isSelectable && shiftKey && key === ' ') {
+      assertIsValidKeyGetter<R, K>(rowKeyGetter);
+      const rowKey = rowKeyGetter(row);
+      selectRow({ row, checked: !selectedRows!.has(rowKey), isShiftClick: false });
+      // do not scroll
+      event.preventDefault();
       return;
     }
 

--- a/test/rowSelection.test.tsx
+++ b/test/rowSelection.test.tsx
@@ -14,10 +14,7 @@ const columns: readonly Column<Row>[] = [
   SelectColumn,
   {
     key: 'name',
-    name: 'Name',
-    formatter() {
-      return null;
-    }
+    name: 'Name'
   }
 ];
 

--- a/test/rowSelection.test.tsx
+++ b/test/rowSelection.test.tsx
@@ -10,7 +10,16 @@ interface Row {
   id: number;
 }
 
-const columns: readonly Column<Row>[] = [SelectColumn];
+const columns: readonly Column<Row>[] = [
+  SelectColumn,
+  {
+    key: 'name',
+    name: 'Name',
+    formatter() {
+      return null;
+    }
+  }
+];
 
 const defaultRows: readonly Row[] = [{ id: 1 }, { id: 2 }, { id: 3 }];
 
@@ -185,4 +194,15 @@ test('select rows using shift click', () => {
   testSelection(0, true);
   testSelection(1, true);
   testSelection(2, true);
+});
+
+test('select rows using shift space', () => {
+  setup();
+  userEvent.click(getCellsAtRowIndex(0)[1]);
+  userEvent.keyboard('{shift}{space}');
+  testSelection(0, true);
+  userEvent.keyboard('{space}');
+  testSelection(0, true);
+  userEvent.keyboard('{shift}{space}');
+  testSelection(0, false);
 });


### PR DESCRIPTION
https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-for-data-grids

> Shift + Space: Selects the row that contains the focus. If the grid includes a column with checkboxes for selecting rows, this key can serve as a shortcut for checking the box when focus is not on the checkbox.