### PR TITLE
Jest: Use the default `coverageProvider`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 // https://jestjs.io/docs/configuration
 
 export default {
-  coverageProvider: 'v8',
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/types.ts'],
   coverageReporters: ['json'],
   restoreMocks: true,


### PR DESCRIPTION
The v8 provider/underlying tools make for somewhat inaccurate results.
https://github.com/istanbuljs/v8-to-istanbul/issues