### PR TITLE
CI: add paths-ignore, don't build on *.md file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - ign
     paths-ignore:
       - '**.md'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - ign
     paths-ignore:
       - '**.md'
   pull_request:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 npm install react-data-grid
 ```
 
-test
-
 react-data-grid is published as ES2020 modules, you'll probably want to transpile those down to scripts for the browsers you target using [Babel](https://babeljs.io/) and [browserslist](https://github.com/browserslist/browserslist/blob/main/README.md).
 
 <details>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 npm install react-data-grid
 ```
 
+test
+
 react-data-grid is published as ES2020 modules, you'll probably want to transpile those down to scripts for the browsers you target using [Babel](https://babeljs.io/) and [browserslist](https://github.com/browserslist/browserslist/blob/main/README.md).
 
 <details>


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

Tested by building this branch:
branch (`push`) is built on non-md file change:
![image](https://user-images.githubusercontent.com/567105/132686821-bbdd4d37-242a-489f-a590-561e93011fea.png)
branch (`push`) is not built on md file change:
![image](https://user-images.githubusercontent.com/567105/132686847-79fea827-6ae2-4a98-bc13-05c66a8aa613.png)
