### PR TITLE
Use a forwardRef-less Row component internally by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.x'
+          node-version: '16.8'
           check-latest: true
       - uses: actions/cache@v2
         with:

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -109,6 +109,8 @@ function Row<R, SR>(
   );
 }
 
-export default memo(forwardRef(Row)) as <R, SR>(
+export default memo(Row) as <R, SR>(props: RowRendererProps<R, SR>) => JSX.Element;
+
+export const RowWithRef = memo(forwardRef(Row)) as <R, SR>(
   props: RowRendererProps<R, SR> & RefAttributes<HTMLDivElement>
 ) => JSX.Element;

--- a/src/hooks/useCombinedRefs.ts
+++ b/src/hooks/useCombinedRefs.ts
@@ -6,7 +6,7 @@ export function useCombinedRefs<T>(...refs: readonly React.Ref<T>[]) {
       for (const ref of refs) {
         if (typeof ref === 'function') {
           ref(handle);
-        } else if (ref !== null) {
+        } else if (ref !== null && 'current' in ref) {
           // @ts-expect-error: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
           ref.current = handle;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { default } from './DataGrid';
 export type { DataGridProps, DataGridHandle } from './DataGrid';
-export { default as Row } from './Row';
+export { RowWithRef as Row } from './Row';
 export * from './Columns';
 export * from './formatters';
 export { default as TextEditor } from './editors/TextEditor';


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/567105/132501543-d21fa562-e7b2-4234-ac44-6e1cf9d7cc2b.png)
After:
![image](https://user-images.githubusercontent.com/567105/132501421-0d5452bb-4145-4949-9337-d30e3908eb5e.png)

-1 component per row by default!
`RowWithRef` will also be tree-shaken if left unused.