### PR TITLE
Remove core-js

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,3 @@
-import 'core-js/stable';
 import { css } from '@linaria/core';
 
 css`

--- a/README.md
+++ b/README.md
@@ -60,11 +60,6 @@ See [documentation](https://github.com/browserslist/browserslist/blob/main/READM
 See [documentation](https://babeljs.io/docs/en/)
 
 - It's important that the configuration filename be `babel.config.*` instead of `.babelrc.*`, otherwise Babel might not transpile modules under `node_modules`.
-- We recommend polyfilling modern JS features with [core-js](https://www.npmjs.com/package/core-js) by adding the following snippet at the top of your bundle's entry file:
-  ```js
-  import 'core-js/stable';
-  ```
-  - Babel's `env` preset, if configured correctly, will transform this import so only the necessary polyfills are included in your bundle.
 - Polyfilling the [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) API is required for older browsers.
 </details>
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -5,9 +5,7 @@
       {
         "loose": true,
         "bugfixes": true,
-        "shippedProposals": true,
-        "corejs": 3,
-        "useBuiltIns": "entry"
+        "shippedProposals": true
       }
     ],
     ["@babel/react", { "runtime": "automatic" }],

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@typescript-eslint/parser": "^4.28.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-optimize-clsx": "^2.6.2",
-    "core-js": "^3.15.1",
     "css-loader": "^5.2.6",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,3 @@
-import 'core-js/stable';
 import { act } from 'react-dom/test-utils';
 
 window.ResizeObserver ??= class {


### PR DESCRIPTION
We don't use any features that need to be polyfilled in the storybook/tests.
Running Babel with `debug: true`, it shows that only 3 polyfills are loaded, and we actually use none of these features:
```
[D:\repos\react-data-grid\test\setup.ts]
The corejs3 polyfill entry has been replaced with the following polyfills:
  es.math.hypot { "chrome":"91", "edge":"91", "firefox":"90", "node":"12.22", "safari":"14" }
  es.typed-array.sort { "chrome":"91", "edge":"91", "firefox":"90", "node":"12.22", "safari":"14" }
  web.immediate { "chrome":"91", "edge":"91", "firefox":"90", "node":"12.22", "safari":"14" }
```
I think going forward we can avoid relying on any polyfills at all. We can always add it back otherwise.