### PR TITLE
README: Trim install section

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Questions and discussions
     url: https://github.com/adazzle/react-data-grid/discussions
-    about: Please check the discussions tab for help discussions.
+    about: Please check the discussions tab for help and discussions.

--- a/README.md
+++ b/README.md
@@ -55,86 +55,9 @@
 npm install react-data-grid
 ```
 
-react-data-grid is published as ES2020 modules, you'll probably want to transpile those down to scripts for the browsers you target using [Babel](https://babeljs.io/) and [browserslist](https://github.com/browserslist/browserslist/blob/main/README.md).
+`react-data-grid` is published as ECMAScript modules for evergreen browsers / bundlers, and CommonJS for server-side rendering / Jest.
 
-<details>
-<summary>Example browserslist configuration file</summary>
-
-```
-last 2 chrome versions
-last 2 edge versions
-last 2 firefox versions
-last 2 safari versions
-```
-
-See [documentation](https://github.com/browserslist/browserslist/blob/main/README.md)
-
-</details>
-
-<details>
-<summary>Example babel.config.json file</summary>
-
-```json
-{
-  "presets": [
-    [
-      "@babel/env",
-      {
-        "bugfixes": true,
-        "shippedProposals": true,
-        "corejs": 3,
-        "useBuiltIns": "entry"
-      }
-    ]
-  ]
-}
-```
-
-See [documentation](https://babeljs.io/docs/en/)
-
-- It's important that the configuration filename be `babel.config.*` instead of `.babelrc.*`, otherwise Babel might not transpile modules under `node_modules`.
-- Polyfilling the [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) API is required for older browsers.
-</details>
-
-<details>
-<summary>Webpack configuration with babel-loader</summary>
-
-```js
-{
-  // ...
-  module: {
-    rules: {
-      test: /\.js$/,
-      exclude: /node_modules[/\\](?!react-data-grid[/\\]lib)/,
-      use: 'babel-loader'
-    }
-  }
-}
-```
-
-See [documentation](https://github.com/babel/babel-loader/blob/main/README.md)
-
-</details>
-
-<details>
-<summary>rollup.js configuration with @rollup/plugin-babel</summary>
-
-```js
-{
-  // ...
-  plugins: {
-    babel({
-      include: ['./src/**/*', './node_modules/react-data-grid/lib/**/*']
-    });
-  }
-}
-```
-
-See [documentation](https://github.com/rollup/plugins/blob/master/packages/babel/README.md)
-
-</details>
-
-## Usage
+## Quick start
 
 ```jsx
 import DataGrid from 'react-data-grid';


### PR DESCRIPTION
Since we ship both ESM and CJS, and we target old Node versions as well, the need to transpile rdg further for older browsers is less likely, so I removed those parts.