### PR TITLE
rollup@2.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-dom": "^17.0.2",
     "react-refresh": "^0.10.0",
     "react-router-dom": "^5.3.0",
-    "rollup": "^2.52.3",
+    "rollup": "^2.57.0",
     "rollup-plugin-postcss": "^4.0.0",
     "style-loader": "^3.2.1",
     "typescript": "~4.4.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,13 +14,13 @@ export default {
     {
       file: './lib/bundle.js',
       format: 'es',
-      preferConst: true,
+      generatedCode: 'es2015',
       sourcemap: true
     },
     {
       file: './lib/bundle.cjs',
       format: 'cjs',
-      preferConst: true,
+      generatedCode: 'es2015',
       sourcemap: true,
       interop: false
     }


### PR DESCRIPTION
- https://github.com/rollup/rollup/releases/tag/v2.57.0
- https://rollupjs.org/guide/en/#outputgeneratedcode

Only one difference in the cjs output:
![image](https://user-images.githubusercontent.com/567105/134349946-3b39f387-661a-4596-aa0e-71019d42b8ef.png)
