### PR TITLE
Tweak flickering grid workaround

### DIFF
--- a/src/hooks/useGridDimensions.ts
+++ b/src/hooks/useGridDimensions.ts
@@ -23,7 +23,7 @@ export function useGridDimensions(): [
       // TODO: remove once fixed upstream
       // we reduce width by 1px here to avoid layout issues in Chrome
       // https://bugs.chromium.org/p/chromium/issues/detail?id=1206298
-      setGridWidth(clientWidth - (devicePixelRatio % 0.5 === 0 ? 0 : 1));
+      setGridWidth(clientWidth - (devicePixelRatio % 1 === 0 ? 0 : 1));
       setGridHeight(clientHeight);
     });
 


### PR DESCRIPTION
https://github.com/adazzle/react-data-grid/pull/2389#issuecomment-900192997

@ekeuus I've never reproduced the issue since we added the workaround, and I never had issues with 150% zoom level, so that's why it was `% 0.5`. I don't mind using `% 1` to catch more edge cases.

>Should the fix rather be to round the width down/up always to prevent the flickering?

`clientWidth` is always an integer.