### PR TITLE
Optimize webpack output

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@linaria/shaker": "^3.0.0-beta.12",
     "@linaria/webpack5-loader": "^3.0.0-beta.12",
     "@microsoft/api-extractor": "^7.16.1",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-rc.6",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@testing-library/jest-dom": "^5.14.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,9 @@ export default (env, { mode }) => {
     },
 
     optimization: {
+      splitChunks: {
+        chunks: 'all'
+      },
       minimizer: ['...', new CssMinimizerPlugin()]
     },
 

--- a/website/root.tsx
+++ b/website/root.tsx
@@ -1,27 +1,27 @@
-import { lazy, StrictMode, Suspense } from 'react';
+import { StrictMode } from 'react';
 import { render } from 'react-dom';
 import { css } from '@linaria/core';
 import { HashRouter as Router, Switch, Redirect, Route } from 'react-router-dom';
 
 import Nav from './Nav';
 
-const CommonFeatures = lazy(() => import('./demos/CommonFeatures'));
-const AllFeatures = lazy(() => import('./demos/AllFeatures'));
-const CellNavigation = lazy(() => import('./demos/CellNavigation'));
-const ColumnSpanning = lazy(() => import('./demos/ColumnSpanning'));
-const ColumnsReordering = lazy(() => import('./demos/ColumnsReordering'));
-const ContextMenuDemo = lazy(() => import('./demos/ContextMenu'));
-const Grouping = lazy(() => import('./demos/Grouping'));
-const HeaderFilters = lazy(() => import('./demos/HeaderFilters'));
-const InfiniteScrolling = lazy(() => import('./demos/InfiniteScrolling'));
-const MasterDetail = lazy(() => import('./demos/MasterDetail'));
-const MillionCells = lazy(() => import('./demos/MillionCells'));
-const NoRows = lazy(() => import('./demos/NoRows'));
-const ResizableGrid = lazy(() => import('./demos/Resizable'));
-const RowsReordering = lazy(() => import('./demos/RowsReordering'));
-const ScrollToRow = lazy(() => import('./demos/ScrollToRow'));
-const TreeView = lazy(() => import('./demos/TreeView'));
-const VariableRowHeight = lazy(() => import('./demos/VariableRowHeight'));
+import CommonFeatures from './demos/CommonFeatures';
+import AllFeatures from './demos/AllFeatures';
+import CellNavigation from './demos/CellNavigation';
+import ColumnSpanning from './demos/ColumnSpanning';
+import ColumnsReordering from './demos/ColumnsReordering';
+import ContextMenuDemo from './demos/ContextMenu';
+import Grouping from './demos/Grouping';
+import HeaderFilters from './demos/HeaderFilters';
+import InfiniteScrolling from './demos/InfiniteScrolling';
+import MasterDetail from './demos/MasterDetail';
+import MillionCells from './demos/MillionCells';
+import NoRows from './demos/NoRows';
+import ResizableGrid from './demos/Resizable';
+import RowsReordering from './demos/RowsReordering';
+import ScrollToRow from './demos/ScrollToRow';
+import TreeView from './demos/TreeView';
+import VariableRowHeight from './demos/VariableRowHeight';
 
 css`
   @at-root {
@@ -85,65 +85,63 @@ function Root() {
       <Nav />
 
       <main className={mainClassname}>
-        <Suspense fallback="Loading...">
-          <Switch>
-            <Redirect exact from="/" to="/common-features" />
-            <Route exact path="/common-features">
-              <CommonFeatures />
-            </Route>
-            <Route exact path="/all-features">
-              <AllFeatures />
-            </Route>
-            <Route exact path="/cell-navigation">
-              <CellNavigation />
-            </Route>
-            <Route exact path="/column-spanning">
-              <ColumnSpanning />
-            </Route>
-            <Route exact path="/columns-reordering">
-              <ColumnsReordering />
-            </Route>
-            <Route exact path="/context-menu">
-              <ContextMenuDemo />
-            </Route>
-            <Route exact path="/grouping">
-              <Grouping />
-            </Route>
-            <Route exact path="/header-filters">
-              <HeaderFilters />
-            </Route>
-            <Route exact path="/infinite-scrolling">
-              <InfiniteScrolling />
-            </Route>
-            <Route exact path="/master-detail">
-              <MasterDetail />
-            </Route>
-            <Route exact path="/million-cells">
-              <MillionCells />
-            </Route>
-            <Route exact path="/no-rows">
-              <NoRows />
-            </Route>
-            <Route exact path="/resizable-grid">
-              <ResizableGrid />
-            </Route>
-            <Route exact path="/rows-reordering">
-              <RowsReordering />
-            </Route>
-            <Route exact path="/scroll-to-row">
-              <ScrollToRow />
-            </Route>
-            <Route exact path="/tree-view">
-              <TreeView />
-            </Route>
-            <Route exact path="/variable-row-height">
-              <VariableRowHeight />
-            </Route>
-            <Route>
-              <>Nothing to see here</>
-            </Route>
-          </Switch>
-        </Suspense>
+        <Switch>
+          <Redirect exact from="/" to="/common-features" />
+          <Route exact path="/common-features">
+            <CommonFeatures />
+          </Route>
+          <Route exact path="/all-features">
+            <AllFeatures />
+          </Route>
+          <Route exact path="/cell-navigation">
+            <CellNavigation />
+          </Route>
+          <Route exact path="/column-spanning">
+            <ColumnSpanning />
+          </Route>
+          <Route exact path="/columns-reordering">
+            <ColumnsReordering />
+          </Route>
+          <Route exact path="/context-menu">
+            <ContextMenuDemo />
+          </Route>
+          <Route exact path="/grouping">
+            <Grouping />
+          </Route>
+          <Route exact path="/header-filters">
+            <HeaderFilters />
+          </Route>
+          <Route exact path="/infinite-scrolling">
+            <InfiniteScrolling />
+          </Route>
+          <Route exact path="/master-detail">
+            <MasterDetail />
+          </Route>
+          <Route exact path="/million-cells">
+            <MillionCells />
+          </Route>
+          <Route exact path="/no-rows">
+            <NoRows />
+          </Route>
+          <Route exact path="/resizable-grid">
+            <ResizableGrid />
+          </Route>
+          <Route exact path="/rows-reordering">
+            <RowsReordering />
+          </Route>
+          <Route exact path="/scroll-to-row">
+            <ScrollToRow />
+          </Route>
+          <Route exact path="/tree-view">
+            <TreeView />
+          </Route>
+          <Route exact path="/variable-row-height">
+            <VariableRowHeight />
+          </Route>
+          <Route>
+            <>Nothing to see here</>
+          </Route>
+        </Switch>
       </main>
     </Router>
   );


### PR DESCRIPTION
Code-splitting each page is kind of overkill, and webpack was generating many duplicate code in each modules as they were small enough. It also caused issues with styles getting duplicated in the actual website.
![image](https://user-images.githubusercontent.com/567105/133234810-fb1bccd8-5b56-4763-bef8-665a347218dc.png)


Bonus: https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/CHANGELOG.md