### PR TITLE
Refactor pointer events handling when resizing columns

### DIFF
--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -44,6 +44,45 @@ export default function HeaderCell<R, SR>({
   sortColumns,
   onSortColumnsChange
 }: HeaderCellProps<R, SR>) {
+  function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    if (event.pointerType === 'mouse' && event.buttons !== 1) {
+      return;
+    }
+
+    const { currentTarget, pointerId } = event;
+    const { right } = currentTarget.getBoundingClientRect();
+    const offset = right - event.clientX;
+
+    if (offset > 11) {
+      // +1px to account for the border size
+      return;
+    }
+
+    function onPointerMove(event: PointerEvent) {
+      if (event.pointerType === 'mouse' && event.buttons !== 1) {
+        // handle case where the pointer `up`'d outside an iframe
+        onPointerUp();
+        return;
+      }
+
+      const width = event.clientX + offset - currentTarget.getBoundingClientRect().left;
+      if (width > 0) {
+        onColumnResize(column, width);
+      }
+    }
+
+    function onPointerUp() {
+      currentTarget.releasePointerCapture(pointerId);
+      currentTarget.removeEventListener('pointermove', onPointerMove);
+      currentTarget.removeEventListener('pointerup', onPointerUp);
+    }
+
+    event.preventDefault();
+    currentTarget.setPointerCapture(pointerId);
+    currentTarget.addEventListener('pointermove', onPointerMove);
+    currentTarget.addEventListener('pointerup', onPointerUp);
+  }
+
   const sortIndex = sortColumns?.findIndex((sort) => sort.columnKey === column.key);
   const sortColumn =
     sortIndex !== undefined && sortIndex > -1 ? sortColumns![sortIndex] : undefined;
@@ -88,45 +127,6 @@ export default function HeaderCell<R, SR>({
       }
     }
   };
-
-  function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
-    if (event.pointerType === 'mouse' && event.buttons !== 1) {
-      return;
-    }
-
-    const { currentTarget, pointerId } = event;
-    const { right } = currentTarget.getBoundingClientRect();
-    const offset = right - event.clientX;
-
-    if (offset > 11) {
-      // +1px to account for the border size
-      return;
-    }
-
-    function onPointerMove(event: PointerEvent) {
-      if (event.pointerType === 'mouse' && event.buttons !== 1) {
-        // handle case where the pointer `up`'d outside an iframe
-        onPointerUp();
-        return;
-      }
-
-      const width = event.clientX + offset - currentTarget.getBoundingClientRect().left;
-      if (width > 0) {
-        onColumnResize(column, width);
-      }
-    }
-
-    function onPointerUp() {
-      currentTarget.releasePointerCapture(pointerId);
-      currentTarget.removeEventListener('pointermove', onPointerMove);
-      currentTarget.removeEventListener('pointerup', onPointerUp);
-    }
-
-    event.preventDefault();
-    currentTarget.setPointerCapture(pointerId);
-    currentTarget.addEventListener('pointermove', onPointerMove);
-    currentTarget.addEventListener('pointerup', onPointerUp);
-  }
 
   function getCell() {
     if (column.headerRenderer) {

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -103,19 +103,17 @@ export default function HeaderCell<R, SR>({
       return;
     }
 
-    let frameRequest: number;
-
     function onPointerMove(event: PointerEvent) {
-      // `pointermove` events can trigger more than once per frame,
-      // leading to poor performance.
-      cancelAnimationFrame(frameRequest);
+      if (event.pointerType === 'mouse' && event.buttons !== 1) {
+        // handle case where the pointer `up`'d outside an iframe
+        onPointerUp();
+        return;
+      }
 
-      frameRequest = requestAnimationFrame(() => {
-        const width = event.clientX + offset - currentTarget.getBoundingClientRect().left;
-        if (width > 0) {
-          onColumnResize(column, width);
-        }
-      });
+      const width = event.clientX + offset - currentTarget.getBoundingClientRect().left;
+      if (width > 0) {
+        onColumnResize(column, width);
+      }
     }
 
     function onPointerUp() {

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -74,7 +74,6 @@ export default function HeaderCell<R, SR>({
     }
 
     function onPointerUp() {
-      currentTarget.releasePointerCapture(pointerId);
       currentTarget.removeEventListener('pointermove', onPointerMove);
       currentTarget.removeEventListener('pointerup', onPointerUp);
     }

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -61,6 +61,8 @@ export default function HeaderCell<R, SR>({
     function onPointerMove(event: PointerEvent) {
       if (event.pointerType === 'mouse' && event.buttons !== 1) {
         // handle case where the pointer `up`'d outside an iframe
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=606896
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=693494
         onPointerUp();
         return;
       }

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -33,7 +33,6 @@ const headerRow = css`
   background-color: var(--header-background-color);
   font-weight: bold;
   z-index: 3;
-  touch-action: none;
 `;
 
 const headerRowClassname = `rdg-header-row ${headerRow}`;
@@ -60,7 +59,7 @@ function HeaderRow<R, SR, K extends React.Key>({
         key={column.key}
         column={column}
         colSpan={colSpan}
-        onResize={onColumnResize}
+        onColumnResize={onColumnResize}
         allRowsSelected={allRowsSelected}
         onAllRowsSelectionChange={onAllRowsSelectionChange}
         onSortColumnsChange={onSortColumnsChange}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -66,3 +66,6 @@ Object.defineProperties(Element.prototype, {
     }
   }
 });
+
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture
With this API, we shouldn't need any special handling when the pointer is outside the target.
Except iframes...
I believe we also don't need to check for multi-touch, not 100% sure, can't really test.
We should try this with the drag handle as well.