### PR TITLE
Do not steal focus back to the cell if the editor is not in the viewport and another cell is clicked

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -700,13 +700,11 @@ function DataGrid<R, SR, K extends Key>(
     if (enableEditor && isCellEditable(position)) {
       const row = rows[position.rowIdx] as R;
       setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row });
-    } else if (
-      selectedPosition.mode !== 'SELECT' ||
-      selectedPosition.idx !== position.idx ||
-      selectedPosition.rowIdx !== position.rowIdx
-    ) {
+    } else if (isSamePosition(selectedPosition, position)) {
       // Avoid re-renders if the selected cell state is the same
       // TODO: replace with a #record? https://github.com/microsoft/TypeScript/issues/39831
+      scrollToCell(position);
+    } else {
       setSelectedPosition({ ...position, mode: 'SELECT' });
     }
   }

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -363,11 +363,12 @@ function DataGrid<R, SR, K extends Key>(
   useLayoutEffect(() => {
     if (
       !selectedCellIsWithinSelectionBounds ||
-      selectedPosition === prevSelectedPosition.current ||
-      selectedPosition.mode === 'EDIT'
+      isSamePosition(selectedPosition, prevSelectedPosition.current)
     ) {
+      prevSelectedPosition.current = selectedPosition;
       return;
     }
+
     prevSelectedPosition.current = selectedPosition;
     scrollToCell(selectedPosition);
   });
@@ -619,6 +620,7 @@ function DataGrid<R, SR, K extends Key>(
         // Custom editors can listen for the event and stop propagation to prevent commit
         commitEditorChanges();
         closeEditor();
+        scrollToCell(selectedPosition);
       }
       return;
     }
@@ -855,12 +857,7 @@ function DataGrid<R, SR, K extends Key>(
 
     const ctrlKey = isCtrlKeyHeldDown(event);
     const nextPosition = getNextPosition(key, ctrlKey, shiftKey);
-    if (
-      nextPosition.rowIdx === selectedPosition.rowIdx &&
-      nextPosition.idx === selectedPosition.idx
-    ) {
-      return;
-    }
+    if (isSamePosition(selectedPosition, nextPosition)) return;
 
     const nextSelectedCellPosition = getNextSelectedCellPosition({
       columns,
@@ -1132,6 +1129,10 @@ function DataGrid<R, SR, K extends Key>(
       )}
     </div>
   );
+}
+
+function isSamePosition(p1: Position, p2: Position) {
+  return p1.idx === p2.idx && p1.rowIdx === p2.rowIdx;
 }
 
 export default forwardRef(DataGrid) as <R, SR = unknown, K extends Key = Key>(

--- a/src/hooks/useRovingCellRef.ts
+++ b/src/hooks/useRovingCellRef.ts
@@ -20,7 +20,7 @@ export function useRovingCellRef(isSelected: boolean) {
       forceRender({});
       return;
     }
-    ref.current?.focus();
+    ref.current?.focus({ preventScroll: true });
   }, [isSelected]);
 
   function onFocus(event: React.FocusEvent<HTMLDivElement>) {

--- a/test/column/editor.test.tsx
+++ b/test/column/editor.test.tsx
@@ -2,7 +2,7 @@ import { StrictMode, useMemo, useState } from 'react';
 import { act, fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import DataGrid, { TextEditor } from '../../src';
+import DataGrid from '../../src';
 import type { Column } from '../../src';
 import { getCellsAtRowIndex, getGrid, getSelectedCell } from '../utils';
 import { createPortal } from 'react-dom';
@@ -220,44 +220,25 @@ describe('Editor', () => {
   });
 
   describe('editor focus', () => {
-    const columns: readonly Column<Row>[] = [
-      {
-        key: 'col2',
-        name: 'Column',
-        editor: TextEditor
-      }
-    ];
-
-    function Grid() {
-      const [rows, setRows] = useState<readonly Row[]>(() => {
-        const rows: Row[] = [];
-        for (let i = 0; i < 60; i++) {
-          rows.push({
-            col1: 1,
-            col2: `value${i}`
-          });
-        }
-
-        return rows;
-      });
-
-      return <DataGrid columns={columns} rows={rows} onRowsChange={setRows} />;
-    }
-
     it('should not steal focus back to the cell if the editor is not in the viewport and another cell is clicked', () => {
-      render(<Grid />);
+      const rows: Row[] = [];
+      for (let i = 0; i < 99; i++) {
+        rows.push({ col1: i, col2: `${i}` });
+      }
+
+      render(<EditorTest gridRows={rows} />);
       const grid = getGrid();
 
-      userEvent.dblClick(getCellsAtRowIndex(0)[0]);
+      userEvent.dblClick(getCellsAtRowIndex(0)[1]);
       userEvent.keyboard('abc');
 
       grid.scrollTop = 1500;
 
-      expect(getCellsAtRowIndex(40)[0]).toHaveTextContent('value40');
-      userEvent.click(getCellsAtRowIndex(40)[0]);
-      expect(getSelectedCell()).toHaveTextContent('value40');
+      expect(getCellsAtRowIndex(40)[1]).toHaveTextContent('40');
+      userEvent.click(getCellsAtRowIndex(40)[1]);
+      expect(getSelectedCell()).toHaveTextContent('40');
       grid.scrollTop = 0;
-      expect(getCellsAtRowIndex(0)[0]).toHaveTextContent('abc');
+      expect(getCellsAtRowIndex(0)[1]).toHaveTextContent('abc');
     });
 
     it.skip('should not steal focus back to the cell after being closed by clicking outside the grid', async () => {


### PR DESCRIPTION
Fixes https://github.com/adazzle/react-data-grid/issues/2670