### PR TITLE
Tweak storybook deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           git worktree add gh-pages gh-pages
           cd gh-pages
           git rm -r .
+          git checkout gh-pages -- old
           mv ../storybook-static/* .
           git add .
           git commit -m "gh-pages deployment" || echo "Nothing to commit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,5 @@ jobs:
           git rm -r .
           mv ../storybook-static/* .
           git add .
-          git commit --allow-empty -m "gh-pages deployment"
+          git commit -m "gh-pages deployment" || echo "Nothing to commit"
           git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,25 +63,14 @@ jobs:
         run: |
           git config --global user.email 'action@github.com'
           git config --global user.name 'GitHub Action'
-      # - name: Deploy main
-      #   if: github.ref == 'refs/heads/main'
-      #   run: |
-      #     git fetch origin gh-pages
-      #     git worktree add gh-pages gh-pages
-      #     git rm -r .
-      #     git checkout gh-pages -- canary
-      #     mv ../storybook-static/* .
-      #     git add .
-      #     git commit --allow-empty -m "main storybook deployment"
-      #     git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git
-      - name: Deploy main
+      - name: Deploy gh-pages
         if: github.ref == 'refs/heads/main'
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages gh-pages
           cd gh-pages
-          git rm -r --ignore-unmatch canary
-          mv ../storybook-static canary
-          git add canary
-          git commit --allow-empty -m "beta storybook deployment"
+          git rm -r .
+          mv ../storybook-static/* .
+          git add .
+          git commit --allow-empty -m "gh-pages deployment"
           git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@
 
 ## v7.0.0-canary.22
 
-- Add Grouping ([PR](https://github.com/adazzle/react-data-grid/pull/2106)). Check the new [example](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--grouping).
+- Add Grouping ([PR](https://github.com/adazzle/react-data-grid/pull/2106)). Check the new [example](https://adazzle.github.io/react-data-grid/?path=/story/demos--grouping).
 - (Breaking) Removed `height` and `width` props and added new `className` and `style` props. We are now using `ResizeObserver` to calculate all the grid dimensions ([PR](https://github.com/adazzle/react-data-grid/pull/2130))
 - (Breaking) Removed formatterOptions. Grid now handles formatter focus internally so this prop is no longer required ([PR](https://github.com/adazzle/react-data-grid/pull/2138))
 - Added support for React 17
@@ -217,7 +217,7 @@
     - ⚠️ `height`
     - ⚠️ `cellContentRenderer`
     - ⚠️ `contextMenu`
-      - Check the [Context Menu](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--context-menu) example
+      - Check the [Context Menu](https://adazzle.github.io/react-data-grid/?path=/story/demos--context-menu) example
     - ⚠️ `enableCellSelect`
     - ⚠️ `enableCellAutoFocus`
     - ⚠️ `getValidFilterValues`

--- a/README.md
+++ b/README.md
@@ -23,29 +23,28 @@
 - Tree-shaking support and only [one npm dependency](package.json) to keep your bundles slim
 - Great performance thanks to virtualization: columns and rows outside the viewport are not rendered
 - Strictly typed with TypeScript
-- [Keyboard accessibility](<(https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)>)
+- [Keyboard accessibility](<(https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)>)
 - Light and dark mode support out of the box. The light or dark themes can be enforced using the `rdg-light` or `rdg-dark` classes.
-- [Frozen columns](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
-- [Column resizing](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
-- [Multi-column sorting](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
+- [Frozen columns](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
+- [Column resizing](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
+- [Multi-column sorting](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
   - Click on a sortable column header to toggle between its ascending/descending sort order
   - Ctrl+Click / Meta+Click to sort an additional column
-- [Column spanning](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--column-spanning)
-- [Row selection](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
-- [Row grouping](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--grouping)
-- [Summary rows](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
-- [Dynamic row heights](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--variable-row-height)
-- [No rows fallback](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--no-rows)
-- [Cell formatting](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
-- [Cell editing](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--common-features)
-- [Cell copy / pasting](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--all-features)
-- [Cell value dragging / filling](https://adazzle.github.io/react-data-grid/canary/?path=/story/demos--all-features)
+- [Column spanning](https://adazzle.github.io/react-data-grid/?path=/story/demos--column-spanning)
+- [Row selection](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
+- [Row grouping](https://adazzle.github.io/react-data-grid/?path=/story/demos--grouping)
+- [Summary rows](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
+- [Dynamic row heights](https://adazzle.github.io/react-data-grid/?path=/story/demos--variable-row-height)
+- [No rows fallback](https://adazzle.github.io/react-data-grid/?path=/story/demos--no-rows)
+- [Cell formatting](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
+- [Cell editing](https://adazzle.github.io/react-data-grid/?path=/story/demos--common-features)
+- [Cell copy / pasting](https://adazzle.github.io/react-data-grid/?path=/story/demos--all-features)
+- [Cell value dragging / filling](https://adazzle.github.io/react-data-grid/?path=/story/demos--all-features)
 
 ## Links
 
-- [Website](https://adazzle.github.io/react-data-grid/canary/)
+- [Website](https://adazzle.github.io/react-data-grid/)
   - [Source code](stories)
-- [Old website for react-data-grid v5](https://adazzle.github.io/react-data-grid/)
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 
 - [Examples website](https://adazzle.github.io/react-data-grid/)
   - [Source code](stories)
+- [Old website for react-data-grid v6](https://adazzle.github.io/react-data-grid/old/)
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ## Links
 
-- [Website](https://adazzle.github.io/react-data-grid/)
+- [Examples website](https://adazzle.github.io/react-data-grid/)
   - [Source code](stories)
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1141,11 +1141,6 @@ function DataGrid<R, SR, K extends Key>(
   );
 }
 
-/**
- * Check the README for API documentation:
- * https://github.com/adazzle/react-data-grid/blob/main/README.md#api
- * @see {@link DataGridProps}
- */
 export default forwardRef(DataGrid) as <R, SR = unknown, K extends Key = Key>(
   props: DataGridProps<R, SR, K> & RefAttributes<DataGridHandle>
 ) => JSX.Element;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1141,6 +1141,11 @@ function DataGrid<R, SR, K extends Key>(
   );
 }
 
+/**
+ * Check the README for API documentation:
+ * https://github.com/adazzle/react-data-grid/blob/main/README.md#api
+ * @see {@link DataGridProps}
+ */
 export default forwardRef(DataGrid) as <R, SR = unknown, K extends Key = Key>(
   props: DataGridProps<R, SR, K> & RefAttributes<DataGridHandle>
 ) => JSX.Element;


### PR DESCRIPTION
This will remove the `canary/` storybook and preserve the old website, now we'll have the storybook directly available at https://adazzle.github.io/react-data-grid/