### PR TITLE
I had attempt to migrate from Slick.Grid to React-Data-Grid and found that need introduce  some changes. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v7.0.0-av1
+AV:DataGrid, DataGridHandle: added method ::forceUpdate() to update visible rows when row content changed.
+AV:DataGrid: fixed viewport height and scroll.
+
+## v7.0.0-av
+
+
+- AV: refactored EditCell, props, layout to use instead of SlickGrid. New rule: only AppCode can change data rows.
+- AV: Header: Refactored  layout to Header/Viewport, added scroll synchronization viewport to Header. Because position:sticky work wrong. And scroll position does not correspond to outer components. (when required scroll sync)
+- AV: extracted Prop classes to single files. (It's good C++ way header+implementaton)
+- AV: added experiment with ClassComponent for Cell - CellClass. it more simplified code but same performance.
+- AV: added extra DataGridProps: onBeforeEditCell, onBeforeCellEditorDestroy, onContextMenu, onHeaderContextMenu, onKeyDown - required for us and implemented in Slick.Grid.
+- AV: added extra methods to DataGridHandle: updateRow(), inEditor(), forceUpdate()
+- AV: fixed keyboard behaviour:  ask client-code for processing keys, skip default behaviour on when modification keys is active
+- AV: Editor: changed editor behaviour, added interface ICanCommit to work with statefull editor. Editor can commit change or not. But Editor MUST NOT change row directly and 'by-design'. Editor can change row only after ::commit().
+- AV: Header: every header must have @title. because caption can be bigger than cel size.
+- AV: DataGrid: introduced 'props' variable because copy-paste (Props/local) is not good idea.
+- AV: DataGrid: Added caching check for rows.length - Every time copying rows array is not good idea to update components. Because User can loaded 2000-5000 items. But we have changed only 1-2 rows.
+- AV: DataGrid: changed onRowUpdated() behaviour: sent only updated rows , User have self own unchanged rows.  Added argument:'previousRow' - because we need make diff of changes. Original row we recive from Editor or location.
+- AV: added ContextMenu handlers.
+
+
 ## v7.0.0-canary.48
 
 - Fixed an edge case where clicking outside the grid wouldn't close and commit an open editor quickly enough, resulting in the previous rows state being used by parent components in `click` handlers. ([PR](https://github.com/adazzle/react-data-grid/pull/2415))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid",
-  "version": "7.0.0-beta.7",
+  "version": "7.0.0-beta.7-av1",
   "license": "MIT",
   "description": "Feature-rich and customizable data grid React component",
   "keywords": [
@@ -38,7 +38,8 @@
     "prettier:format": "prettier --write .",
     "typecheck": "tsc -p tsconfig.all.json",
     "prepublishOnly": "npm install && npm run build && npm run build:types",
-    "postpublish": "git push --follow-tags origin HEAD"
+    "postpublish": "git push --follow-tags origin HEAD",
+    "dist":"mkdir dist; cp -f package.json -r LICENSE README.md lib/ dist/"
   },
   "dependencies": {
     "clsx": "^1.1.1"

--- a/src/CellClass.tsx
+++ b/src/CellClass.tsx
@@ -1,0 +1,141 @@
+import React, {PureComponent, RefObject} from 'react';
+import { css } from '@linaria/core';
+
+import { getCellStyle, getCellClassname, isCellEditable } from './utils';
+import type { CellRendererProps } from './types';
+
+// import { useRovingCellRef } from './hooks';
+
+const cellCopied = css`
+  background-color: #ccccff;
+`;
+
+const cellCopiedClassname = `rdg-cell-copied ${cellCopied}`;
+
+const cellDraggedOver = css`
+  background-color: #ccccff;
+
+  &.${cellCopied} {
+    background-color: #9999ff;
+  }
+`;
+
+const cellDraggedOverClassname = `rdg-cell-dragged-over ${cellDraggedOver}`;
+
+// eslint-disable-next-line react/no-unsafe
+export default class Cell<R, SR> extends PureComponent<CellRendererProps<R, SR>> {
+    ref :RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+    isChildFocused = false;
+
+    constructor(props:Readonly<CellRendererProps<R, SR>>) {
+        super(props);
+        this.importProps(props);
+    }
+
+    importProps(props:Readonly<CellRendererProps<R, SR>>)
+    {
+        if  (!props.isCellSelected) {
+            this.isChildFocused = false;
+            return;
+        }
+        if ( this.isChildFocused ) {
+            this.forceUpdate();
+            return;
+        }
+        this.ref.current?.focus({ preventScroll: true });
+    }
+
+    UNSAFE_componentWillUpdate(nextProps: Readonly<CellRendererProps<R, SR>>): void {
+        this.importProps(nextProps);
+    }
+
+    handleFocus = (event: React.FocusEvent<HTMLDivElement>) =>{
+        if (event.target !== this.ref.current) {
+            this.isChildFocused = true;
+        }
+    };
+    selectCellWrapper(openEditor?: boolean | null) {
+        this.props.selectCell(this.props.row, this.props.column, openEditor);
+    }
+
+    handleClick= () =>{
+        this.selectCellWrapper(this.props.column.editorOptions?.editOnClick);
+        this.props.onRowClick?.(this.props.row, this.props.column);
+    };
+
+    handleContextMenu=() =>{
+        this.selectCellWrapper();
+    };
+
+    handleDoubleClick= () =>{
+        this.selectCellWrapper(true);
+        this.props.onRowDoubleClick?.(this.props.row, this.props.column);
+    };
+
+    render() {
+        let {
+            column,
+            colSpan,
+            isCellSelected,
+            isCopied,
+            isDraggedOver,
+            row,
+            dragHandle,
+            onRowClick,
+            onRowDoubleClick,
+            onRowChange,
+            selectCell,
+            ...props
+        } = this.props;
+
+
+        const isFocused = isCellSelected && !this.isChildFocused;
+        const tabIndex = isFocused ? 0 : -1;
+
+        // const {ref, tabIndex, onFocus} = useRovingCellRef(isCellSelected);
+
+        const {cellClass} = column;
+        const className = getCellClassname(
+            column,
+            {
+                [cellCopiedClassname]: isCopied,
+                [cellDraggedOverClassname]: isDraggedOver
+            },
+            typeof cellClass === 'function' ? cellClass(row) : cellClass
+        );
+
+
+        return (
+            <div
+                role="gridcell"
+                aria-colindex={column.idx + 1} // aria-colindex is 1-based
+                aria-selected={isCellSelected}
+                aria-colspan={colSpan}
+                aria-readonly={!isCellEditable(column, row) || undefined}
+                ref={this.ref}
+                tabIndex={tabIndex}
+                className={className}
+                style={getCellStyle(column, colSpan)}
+                onClick={this.handleClick}
+                onDoubleClick={this.handleDoubleClick}
+                onContextMenu={this.handleContextMenu}
+                onFocus={this.handleFocus}
+                {...props}
+            >
+                {!column.rowGroup && (
+                    <>
+                        <column.formatter
+                            column={column}
+                            row={row}
+                            isCellSelected={isCellSelected}
+                            onRowChange={onRowChange}
+                        />
+                        {dragHandle}
+                    </>
+                )}
+            </div>
+        );
+    }
+}
+
+//export default memo(Cell) as <R, SR>(props: CellRendererProps<R, SR>) => JSX.Element;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1,166 +1,62 @@
-import { forwardRef, useState, useRef, useImperativeHandle, useCallback, useMemo } from 'react';
-import type { Key, RefAttributes } from 'react';
+import {forwardRef, RefObject, useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import clsx from 'clsx';
 
-import { rootClassname, viewportDraggingClassname } from './style';
+import {rootClassname, viewportDraggingClassname} from './style';
 import {
-  useLayoutEffect,
-  useGridDimensions,
-  useCalculatedColumns,
-  useViewportColumns,
-  useViewportRows,
-  useLatestFunc,
-  RowSelectionChangeProvider
+    RowSelectionChangeProvider,
+    useCalculatedColumns,
+    useGridDimensions,
+    useLatestFunc,
+    useLayoutEffect,
+    useViewportColumns,
+    useViewportRows
 } from './hooks';
 import HeaderRow from './HeaderRow';
-import Row from './Row';
+import {RowWithRef} from './Row';
 import GroupRowRenderer from './GroupRow';
 import SummaryRow from './SummaryRow';
 import EditCell from './EditCell';
 import DragHandle from './DragHandle';
 import {
-  assertIsValidKeyGetter,
-  getNextSelectedCellPosition,
-  isSelectedCellEditable,
-  canExitGrid,
-  isCtrlKeyHeldDown,
-  isDefaultCellInput,
-  getColSpan,
-  max,
-  sign,
-  getSelectedCellColSpan
+    assertIsValidKeyGetter,
+    canExitGrid,
+    getColSpan,
+    getNextSelectedCellPosition,
+    getSelectedCellColSpan,
+    isCtrlKeyHeldDown,
+    isDefaultCellInput,
+    isSelectedCellEditable,
+    max,
+    sign
 } from './utils';
-
+import {ICanCommit} from "./editors/ICanCommit";
+import {DataGridProps} from "./DataGridProps";
+import {RowHandle} from "./RowHandle";
+import {DataGridHandle} from "./DataGridHandle";
+import type { Key, RefAttributes } from 'react';
 import type {
-  CalculatedColumn,
-  Column,
-  Position,
-  RowRendererProps,
-  RowsChangeData,
-  SelectRowEvent,
-  FillEvent,
-  PasteEvent,
-  CellNavigationMode,
-  SortColumn,
-  RowHeightArgs,
-  Maybe
+    CalculatedColumn,
+    Position,
+    SelectRowEvent,
+    Maybe
 } from './types';
 
+
 export interface SelectCellState extends Position {
-  readonly mode: 'SELECT';
+    readonly mode: 'SELECT';
 }
 
 interface EditCellState<R> extends Position {
-  readonly mode: 'EDIT';
-  readonly row: R;
-  readonly originalRow: R;
+    readonly mode: 'EDIT';
+    readonly row: R;
+    readonly originalRow: R;
 }
-
-type DefaultColumnOptions<R, SR> = Pick<
-  Column<R, SR>,
-  'formatter' | 'minWidth' | 'resizable' | 'sortable'
->;
 
 const initialPosition: SelectCellState = {
-  idx: -1,
-  rowIdx: -2,
-  mode: 'SELECT'
+    idx: -1,
+    rowIdx: -1,
+    mode: 'SELECT'
 };
-
-export interface DataGridHandle {
-  element: HTMLDivElement | null;
-  scrollToColumn: (colIdx: number) => void;
-  scrollToRow: (rowIdx: number) => void;
-  selectCell: (position: Position, enableEditor?: Maybe<boolean>) => void;
-}
-
-type SharedDivProps = Pick<
-  React.HTMLAttributes<HTMLDivElement>,
-  'aria-label' | 'aria-labelledby' | 'aria-describedby' | 'className' | 'style'
->;
-
-export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends SharedDivProps {
-  /**
-   * Grid and data Props
-   */
-  /** An array of objects representing each column on the grid */
-  columns: readonly Column<R, SR>[];
-  /** A function called for each rendered row that should return a plain key/value pair object */
-  rows: readonly R[];
-  /**
-   * Rows to be pinned at the bottom of the rows view for summary, the vertical scroll bar will not scroll these rows.
-   * Bottom horizontal scroll bar can move the row left / right. Or a customized row renderer can be used to disabled the scrolling support.
-   */
-  summaryRows?: Maybe<readonly SR[]>;
-  /** The getter should return a unique key for each row */
-  rowKeyGetter?: Maybe<(row: R) => K>;
-  onRowsChange?: Maybe<(rows: R[], data: RowsChangeData<R, SR>) => void>;
-
-  /**
-   * Dimensions props
-   */
-  /**
-   * The height of each row in pixels
-   * @default 35
-   */
-  rowHeight?: Maybe<number | ((args: RowHeightArgs<R>) => number)>;
-  /**
-   * The height of the header row in pixels
-   * @default 35
-   */
-  headerRowHeight?: Maybe<number>;
-  /**
-   * The height of each summary row in pixels
-   * @default 35
-   */
-  summaryRowHeight?: Maybe<number>;
-
-  /**
-   * Feature props
-   */
-  /** Set of selected row keys */
-  selectedRows?: Maybe<ReadonlySet<K>>;
-  /** Function called whenever row selection is changed */
-  onSelectedRowsChange?: Maybe<(selectedRows: Set<K>) => void>;
-  /** Used for multi column sorting */
-  sortColumns?: Maybe<readonly SortColumn[]>;
-  onSortColumnsChange?: Maybe<(sortColumns: SortColumn[]) => void>;
-  defaultColumnOptions?: Maybe<DefaultColumnOptions<R, SR>>;
-  groupBy?: Maybe<readonly string[]>;
-  rowGrouper?: Maybe<(rows: readonly R[], columnKey: string) => Record<string, readonly R[]>>;
-  expandedGroupIds?: Maybe<ReadonlySet<unknown>>;
-  onExpandedGroupIdsChange?: Maybe<(expandedGroupIds: Set<unknown>) => void>;
-  onFill?: Maybe<(event: FillEvent<R>) => R>;
-  onPaste?: Maybe<(event: PasteEvent<R>) => R>;
-
-  /**
-   * Event props
-   */
-  /** Function called whenever a row is clicked */
-  onRowClick?: Maybe<(row: R, column: CalculatedColumn<R, SR>) => void>;
-  /** Function called whenever a row is double clicked */
-  onRowDoubleClick?: Maybe<(row: R, column: CalculatedColumn<R, SR>) => void>;
-  /** Called when the grid is scrolled */
-  onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;
-  /** Called when a column is resized */
-  onColumnResize?: Maybe<(idx: number, width: number) => void>;
-
-  /**
-   * Toggles and modes
-   */
-  /** @default 'NONE' */
-  cellNavigationMode?: Maybe<CellNavigationMode>;
-  /** @default true */
-  enableVirtualization?: Maybe<boolean>;
-
-  /**
-   * Miscellaneous
-   */
-  rowRenderer?: Maybe<React.ComponentType<RowRendererProps<R, SR>>>;
-  noRowsFallback?: React.ReactNode;
-  rowClass?: Maybe<(row: R) => Maybe<string>>;
-  'data-testid'?: Maybe<string>;
-}
 
 /**
  * Main API Component to render a data grid of rows and columns
@@ -169,936 +65,1002 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
  *
  * <DataGrid columns={columns} rows={rows} />
  */
-function DataGrid<R, SR, K extends Key>(
-  {
-    // Grid and data Props
-    columns: rawColumns,
-    rows: rawRows,
-    summaryRows,
-    rowKeyGetter,
-    onRowsChange,
-    // Dimensions props
-    rowHeight,
-    headerRowHeight: rawHeaderRowHeight,
-    summaryRowHeight: rawSummaryRowHeight,
-    // Feature props
-    selectedRows,
-    onSelectedRowsChange,
-    sortColumns,
-    onSortColumnsChange,
-    defaultColumnOptions,
-    groupBy: rawGroupBy,
-    rowGrouper,
-    expandedGroupIds,
-    onExpandedGroupIdsChange,
-    // Event props
-    onRowClick,
-    onRowDoubleClick,
-    onScroll,
-    onColumnResize,
-    onFill,
-    onPaste,
-    // Toggles and modes
-    cellNavigationMode: rawCellNavigationMode,
-    enableVirtualization,
-    // Miscellaneous
-    rowRenderer,
-    noRowsFallback,
-    className,
-    style,
-    rowClass,
-    // ARIA
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-    'aria-describedby': ariaDescribedBy,
-    'data-testid': testId
-  }: DataGridProps<R, SR, K>,
-  ref: React.Ref<DataGridHandle>
+function DataGrid<R, SR, K extends Key>(gridProps: DataGridProps<R, SR, K>,
+    ref: React.Ref<DataGridHandle>
 ) {
-  /**
-   * defaults
-   */
-  rowHeight ??= 35;
-  const headerRowHeight = rawHeaderRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
-  const summaryRowHeight = rawSummaryRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
-  const RowRenderer = rowRenderer ?? Row;
-  const cellNavigationMode = rawCellNavigationMode ?? 'NONE';
-  enableVirtualization ??= true;
+    let {
+        // Grid and data Props
+        columns: rawColumns,
+        rows: rawRows,
+        summaryRows,
+        rowKeyGetter,
+        onRowsChange,
+        onCurrentRowChanged,
+        // Dimensions gridProps
+        rowHeight,
+        headerRowHeight: rawHeaderRowHeight,
+        summaryRowHeight: rawSummaryRowHeight,
+        // Feature gridProps
+        selectedRows,
+        onSelectedRowsChange,
+        sortColumns,
+        onSortColumnsChange,
+        defaultColumnOptions,
+        groupBy: rawGroupBy,
+        rowGrouper,
+        expandedGroupIds,
+        onExpandedGroupIdsChange,
+        // Event gridProps
+        onRowClick,
+        onRowDoubleClick,
+        onScroll,
+        onColumnResize,
+        onFill,
+        onPaste,
+        // Toggles and modes
+        cellNavigationMode: rawCellNavigationMode,
+        enableVirtualization,
+        // Miscellaneous
+        rowRenderer,
+        noRowsFallback,
+        className,
+        style,
+        rowClass,
+        // ARIA
+        'aria-label': ariaLabel,
+        'aria-labelledby': ariaLabelledBy,
+        'aria-describedby': ariaDescribedBy,
+        'data-testid': testId,
+    } = gridProps;
+    /**
+     * defaults
+     */
+    rowHeight ??= 35;
+    const headerRowHeight = rawHeaderRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
+    const summaryRowHeight = rawSummaryRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
+    const RowRenderer = rowRenderer ?? RowWithRef;
+    const cellNavigationMode = rawCellNavigationMode ?? 'NONE';
+    enableVirtualization ??= true;
 
-  /**
-   * states
-   */
-  const [scrollTop, setScrollTop] = useState(0);
-  const [scrollLeft, setScrollLeft] = useState(0);
-  const [columnWidths, setColumnWidths] = useState<ReadonlyMap<string, number>>(() => new Map());
-  const [selectedPosition, setSelectedPosition] = useState<SelectCellState | EditCellState<R>>(
-    initialPosition
-  );
-  const [copiedCell, setCopiedCell] = useState<{ row: R; columnKey: string } | null>(null);
-  const [isDragging, setDragging] = useState(false);
-  const [draggedOverRowIdx, setOverRowIdx] = useState<number | undefined>(undefined);
-
-  /**
-   * refs
-   */
-  const prevSelectedPosition = useRef(selectedPosition);
-  const latestDraggedOverRowIdx = useRef(draggedOverRowIdx);
-  const lastSelectedRowIdx = useRef(-1);
-
-  /**
-   * computed values
-   */
-  const [gridRef, gridWidth, gridHeight] = useGridDimensions();
-  const headerRowsCount = 1;
-  const summaryRowsCount = summaryRows?.length ?? 0;
-  const clientHeight = gridHeight - headerRowHeight - summaryRowsCount * summaryRowHeight;
-  const isSelectable = selectedRows != null && onSelectedRowsChange != null;
-  const isHeaderRowSelected = selectedPosition.rowIdx === -1;
-
-  const allRowsSelected = useMemo((): boolean => {
-    // no rows to select = explicitely unchecked
-    const { length } = rawRows;
-    return (
-      length !== 0 &&
-      selectedRows != null &&
-      rowKeyGetter != null &&
-      selectedRows.size >= length &&
-      rawRows.every((row) => selectedRows.has(rowKeyGetter(row)))
+    /**
+     * states
+     */
+    const [scrollTop, setScrollTop] = useState(0);
+    const [scrollLeft, setScrollLeft] = useState(0);
+    const [columnWidths, setColumnWidths] = useState<ReadonlyMap<string, number>>(() => new Map());
+    const [selectedPosition, setSelectedPosition] = useState<SelectCellState | EditCellState<R>>(
+        initialPosition
     );
-  }, [rawRows, selectedRows, rowKeyGetter]);
+    const [copiedCell, setCopiedCell] = useState<{ row: R; columnKey: string } | null>(null);
+    const [isDragging, setDragging] = useState(false);
+    const [draggedOverRowIdx, setOverRowIdx] = useState<number | undefined>(undefined);
 
-  const {
-    columns,
-    colSpanColumns,
-    colOverscanStartIdx,
-    colOverscanEndIdx,
-    layoutCssVars,
-    columnMetrics,
-    totalColumnWidth,
-    lastFrozenColumnIndex,
-    totalFrozenColumnWidth,
-    groupBy
-  } = useCalculatedColumns({
-    rawColumns,
-    columnWidths,
-    scrollLeft,
-    viewportWidth: gridWidth,
-    defaultColumnOptions,
-    rawGroupBy: rowGrouper ? rawGroupBy : undefined,
-    enableVirtualization
-  });
+    /**
+     * refs
+     */
+    const prevSelectedPosition = useRef(selectedPosition);
+    const latestDraggedOverRowIdx = useRef(draggedOverRowIdx);
+    const lastSelectedRowIdx = useRef(-1);
 
-  const {
-    rowOverscanStartIdx,
-    rowOverscanEndIdx,
-    rows,
-    rowsCount,
-    totalRowHeight,
-    isGroupRow,
-    getRowTop,
-    getRowHeight,
-    findRowIdx
-  } = useViewportRows({
-    rawRows,
-    groupBy,
-    rowGrouper,
-    rowHeight,
-    clientHeight,
-    scrollTop,
-    expandedGroupIds,
-    enableVirtualization
-  });
+    /**
+     * computed values
+     */
+    const [gridRef, gridWidth, gridHeight] = useGridDimensions();
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const headerRowsCount = 1;
+    const summaryRowsCount = summaryRows?.length ?? 0;
+    const clientHeight = gridHeight - headerRowHeight - summaryRowsCount * summaryRowHeight;
+    const isSelectable = selectedRows != null && onSelectedRowsChange != null;
+    const isHeaderRowSelected = selectedPosition.rowIdx === -1;
 
-  const viewportColumns = useViewportColumns({
-    columns,
-    colSpanColumns,
-    colOverscanStartIdx,
-    colOverscanEndIdx,
-    lastFrozenColumnIndex,
-    rowOverscanStartIdx,
-    rowOverscanEndIdx,
-    rows,
-    summaryRows,
-    isGroupRow
-  });
+    const allRowsSelected = useMemo((): boolean => {
+        // no rows to select = explicitely unchecked
+        const { length } = rawRows;
+        return (
+            length !== 0 &&
+            selectedRows != null &&
+            rowKeyGetter != null &&
+            selectedRows.size >= length &&
+            rawRows.every((row) => {
+                if (!selectedRows || !rowKeyGetter ) return false;
+                return selectedRows.has(rowKeyGetter(row))
+            })
+        );
+    }, [rawRows, selectedRows, rowKeyGetter]);
 
-  const hasGroups = groupBy.length > 0 && typeof rowGrouper === 'function';
-  const minColIdx = hasGroups ? -1 : 0;
-  const maxColIdx = columns.length - 1;
-  const minRowIdx = -1; // change it to 0?
-  const maxRowIdx = headerRowsCount + rows.length + summaryRowsCount - 2;
-  const selectedCellIsWithinSelectionBounds = isCellWithinSelectionBounds(selectedPosition);
-  const selectedCellIsWithinViewportBounds = isCellWithinViewportBounds(selectedPosition);
-
-  /**
-   * The identity of the wrapper function is stable so it won't break memoization
-   */
-  const selectRowLatest = useLatestFunc(selectRow);
-  const selectAllRowsLatest = useLatestFunc(selectAllRows);
-  const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
-  const selectViewportCellLatest = useLatestFunc(
-    (row: R, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
-      const rowIdx = rows.indexOf(row);
-      selectCell({ rowIdx, idx: column.idx }, enableEditor);
-    }
-  );
-  const selectGroupLatest = useLatestFunc((rowIdx: number) => {
-    selectCell({ rowIdx, idx: -1 });
-  });
-  const selectHeaderCellLatest = useLatestFunc((idx: number) => {
-    selectCell({ rowIdx: -1, idx });
-  });
-  const selectSummaryCellLatest = useLatestFunc(
-    (summaryRow: SR, column: CalculatedColumn<R, SR>) => {
-      const rowIdx = summaryRows!.indexOf(summaryRow) + headerRowsCount + rows.length - 1;
-      selectCell({ rowIdx, idx: column.idx });
-    }
-  );
-  const toggleGroupLatest = useLatestFunc(toggleGroup);
-
-  /**
-   * effects
-   */
-  useLayoutEffect(() => {
-    if (
-      !selectedCellIsWithinSelectionBounds ||
-      isSamePosition(selectedPosition, prevSelectedPosition.current)
-    ) {
-      prevSelectedPosition.current = selectedPosition;
-      return;
-    }
-
-    prevSelectedPosition.current = selectedPosition;
-    scrollToCell(selectedPosition);
-  });
-
-  useImperativeHandle(ref, () => ({
-    element: gridRef.current,
-    scrollToColumn(idx: number) {
-      scrollToCell({ idx });
-    },
-    scrollToRow(rowIdx: number) {
-      const { current } = gridRef;
-      if (!current) return;
-      current.scrollTo({
-        top: getRowTop(rowIdx),
-        behavior: 'smooth'
-      });
-    },
-    selectCell
-  }));
-
-  /**
-   * callbacks
-   */
-  const handleColumnResize = useCallback(
-    (column: CalculatedColumn<R, SR>, width: number) => {
-      setColumnWidths((columnWidths) => {
-        const newColumnWidths = new Map(columnWidths);
-        newColumnWidths.set(column.key, width);
-        return newColumnWidths;
-      });
-
-      onColumnResize?.(column.idx, width);
-    },
-    [onColumnResize]
-  );
-
-  const setDraggedOverRowIdx = useCallback((rowIdx?: number) => {
-    setOverRowIdx(rowIdx);
-    latestDraggedOverRowIdx.current = rowIdx;
-  }, []);
-
-  /**
-   * event handlers
-   */
-  function selectRow({ row, checked, isShiftClick }: SelectRowEvent<R>) {
-    if (!onSelectedRowsChange) return;
-
-    assertIsValidKeyGetter<R, K>(rowKeyGetter);
-    const newSelectedRows = new Set(selectedRows);
-    if (isGroupRow(row)) {
-      for (const childRow of row.childRows) {
-        const rowKey = rowKeyGetter(childRow);
-        if (checked) {
-          newSelectedRows.add(rowKey);
-        } else {
-          newSelectedRows.delete(rowKey);
-        }
-      }
-      onSelectedRowsChange(newSelectedRows);
-      return;
-    }
-
-    const rowKey = rowKeyGetter(row);
-    if (checked) {
-      newSelectedRows.add(rowKey);
-      const previousRowIdx = lastSelectedRowIdx.current;
-      const rowIdx = rows.indexOf(row);
-      lastSelectedRowIdx.current = rowIdx;
-      if (isShiftClick && previousRowIdx !== -1 && previousRowIdx !== rowIdx) {
-        const step = sign(rowIdx - previousRowIdx);
-        for (let i = previousRowIdx + step; i !== rowIdx; i += step) {
-          const row = rows[i];
-          if (isGroupRow(row)) continue;
-          newSelectedRows.add(rowKeyGetter(row));
-        }
-      }
-    } else {
-      newSelectedRows.delete(rowKey);
-      lastSelectedRowIdx.current = -1;
-    }
-
-    onSelectedRowsChange(newSelectedRows);
-  }
-
-  function selectAllRows(checked: boolean) {
-    if (!onSelectedRowsChange) return;
-
-    assertIsValidKeyGetter<R, K>(rowKeyGetter);
-    const newSelectedRows = new Set(selectedRows);
-
-    for (const row of rawRows) {
-      const rowKey = rowKeyGetter(row);
-      if (checked) {
-        newSelectedRows.add(rowKey);
-      } else {
-        newSelectedRows.delete(rowKey);
-      }
-    }
-
-    onSelectedRowsChange(newSelectedRows);
-  }
-
-  function toggleGroup(expandedGroupId: unknown) {
-    if (!onExpandedGroupIdsChange) return;
-    const newExpandedGroupIds = new Set(expandedGroupIds);
-    if (newExpandedGroupIds.has(expandedGroupId)) {
-      newExpandedGroupIds.delete(expandedGroupId);
-    } else {
-      newExpandedGroupIds.add(expandedGroupId);
-    }
-    onExpandedGroupIdsChange(newExpandedGroupIds);
-  }
-
-  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (!(event.target instanceof Element)) return;
-    const isCellEvent = event.target.closest('.rdg-cell') !== null;
-    const isRowEvent = hasGroups && event.target.matches('.rdg-row, .rdg-header-row');
-    if (!isCellEvent && !isRowEvent) return;
-
-    const { key, keyCode } = event;
-    const { rowIdx } = selectedPosition;
-
-    if (
-      selectedCellIsWithinViewportBounds &&
-      onPaste != null &&
-      isCtrlKeyHeldDown(event) &&
-      !isGroupRow(rows[rowIdx]) &&
-      selectedPosition.mode === 'SELECT'
-    ) {
-      // event.key may differ by keyboard input language, so we use event.keyCode instead
-      // event.nativeEvent.code cannot be used either as it would break copy/paste for the DVORAK layout
-      const cKey = 67;
-      const vKey = 86;
-      if (keyCode === cKey) {
-        handleCopy();
-        return;
-      }
-      if (keyCode === vKey) {
-        handlePaste();
-        return;
-      }
-    }
-
-    if (isRowIdxWithinViewportBounds(rowIdx)) {
-      const row = rows[rowIdx];
-
-      if (
-        isGroupRow(row) &&
-        selectedPosition.idx === -1 &&
-        // Collapse the current group row if it is focused and is in expanded state
-        ((key === 'ArrowLeft' && row.isExpanded) ||
-          // Expand the current group row if it is focused and is in collapsed state
-          (key === 'ArrowRight' && !row.isExpanded))
-      ) {
-        event.preventDefault(); // Prevents scrolling
-        toggleGroup(row.id);
-        return;
-      }
-    }
-
-    switch (event.key) {
-      case 'Escape':
-        setCopiedCell(null);
-        return;
-      case 'ArrowUp':
-      case 'ArrowDown':
-      case 'ArrowLeft':
-      case 'ArrowRight':
-      case 'Tab':
-      case 'Home':
-      case 'End':
-      case 'PageUp':
-      case 'PageDown':
-        navigate(event);
-        break;
-      default:
-        handleCellInput(event);
-        break;
-    }
-  }
-
-  function handleScroll(event: React.UIEvent<HTMLDivElement>) {
-    const { scrollTop, scrollLeft } = event.currentTarget;
-    setScrollTop(scrollTop);
-    setScrollLeft(scrollLeft);
-    onScroll?.(event);
-  }
-
-  function getRawRowIdx(rowIdx: number) {
-    return hasGroups ? rawRows.indexOf(rows[rowIdx] as R) : rowIdx;
-  }
-
-  function updateRow(rowIdx: number, row: R) {
-    if (typeof onRowsChange !== 'function') return;
-    const rawRowIdx = getRawRowIdx(rowIdx);
-    if (row === rawRows[rawRowIdx]) return;
-    const updatedRows = [...rawRows];
-    updatedRows[rawRowIdx] = row;
-    onRowsChange(updatedRows, {
-      indexes: [rawRowIdx],
-      column: columns[selectedPosition.idx]
-    });
-  }
-
-  function commitEditorChanges() {
-    if (selectedPosition.mode !== 'EDIT') return;
-    updateRow(selectedPosition.rowIdx, selectedPosition.row);
-  }
-
-  function handleCopy() {
-    const { idx, rowIdx } = selectedPosition;
-    setCopiedCell({ row: rawRows[getRawRowIdx(rowIdx)], columnKey: columns[idx].key });
-  }
-
-  function handlePaste() {
-    if (!onPaste || !onRowsChange || copiedCell === null || !isCellEditable(selectedPosition)) {
-      return;
-    }
-
-    const { idx, rowIdx } = selectedPosition;
-    const targetRow = rawRows[getRawRowIdx(rowIdx)];
-
-    const updatedTargetRow = onPaste({
-      sourceRow: copiedCell.row,
-      sourceColumnKey: copiedCell.columnKey,
-      targetRow,
-      targetColumnKey: columns[idx].key
+    const {
+        columns,
+        colSpanColumns,
+        colOverscanStartIdx,
+        colOverscanEndIdx,
+        layoutCssVars,
+        columnMetrics,
+        totalColumnWidth,
+        lastFrozenColumnIndex,
+        totalFrozenColumnWidth,
+        groupBy
+    } = useCalculatedColumns({
+        rawColumns,
+        columnWidths,
+        scrollLeft,
+        viewportWidth: gridWidth,
+        defaultColumnOptions,
+        rawGroupBy: rowGrouper ? rawGroupBy : undefined,
+        enableVirtualization
     });
 
-    updateRow(rowIdx, updatedTargetRow);
-  }
+    const {
+        rowOverscanStartIdx,
+        rowOverscanEndIdx,
+        rows,
+        rowsCount,
+        totalRowHeight,
+        isGroupRow,
+        getRowTop,
+        getRowHeight,
+        findRowIdx
+    } = useViewportRows({
+        rawRows,
+        groupBy,
+        rowGrouper,
+        rowHeight,
+        clientHeight,
+        scrollTop,
+        expandedGroupIds,
+        enableVirtualization
+    });
 
-  function handleCellInput(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (!selectedCellIsWithinViewportBounds) return;
-    const row = rows[selectedPosition.rowIdx];
-    if (isGroupRow(row)) return;
-    const { key, shiftKey } = event;
-
-    // Select the row on Shift + Space
-    if (isSelectable && shiftKey && key === ' ') {
-      assertIsValidKeyGetter<R, K>(rowKeyGetter);
-      const rowKey = rowKeyGetter(row);
-      selectRow({ row, checked: !selectedRows.has(rowKey), isShiftClick: false });
-      // do not scroll
-      event.preventDefault();
-      return;
-    }
-
-    const column = columns[selectedPosition.idx];
-    column.editorOptions?.onCellKeyDown?.(event);
-    if (event.isDefaultPrevented()) return;
-
-    if (isCellEditable(selectedPosition) && isDefaultCellInput(event)) {
-      setSelectedPosition(({ idx, rowIdx }) => ({
-        idx,
-        rowIdx,
-        mode: 'EDIT',
-        row,
-        originalRow: row
-      }));
-    }
-  }
-
-  /**
-   * utils
-   */
-  function isColIdxWithinSelectionBounds(idx: number) {
-    return idx >= minColIdx && idx <= maxColIdx;
-  }
-
-  function isRowIdxWithinViewportBounds(rowIdx: number) {
-    return rowIdx >= 0 && rowIdx < rows.length;
-  }
-
-  function isCellWithinSelectionBounds({ idx, rowIdx }: Position): boolean {
-    return rowIdx >= minRowIdx && rowIdx <= maxRowIdx && isColIdxWithinSelectionBounds(idx);
-  }
-
-  function isCellWithinViewportBounds({ idx, rowIdx }: Position): boolean {
-    return isRowIdxWithinViewportBounds(rowIdx) && isColIdxWithinSelectionBounds(idx);
-  }
-
-  function isCellEditable(position: Position): boolean {
-    return (
-      isCellWithinViewportBounds(position) &&
-      isSelectedCellEditable({ columns, rows, selectedPosition: position, isGroupRow })
-    );
-  }
-
-  function selectCell(position: Position, enableEditor?: Maybe<boolean>): void {
-    if (!isCellWithinSelectionBounds(position)) return;
-    commitEditorChanges();
-
-    if (enableEditor && isCellEditable(position)) {
-      const row = rows[position.rowIdx] as R;
-      setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row });
-    } else if (isSamePosition(selectedPosition, position)) {
-      // Avoid re-renders if the selected cell state is the same
-      // TODO: replace with a #record? https://github.com/microsoft/TypeScript/issues/39831
-      scrollToCell(position);
-    } else {
-      setSelectedPosition({ ...position, mode: 'SELECT' });
-    }
-  }
-
-  function scrollToCell({ idx, rowIdx }: Partial<Position>): void {
-    const { current } = gridRef;
-    if (!current) return;
-
-    if (typeof idx === 'number' && idx > lastFrozenColumnIndex) {
-      rowIdx ??= selectedPosition.rowIdx;
-      if (!isCellWithinSelectionBounds({ rowIdx, idx })) return;
-      const { clientWidth } = current;
-      const column = columns[idx];
-      const { left, width } = columnMetrics.get(column)!;
-      let right = left + width;
-
-      const colSpan = getSelectedCellColSpan({
+    const viewportColumns = useViewportColumns({
+        columns,
+        colSpanColumns,
+        colOverscanStartIdx,
+        colOverscanEndIdx,
+        lastFrozenColumnIndex,
+        rowOverscanStartIdx,
+        rowOverscanEndIdx,
         rows,
         summaryRows,
-        rowIdx,
-        lastFrozenColumnIndex,
-        column,
         isGroupRow
-      });
-
-      if (colSpan !== undefined) {
-        const { left, width } = columnMetrics.get(columns[column.idx + colSpan - 1])!;
-        right = left + width;
-      }
-
-      const isCellAtLeftBoundary = left < scrollLeft + totalFrozenColumnWidth;
-      const isCellAtRightBoundary = right > clientWidth + scrollLeft;
-      if (isCellAtLeftBoundary) {
-        current.scrollLeft = left - totalFrozenColumnWidth;
-      } else if (isCellAtRightBoundary) {
-        current.scrollLeft = right - clientWidth;
-      }
-    }
-
-    if (typeof rowIdx === 'number' && isRowIdxWithinViewportBounds(rowIdx)) {
-      const rowTop = getRowTop(rowIdx);
-      const rowHeight = getRowHeight(rowIdx);
-      if (rowTop < scrollTop) {
-        // at top boundary, scroll to the row's top
-        current.scrollTop = rowTop;
-      } else if (rowTop + rowHeight > scrollTop + clientHeight) {
-        // at bottom boundary, scroll the next row's top to the bottom of the viewport
-        current.scrollTop = rowTop + rowHeight - clientHeight;
-      }
-    }
-  }
-
-  function getNextPosition(key: string, ctrlKey: boolean, shiftKey: boolean): Position {
-    const { idx, rowIdx } = selectedPosition;
-    const row = rows[rowIdx];
-    const isRowSelected = selectedCellIsWithinSelectionBounds && idx === -1;
-
-    // If a group row is focused, and it is collapsed, move to the parent group row (if there is one).
-    if (
-      key === 'ArrowLeft' &&
-      isRowSelected &&
-      isGroupRow(row) &&
-      !row.isExpanded &&
-      row.level !== 0
-    ) {
-      let parentRowIdx = -1;
-      for (let i = selectedPosition.rowIdx - 1; i >= 0; i--) {
-        const parentRow = rows[i];
-        if (isGroupRow(parentRow) && parentRow.id === row.parentId) {
-          parentRowIdx = i;
-          break;
-        }
-      }
-      if (parentRowIdx !== -1) {
-        return { idx, rowIdx: parentRowIdx };
-      }
-    }
-
-    switch (key) {
-      case 'ArrowUp':
-        return { idx, rowIdx: rowIdx - 1 };
-      case 'ArrowDown':
-        return { idx, rowIdx: rowIdx + 1 };
-      case 'ArrowLeft':
-        return { idx: idx - 1, rowIdx };
-      case 'ArrowRight':
-        return { idx: idx + 1, rowIdx };
-      case 'Tab':
-        return { idx: idx + (shiftKey ? -1 : 1), rowIdx };
-      case 'Home':
-        // If row is selected then move focus to the first row
-        if (isRowSelected) return { idx, rowIdx: 0 };
-        return { idx: 0, rowIdx: ctrlKey ? minRowIdx : rowIdx };
-      case 'End':
-        // If row is selected then move focus to the last row.
-        if (isRowSelected) return { idx, rowIdx: rows.length - 1 };
-        return { idx: maxColIdx, rowIdx: ctrlKey ? maxRowIdx : rowIdx };
-      case 'PageUp': {
-        if (selectedPosition.rowIdx === minRowIdx) return selectedPosition;
-        const nextRowY = getRowTop(rowIdx) + getRowHeight(rowIdx) - clientHeight;
-        return { idx, rowIdx: nextRowY > 0 ? findRowIdx(nextRowY) : 0 };
-      }
-      case 'PageDown': {
-        if (selectedPosition.rowIdx >= rows.length) return selectedPosition;
-        const nextRowY = getRowTop(rowIdx) + clientHeight;
-        return { idx, rowIdx: nextRowY < totalRowHeight ? findRowIdx(nextRowY) : rows.length - 1 };
-      }
-      default:
-        return selectedPosition;
-    }
-  }
-
-  function navigate(event: React.KeyboardEvent<HTMLDivElement>) {
-    const { key, shiftKey } = event;
-    let mode = cellNavigationMode;
-    if (key === 'Tab') {
-      if (
-        canExitGrid({
-          shiftKey,
-          cellNavigationMode,
-          maxColIdx,
-          minRowIdx,
-          maxRowIdx,
-          selectedPosition
-        })
-      ) {
-        commitEditorChanges();
-        // Allow focus to leave the grid so the next control in the tab order can be focused
-        return;
-      }
-
-      mode = cellNavigationMode === 'NONE' ? 'CHANGE_ROW' : cellNavigationMode;
-    }
-
-    // Do not allow focus to leave
-    event.preventDefault();
-
-    const ctrlKey = isCtrlKeyHeldDown(event);
-    const nextPosition = getNextPosition(key, ctrlKey, shiftKey);
-    if (isSamePosition(selectedPosition, nextPosition)) return;
-
-    const nextSelectedCellPosition = getNextSelectedCellPosition({
-      columns,
-      colSpanColumns,
-      rows,
-      summaryRows,
-      minRowIdx,
-      maxRowIdx,
-      lastFrozenColumnIndex,
-      cellNavigationMode: mode,
-      currentPosition: selectedPosition,
-      nextPosition,
-      isCellWithinBounds: isCellWithinSelectionBounds,
-      isGroupRow
     });
 
-    selectCell(nextSelectedCellPosition);
-  }
+    const hasGroups = groupBy.length > 0 && typeof rowGrouper === 'function';
+    const minColIdx = hasGroups ? -1 : 0;
+    const maxColIdx = columns.length - 1;
+    const minRowIdx = 0; // change it to 0?
+    const maxRowIdx = headerRowsCount + rows.length + summaryRowsCount - 2;
+    const selectedCellIsWithinSelectionBounds = isCellWithinSelectionBounds(selectedPosition);
+    const selectedCellIsWithinViewportBounds = isCellWithinViewportBounds(selectedPosition);
 
-  function getDraggedOverCellIdx(currentRowIdx: number): number | undefined {
-    if (draggedOverRowIdx === undefined) return;
-    const { rowIdx } = selectedPosition;
-
-    const isDraggedOver =
-      rowIdx < draggedOverRowIdx
-        ? rowIdx < currentRowIdx && currentRowIdx <= draggedOverRowIdx
-        : rowIdx > currentRowIdx && currentRowIdx >= draggedOverRowIdx;
-
-    return isDraggedOver ? selectedPosition.idx : undefined;
-  }
-
-  function getDragHandle(rowIdx: number) {
-    if (
-      selectedPosition.rowIdx !== rowIdx ||
-      selectedPosition.mode === 'EDIT' ||
-      hasGroups || // drag fill is not supported when grouping is enabled
-      onFill == null
-    ) {
-      return;
-    }
-
-    return (
-      <DragHandle
-        rows={rawRows}
-        columns={columns}
-        selectedPosition={selectedPosition}
-        isCellEditable={isCellEditable}
-        latestDraggedOverRowIdx={latestDraggedOverRowIdx}
-        onRowsChange={onRowsChange}
-        onFill={onFill}
-        setDragging={setDragging}
-        setDraggedOverRowIdx={setDraggedOverRowIdx}
-      />
-    );
-  }
-
-  function getCellEditor(rowIdx: number) {
-    if (selectedPosition.rowIdx !== rowIdx || selectedPosition.mode === 'SELECT') return;
-
-    const { idx, row } = selectedPosition;
-    const column = columns[idx];
-    const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'ROW', row });
-
-    const closeEditor = () => {
-      setSelectedPosition(({ idx, rowIdx }) => ({ idx, rowIdx, mode: 'SELECT' }));
-    };
-
-    const onRowChange = (row: R, commitChanges?: boolean) => {
-      if (commitChanges) {
-        updateRow(selectedPosition.rowIdx, row);
-        closeEditor();
-      } else {
-        setSelectedPosition((position) => ({ ...position, row }));
-      }
-    };
-
-    if (rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
-      // Discard changes if rows are updated from outside
-      closeEditor();
-    }
-
-    return (
-      <EditCell
-        key={column.key}
-        column={column}
-        colSpan={colSpan}
-        row={row}
-        onRowChange={onRowChange}
-        closeEditor={closeEditor}
-        scrollToCell={() => {
-          scrollToCell(selectedPosition);
-        }}
-      />
-    );
-  }
-
-  function getViewportRows() {
-    const rowElements = [];
-    let startRowIndex = 0;
-
-    const { idx: selectedIdx, rowIdx: selectedRowIdx } = selectedPosition;
-    const startRowIdx =
-      selectedCellIsWithinViewportBounds && selectedRowIdx < rowOverscanStartIdx
-        ? rowOverscanStartIdx - 1
-        : rowOverscanStartIdx;
-    const endRowIdx =
-      selectedCellIsWithinViewportBounds && selectedRowIdx > rowOverscanEndIdx
-        ? rowOverscanEndIdx + 1
-        : rowOverscanEndIdx;
-
-    for (let viewportRowIdx = startRowIdx; viewportRowIdx <= endRowIdx; viewportRowIdx++) {
-      const isRowOutsideViewport =
-        viewportRowIdx === rowOverscanStartIdx - 1 || viewportRowIdx === rowOverscanEndIdx + 1;
-      const rowIdx = isRowOutsideViewport ? selectedRowIdx : viewportRowIdx;
-
-      let rowColumns = viewportColumns;
-      const selectedColumn = columns[selectedIdx];
-      // selectedIdx can be -1 if grouping is enabled
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (selectedColumn !== undefined) {
-        if (isRowOutsideViewport) {
-          // if the row is outside the viewport then only render the selected cell
-          rowColumns = [selectedColumn];
-        } else if (selectedRowIdx === rowIdx && !viewportColumns.includes(selectedColumn)) {
-          // if the row is within the viewport and cell is not, add the selected column to viewport columns
-          rowColumns =
-            selectedIdx > viewportColumns[viewportColumns.length - 1].idx
-              ? [...viewportColumns, selectedColumn]
-              : [
-                  ...viewportColumns.slice(0, lastFrozenColumnIndex + 1),
-                  selectedColumn,
-                  ...viewportColumns.slice(lastFrozenColumnIndex + 1)
-                ];
+    /**
+     * The identity of the wrapper function is stable so it won't break memoization
+     */
+    const selectRowLatest = useLatestFunc(selectRow);
+    const selectAllRowsLatest = useLatestFunc(selectAllRows);
+    const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
+    const selectViewportCellLatest = useLatestFunc(
+        (row: R, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
+            const rowIdx = rows.indexOf(row);
+            selectCell({ rowIdx, idx: column.idx }, enableEditor);
         }
-      }
+    );
+    const selectGroupLatest = useLatestFunc((rowIdx: number) => {
+        selectCell({ rowIdx, idx: -1 });
+    });
+    const selectHeaderCellLatest = useLatestFunc((idx: number) => {
+        selectCell({ rowIdx: -1, idx });
+    });
+    const selectSummaryCellLatest = useLatestFunc(
+        (summaryRow: SR, column: CalculatedColumn<R, SR>) => {
+            const rowIdx = summaryRows!.indexOf(summaryRow) + headerRowsCount + rows.length - 1;
+            selectCell({ rowIdx, idx: column.idx });
+        }
+    );
+    const toggleGroupLatest = useLatestFunc(toggleGroup);
 
-      const row = rows[rowIdx];
-      const top = getRowTop(rowIdx) + headerRowHeight;
-      if (isGroupRow(row)) {
-        ({ startRowIndex } = row);
-        const isGroupRowSelected =
-          isSelectable && row.childRows.every((cr) => selectedRows.has(rowKeyGetter!(cr)));
-        rowElements.push(
-          <GroupRowRenderer
-            aria-level={row.level + 1} // aria-level is 1-based
-            aria-setsize={row.setSize}
-            aria-posinset={row.posInSet + 1} // aria-posinset is 1-based
-            aria-rowindex={headerRowsCount + startRowIndex + 1} // aria-rowindex is 1 based
-            aria-selected={isSelectable ? isGroupRowSelected : undefined}
-            key={row.id}
-            id={row.id}
-            groupKey={row.groupKey}
-            viewportColumns={rowColumns}
-            childRows={row.childRows}
-            rowIdx={rowIdx}
-            row={row}
-            top={top}
-            height={getRowHeight(rowIdx)}
-            level={row.level}
-            isExpanded={row.isExpanded}
-            selectedCellIdx={selectedRowIdx === rowIdx ? selectedIdx : undefined}
-            isRowSelected={isGroupRowSelected}
-            selectGroup={selectGroupLatest}
-            toggleGroup={toggleGroupLatest}
-          />
-        );
-        continue;
-      }
+    const editorRef = useRef<React.ComponentClass|ICanCommit>(null);
+    const rowRefs = useRef<RefObject<RowHandle>[]>([]);
 
-      startRowIndex++;
-      let key;
-      let isRowSelected = false;
-      if (typeof rowKeyGetter === 'function') {
-        key = rowKeyGetter(row);
-        isRowSelected = selectedRows?.has(key) ?? false;
-      } else {
-        key = hasGroups ? startRowIndex : rowIdx;
-      }
+    /**
+     * effects
+     */
+    useLayoutEffect(() => {
+        if (
+            !selectedCellIsWithinSelectionBounds ||
+            isSamePosition(selectedPosition, prevSelectedPosition.current)
+        ) {
+            prevSelectedPosition.current = selectedPosition;
+            return;
+        }
 
-      rowElements.push(
-        <RowRenderer
-          aria-rowindex={headerRowsCount + (hasGroups ? startRowIndex : rowIdx) + 1} // aria-rowindex is 1 based
-          aria-selected={isSelectable ? isRowSelected : undefined}
-          key={key}
-          rowIdx={rowIdx}
-          row={row}
-          viewportColumns={rowColumns}
-          isRowSelected={isRowSelected}
-          onRowClick={onRowClick}
-          onRowDoubleClick={onRowDoubleClick}
-          rowClass={rowClass}
-          top={top}
-          height={getRowHeight(rowIdx)}
-          copiedCellIdx={
-            copiedCell !== null && copiedCell.row === row
-              ? columns.findIndex((c) => c.key === copiedCell.columnKey)
-              : undefined
-          }
-          selectedCellIdx={selectedRowIdx === rowIdx ? selectedIdx : undefined}
-          draggedOverCellIdx={getDraggedOverCellIdx(rowIdx)}
-          setDraggedOverRowIdx={isDragging ? setDraggedOverRowIdx : undefined}
-          lastFrozenColumnIndex={lastFrozenColumnIndex}
-          onRowChange={handleFormatterRowChangeLatest}
-          selectCell={selectViewportCellLatest}
-          selectedCellDragHandle={getDragHandle(rowIdx)}
-          selectedCellEditor={getCellEditor(rowIdx)}
-        />
-      );
+        prevSelectedPosition.current = selectedPosition;
+        scrollToCell(selectedPosition);
+    });
+
+    useImperativeHandle(ref, () => ({
+        element: gridRef.current,
+        scrollToColumn(idx: number) {
+            scrollToCell({ idx });
+        },
+        scrollToRow(rowIdx: number) {
+            const { current } = viewportRef;
+            if (!current) return;
+            const rowTop = getRowTop(rowIdx);
+            current.scrollTo({
+                top: rowTop ,
+                behavior: 'smooth'
+            });
+            setScrollTop(rowTop); //store new position
+        },
+        selectCell,
+        updateRow(position:Position){
+            const rowForceUpdate = rowRefs.current[position.rowIdx];
+            if  (!rowForceUpdate) return;
+            rowForceUpdate.current?.updateRow();
+        },
+        inEditor(){
+            return editorRef.current !== null
+        }
+    }));
+
+    /**
+     * callbacks
+     */
+    const handleColumnResize = useCallback(
+        (column: CalculatedColumn<R, SR>, width: number) => {
+            setColumnWidths((columnWidths) => {
+                const newColumnWidths = new Map(columnWidths);
+                newColumnWidths.set(column.key, width);
+                return newColumnWidths;
+            });
+
+            onColumnResize?.(column.idx, width);
+        },
+        [onColumnResize]
+    );
+
+    const setDraggedOverRowIdx = useCallback((rowIdx?: number) => {
+        setOverRowIdx(rowIdx);
+        latestDraggedOverRowIdx.current = rowIdx;
+    }, []);
+
+    /**
+     * event handlers
+     */
+    function selectRow({ row, checked, isShiftClick }: SelectRowEvent<R>) {
+        if (!onSelectedRowsChange) return;
+
+        assertIsValidKeyGetter<R, K>(rowKeyGetter);
+        const newSelectedRows = new Set(selectedRows);
+        if (isGroupRow(row)) {
+            for (const childRow of row.childRows) {
+                const rowKey = rowKeyGetter(childRow);
+                if (checked) {
+                    newSelectedRows.add(rowKey);
+                } else {
+                    newSelectedRows.delete(rowKey);
+                }
+            }
+            onSelectedRowsChange(newSelectedRows);
+            return;
+        }
+
+        const rowKey = rowKeyGetter(row);
+        if (checked) {
+            newSelectedRows.add(rowKey);
+            const previousRowIdx = lastSelectedRowIdx.current;
+            const rowIdx = rows.indexOf(row);
+            lastSelectedRowIdx.current = rowIdx;
+            if (isShiftClick && previousRowIdx !== -1 && previousRowIdx !== rowIdx) {
+                const step = sign(rowIdx - previousRowIdx);
+                for (let i = previousRowIdx + step; i !== rowIdx; i += step) {
+                    const row = rows[i];
+                    if (isGroupRow(row)) continue;
+                    newSelectedRows.add(rowKeyGetter(row));
+                }
+            }
+        } else {
+            newSelectedRows.delete(rowKey);
+            lastSelectedRowIdx.current = -1;
+        }
+
+        onSelectedRowsChange(newSelectedRows);
     }
 
-    return rowElements;
-  }
+    function selectAllRows(checked: boolean) {
+        if (!onSelectedRowsChange) return;
 
-  // Reset the positions if the current values are no longer valid. This can happen if a column or row is removed
-  if (selectedPosition.idx > maxColIdx || selectedPosition.rowIdx > maxRowIdx) {
-    setSelectedPosition(initialPosition);
-    setDraggedOverRowIdx(undefined);
-  }
+        assertIsValidKeyGetter<R, K>(rowKeyGetter);
+        const newSelectedRows = new Set(selectedRows);
 
-  return (
-    <div
-      role={hasGroups ? 'treegrid' : 'grid'}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      aria-describedby={ariaDescribedBy}
-      aria-multiselectable={isSelectable ? true : undefined}
-      aria-colcount={columns.length}
-      aria-rowcount={headerRowsCount + rowsCount + summaryRowsCount}
-      className={clsx(rootClassname, { [viewportDraggingClassname]: isDragging }, className)}
-      style={
-        {
-          ...style,
-          '--rdg-header-row-height': `${headerRowHeight}px`,
-          '--rdg-row-width': `${totalColumnWidth}px`,
-          '--rdg-summary-row-height': `${summaryRowHeight}px`,
-          ...layoutCssVars
-        } as unknown as React.CSSProperties
-      }
-      ref={gridRef}
-      onScroll={handleScroll}
-      onKeyDown={handleKeyDown}
-      data-testid={testId}
-    >
-      <HeaderRow
-        columns={viewportColumns}
-        onColumnResize={handleColumnResize}
-        allRowsSelected={allRowsSelected}
-        onAllRowsSelectionChange={selectAllRowsLatest}
-        sortColumns={sortColumns}
-        onSortColumnsChange={onSortColumnsChange}
-        lastFrozenColumnIndex={lastFrozenColumnIndex}
-        selectedCellIdx={isHeaderRowSelected ? selectedPosition.idx : undefined}
-        selectCell={selectHeaderCellLatest}
-        shouldFocusGrid={!selectedCellIsWithinSelectionBounds}
-      />
-      {rows.length === 0 && noRowsFallback ? (
-        noRowsFallback
-      ) : (
-        <>
-          <div style={{ height: max(totalRowHeight, clientHeight) }} />
-          <RowSelectionChangeProvider value={selectRowLatest}>
-            {getViewportRows()}
-          </RowSelectionChangeProvider>
-          {summaryRows?.map((row, rowIdx) => {
-            const isSummaryRowSelected =
-              selectedPosition.rowIdx === headerRowsCount + rows.length + rowIdx - 1;
-            return (
-              <SummaryRow
-                aria-rowindex={headerRowsCount + rowsCount + rowIdx + 1}
-                key={rowIdx}
-                rowIdx={rowIdx}
+        for (const row of rawRows) {
+            const rowKey = rowKeyGetter(row);
+            if (checked) {
+                newSelectedRows.add(rowKey);
+            } else {
+                newSelectedRows.delete(rowKey);
+            }
+        }
+
+        onSelectedRowsChange(newSelectedRows);
+    }
+
+    function toggleGroup(expandedGroupId: unknown) {
+        if (!onExpandedGroupIdsChange) return;
+        const newExpandedGroupIds = new Set(expandedGroupIds);
+        if (newExpandedGroupIds.has(expandedGroupId)) {
+            newExpandedGroupIds.delete(expandedGroupId);
+        } else {
+            newExpandedGroupIds.add(expandedGroupId);
+        }
+        onExpandedGroupIdsChange(newExpandedGroupIds);
+    }
+
+    function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+        if (!(event.target instanceof Element)) return;
+        const isCellEvent = event.target.closest('.rdg-cell') !== null;
+        const isRowEvent = hasGroups && event.target.matches('.rdg-row, .rdg-header-row');
+        if (!isCellEvent && !isRowEvent) return;
+
+        const { key, keyCode } = event;
+        const { rowIdx } = selectedPosition;
+
+        if (
+            selectedCellIsWithinViewportBounds &&
+            onPaste != null &&
+            isCtrlKeyHeldDown(event) &&
+            !isGroupRow(rows[rowIdx]) &&
+            selectedPosition.mode === 'SELECT'
+        ) {
+            // event.key may differ by keyboard input language, so we use event.keyCode instead
+            // event.nativeEvent.code cannot be used either as it would break copy/paste for the DVORAK layout
+            const cKey = 67;
+            const vKey = 86;
+            if (keyCode === cKey) {
+                handleCopy();
+                return;
+            }
+            if (keyCode === vKey) {
+                handlePaste();
+                return;
+            }
+        }
+
+        if (isRowIdxWithinViewportBounds(rowIdx)) {
+            const row = rows[rowIdx];
+
+            if (
+                isGroupRow(row) &&
+                selectedPosition.idx === -1 &&
+                // Collapse the current group row if it is focused and is in expanded state
+                ((key === 'ArrowLeft' && row.isExpanded) ||
+                    // Expand the current group row if it is focused and is in collapsed state
+                    (key === 'ArrowRight' && !row.isExpanded))
+            ) {
+                event.preventDefault(); // Prevents scrolling
+                toggleGroup(row.id);
+                return;
+            }
+        }
+
+        if ( gridProps.onKeyDown) {
+            gridProps.onKeyDown(event);
+            if ( event.isDefaultPrevented()) return;
+        }
+        switch (event.key) {
+            case 'Escape':
+                setCopiedCell(null);
+                return;
+            case 'ArrowUp':
+            case 'ArrowDown':
+            case 'ArrowLeft':
+            case 'ArrowRight':
+            case 'Tab':
+            case 'Home':
+            case 'End':
+            case 'PageUp':
+            case 'PageDown':
+                navigate(event);
+                break;
+
+            default:
+                if ( event.altKey || event.ctrlKey || event.metaKey) break; //special keys not edit cell.
+
+                if ( event.key === "Insert"  //must be user defined actions, not edit cell.
+                    || event.key === "Delete"
+                    || event.key === "Backspace") break;
+
+                handleCellInput(event);
+                break;
+        }
+    }
+
+    function handleScroll(event: React.UIEvent<HTMLDivElement>) {
+        onScroll?.(event);
+        const { scrollTop, scrollLeft } = event.currentTarget;
+        setScrollTop(scrollTop);
+        setScrollLeft(scrollLeft);
+    }
+
+    function getRawRowIdx(rowIdx: number) {
+        return hasGroups ? rawRows.indexOf(rows[rowIdx] as R) : rowIdx;
+    }
+
+    function updateRow(rowIdx: number, row: R, previousRow?:R) {
+        if (typeof onRowsChange !== 'function') return;
+        const rawRowIdx = getRawRowIdx(rowIdx);
+        if (row === rawRows[rawRowIdx]) return;
+        //const updatedRows = [...rawRows]; //FIXME: AV: copy all 5000 lines, WHY ??
+        const updatedRows = []; //AV: don't copy all user defined array, 'updated rows' it's only UPDATED rows but not all rows.
+        updatedRows.push(row);
+        gridProps.onRowsChange?.(updatedRows, {
+            indexes: [rawRowIdx],
+            column: columns[selectedPosition.idx],
+            previousRow:previousRow
+        });
+    }
+
+    function commitEditorChanges() {
+        if (selectedPosition.mode !== 'EDIT') return;
+        if (editorRef.current  &&(editorRef.current as ICanCommit).commit !== undefined ) {
+            (editorRef.current as ICanCommit).commit();
+        }
+        else {
+            updateRow(selectedPosition.rowIdx, selectedPosition.row, selectedPosition.originalRow);
+        }
+    }
+
+    function handleCopy() {
+        const { idx, rowIdx } = selectedPosition;
+        setCopiedCell({ row: rawRows[getRawRowIdx(rowIdx)], columnKey: columns[idx].key });
+    }
+
+    function handlePaste() {
+        if (!onPaste || !gridProps.onRowsChange || copiedCell === null || !isCellEditable(selectedPosition)) {
+            return;
+        }
+
+        const { idx, rowIdx } = selectedPosition;
+        const targetRow = rawRows[getRawRowIdx(rowIdx)];
+
+        const updatedTargetRow = onPaste({
+            sourceRow: copiedCell.row,
+            sourceColumnKey: copiedCell.columnKey,
+            targetRow,
+            targetColumnKey: columns[idx].key
+        });
+
+        updateRow(rowIdx, updatedTargetRow);
+    }
+
+    function handleCellInput(event: React.KeyboardEvent<HTMLDivElement>) {
+        if (!selectedCellIsWithinViewportBounds) return;
+        const row = rows[selectedPosition.rowIdx];
+        if (isGroupRow(row)) return;
+        const { key, shiftKey } = event;
+
+        // Select the row on Shift + Space
+        if (isSelectable && shiftKey && key === ' ') {
+            assertIsValidKeyGetter<R, K>(rowKeyGetter);
+            const rowKey = rowKeyGetter(row);
+            selectRow({ row, checked: !!selectedRows && !selectedRows.has(rowKey), isShiftClick: false });
+            // do not scroll
+            event.preventDefault();
+            return;
+        }
+
+        const column = columns[selectedPosition.idx];
+        column.editorOptions?.onCellKeyDown?.(event);
+        if (event.isDefaultPrevented()) return;
+
+        if (isCellEditable(selectedPosition) && isDefaultCellInput(event)) {
+            setSelectedPosition(({ idx, rowIdx }) => ({
+                idx,
+                rowIdx,
+                mode: 'EDIT',
+                row,
+                originalRow: row
+            }));
+        }
+    }
+
+    /**
+     * utils
+     */
+    function isColIdxWithinSelectionBounds(idx: number) {
+        return idx >= minColIdx && idx <= maxColIdx;
+    }
+
+    function isRowIdxWithinViewportBounds(rowIdx: number) {
+        return rowIdx >= 0 && rowIdx < rows.length;
+    }
+
+    function isCellWithinSelectionBounds({ idx, rowIdx }: Position): boolean {
+        return rowIdx >= minRowIdx && rowIdx <= maxRowIdx && isColIdxWithinSelectionBounds(idx);
+    }
+
+    function isCellWithinViewportBounds({ idx, rowIdx }: Position): boolean {
+        return isRowIdxWithinViewportBounds(rowIdx) && isColIdxWithinSelectionBounds(idx);
+    }
+
+    function isCellEditable(position: Position): boolean {
+        return (
+            isCellWithinViewportBounds(position) &&
+            isSelectedCellEditable({ columns, rows, selectedPosition: position, isGroupRow })
+        );
+    }
+
+    function selectCell(position: Position, enableEditor?: Maybe<boolean>): void {
+        if (!isCellWithinSelectionBounds(position)) return;
+        commitEditorChanges();
+
+        if (enableEditor && isCellEditable(position)) {
+            const row = rows[position.rowIdx] as R;
+            setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row });
+            if ( onCurrentRowChanged ) onCurrentRowChanged(position);
+        } else if (isSamePosition(selectedPosition, position)) {
+            // Avoid re-renders if the selected cell state is the same
+            // TODO: replace with a #record? https://github.com/microsoft/TypeScript/issues/39831
+            scrollToCell(position);
+        } else {
+            setSelectedPosition({ ...position, mode: 'SELECT' });
+            if ( onCurrentRowChanged ) onCurrentRowChanged(position);
+        }
+    }
+
+    function scrollToCell({ idx, rowIdx }: Partial<Position>): void {
+        const { current } = viewportRef;
+        if (!current) return;
+
+        if (typeof idx === 'number' && idx > lastFrozenColumnIndex) {
+            rowIdx ??= selectedPosition.rowIdx;
+            if (!isCellWithinSelectionBounds({ rowIdx, idx })) return;
+            const { clientWidth } = current;
+            const column = columns[idx];
+            const { left, width } = columnMetrics.get(column)!;
+            let right = left + width;
+
+            const colSpan = getSelectedCellColSpan({
+                rows,
+                summaryRows,
+                rowIdx,
+                lastFrozenColumnIndex,
+                column,
+                isGroupRow
+            });
+
+            if (colSpan !== undefined) {
+                const { left, width } = columnMetrics.get(columns[column.idx + colSpan - 1])!;
+                right = left + width;
+            }
+
+            const isCellAtLeftBoundary = left < scrollLeft + totalFrozenColumnWidth;
+            const isCellAtRightBoundary = right > clientWidth + scrollLeft;
+            if (isCellAtLeftBoundary) {
+                current.scrollLeft = left - totalFrozenColumnWidth;
+            } else if (isCellAtRightBoundary) {
+                current.scrollLeft = right - clientWidth;
+            }
+        }
+
+        if (typeof rowIdx === 'number' && isRowIdxWithinViewportBounds(rowIdx)) {
+            const rowTop = getRowTop(rowIdx);
+            const rowHeight = getRowHeight(rowIdx);
+            if (rowTop < scrollTop) {
+                // at top boundary, scroll to the row's top
+                current.scrollTop = rowTop;
+            } else if (rowTop + rowHeight > scrollTop + clientHeight) {
+                // at bottom boundary, scroll the next row's top to the bottom of the viewport
+                current.scrollTop = rowTop + rowHeight - clientHeight;
+            }
+        }
+    }
+
+    function getNextPosition(key: string, ctrlKey: boolean, shiftKey: boolean): Position {
+        const { idx, rowIdx } = selectedPosition;
+        const row = rows[rowIdx];
+        const isRowSelected = selectedCellIsWithinSelectionBounds && idx === -1;
+
+        // If a group row is focused, and it is collapsed, move to the parent group row (if there is one).
+        if (
+            key === 'ArrowLeft' &&
+            isRowSelected &&
+            isGroupRow(row) &&
+            !row.isExpanded &&
+            row.level !== 0
+        ) {
+            let parentRowIdx = -1;
+            for (let i = selectedPosition.rowIdx - 1; i >= 0; i--) {
+                const parentRow = rows[i];
+                if (isGroupRow(parentRow) && parentRow.id === row.parentId) {
+                    parentRowIdx = i;
+                    break;
+                }
+            }
+            if (parentRowIdx !== -1) {
+                return { idx, rowIdx: parentRowIdx };
+            }
+        }
+
+        switch (key) {
+            case 'ArrowUp':
+                return { idx, rowIdx: (rowIdx > 0) ? (rowIdx - 1) : 0};
+            case 'ArrowDown':
+                return { idx, rowIdx: rowIdx + 1 };
+            case 'ArrowLeft':
+                return { idx: (idx > 0) ? (idx - 1) : 0, rowIdx };
+            case 'ArrowRight':
+                return { idx: idx + 1, rowIdx };
+            case 'Tab':
+                return { idx: idx + (shiftKey ? -1 : 1), rowIdx };
+            case 'Home':
+                // If row is selected then move focus to the first row
+                if (isRowSelected) return { idx, rowIdx: 0 };
+                return { idx: 0, rowIdx: ctrlKey ? minRowIdx : rowIdx };
+            case 'End':
+                // If row is selected then move focus to the last row.
+                if (isRowSelected) return { idx, rowIdx: rows.length - 1 };
+                return { idx: maxColIdx, rowIdx: ctrlKey ? maxRowIdx : rowIdx };
+            case 'PageUp': {
+                if (selectedPosition.rowIdx === minRowIdx) return selectedPosition;
+                const nextRowY = getRowTop(rowIdx) + getRowHeight(rowIdx) - clientHeight;
+                return { idx, rowIdx: nextRowY > 0 ? findRowIdx(nextRowY) : 0 };
+            }
+            case 'PageDown': {
+                if (selectedPosition.rowIdx >= rows.length) return selectedPosition;
+                const nextRowY = getRowTop(rowIdx) + clientHeight;
+                return { idx, rowIdx: nextRowY < totalRowHeight ? findRowIdx(nextRowY) : rows.length - 1 };
+            }
+            default:
+                return selectedPosition;
+        }
+    }
+
+    function navigate(event: React.KeyboardEvent<HTMLDivElement>) {
+        const { key, shiftKey } = event;
+        let mode = cellNavigationMode;
+        if (key === 'Tab' || key === "ArrowUp" || key === "ArrowDown") {
+            if (
+                canExitGrid({
+                    shiftKey,
+                    cellNavigationMode,
+                    maxColIdx,
+                    minRowIdx,
+                    maxRowIdx,
+                    selectedPosition
+                })
+            ) {
+                commitEditorChanges();
+                // Allow focus to leave the grid so the next control in the tab order can be focused
+                return;
+            }
+
+            mode = cellNavigationMode === 'NONE' ? 'CHANGE_ROW' : cellNavigationMode;
+        }
+
+        // Do not allow focus to leave
+        event.preventDefault();
+
+        const ctrlKey = isCtrlKeyHeldDown(event);
+        const nextPosition = getNextPosition(key, ctrlKey, shiftKey);
+        if (isSamePosition(selectedPosition, nextPosition)) return;
+
+        const nextSelectedCellPosition = getNextSelectedCellPosition({
+            columns,
+            colSpanColumns,
+            rows,
+            summaryRows,
+            minRowIdx,
+            maxRowIdx,
+            lastFrozenColumnIndex,
+            cellNavigationMode: mode,
+            currentPosition: selectedPosition,
+            nextPosition,
+            isCellWithinBounds: isCellWithinSelectionBounds,
+            isGroupRow
+        });
+
+        selectCell(nextSelectedCellPosition);
+    }
+
+    function getDraggedOverCellIdx(currentRowIdx: number): number | undefined {
+        if (draggedOverRowIdx === undefined) return;
+        const { rowIdx } = selectedPosition;
+
+        const isDraggedOver =
+            rowIdx < draggedOverRowIdx
+                ? rowIdx < currentRowIdx && currentRowIdx <= draggedOverRowIdx
+                : rowIdx > currentRowIdx && currentRowIdx >= draggedOverRowIdx;
+
+        return isDraggedOver ? selectedPosition.idx : undefined;
+    }
+
+    function getDragHandle(rowIdx: number) {
+        if (
+            selectedPosition.rowIdx !== rowIdx ||
+            selectedPosition.mode === 'EDIT' ||
+            hasGroups || // drag fill is not supported when grouping is enabled
+            onFill == null
+        ) {
+            return;
+        }
+
+        return (
+            <DragHandle
+                rows={rawRows}
+                columns={columns}
+                selectedPosition={selectedPosition}
+                isCellEditable={isCellEditable}
+                latestDraggedOverRowIdx={latestDraggedOverRowIdx}
+                onRowsChange={gridProps.onRowsChange}
+                onFill={onFill}
+                setDragging={setDragging}
+                setDraggedOverRowIdx={setDraggedOverRowIdx}
+            />
+        );
+    }
+
+    function getCellEditor(rowIdx: number) {
+        if (selectedPosition.rowIdx !== rowIdx || selectedPosition.mode === 'SELECT') return;
+        const { idx, row } = selectedPosition;
+        const column = columns[idx];
+        const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'ROW', row });
+
+        if ( gridProps.onBeforeEditCell && !gridProps.onBeforeEditCell(row, column, { idx, rowIdx })) {
+            //editor canceled
+            setSelectedPosition({...selectedPosition, mode:"SELECT"});
+            return;
+        }
+        const closeEditor = () => {
+            gridProps.onBeforeCellEditorDestroy?.(row, column, selectedPosition);
+            setSelectedPosition(({ idx, rowIdx }) => ({ idx, rowIdx, mode: 'SELECT' }));
+        };
+
+        const handleRowChange = (row: R, commitChanges?: boolean, previousRow?:R) => {
+            if (commitChanges) {
+                updateRow(selectedPosition.rowIdx, row, previousRow);
+                closeEditor();
+            } else {
+                setSelectedPosition((position) => ({ ...position, row }));
+            }
+        };
+
+        if (rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
+            // Discard changes if rows are updated from outside
+            closeEditor();
+        }
+
+        return (
+            <EditCell
+                editorRef={editorRef}
+                key={column.key}
+                column={column}
+                colSpan={colSpan}
                 row={row}
-                bottom={summaryRowHeight * (summaryRows.length - 1 - rowIdx)}
-                viewportColumns={viewportColumns}
-                lastFrozenColumnIndex={lastFrozenColumnIndex}
-                selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
-                selectCell={selectSummaryCellLatest}
-              />
+                onRowChange={handleRowChange}
+                closeEditor={closeEditor}
+                scrollToCell={() => {
+                    scrollToCell(selectedPosition);
+                }}
+            />
+        );
+    }
+
+    function getViewportRows() {
+        const rowElements = [];
+        let startRowIndex = 0;
+
+        const { idx: selectedIdx, rowIdx: selectedRowIdx } = selectedPosition;
+        const startRowIdx =
+            selectedCellIsWithinViewportBounds && selectedRowIdx < rowOverscanStartIdx
+                ? rowOverscanStartIdx - 1
+                : rowOverscanStartIdx;
+        const endRowIdx =
+            selectedCellIsWithinViewportBounds && selectedRowIdx > rowOverscanEndIdx
+                ? rowOverscanEndIdx + 1
+                : rowOverscanEndIdx;
+
+        for (let viewportRowIdx = startRowIdx; viewportRowIdx <= endRowIdx; viewportRowIdx++) {
+            const isRowOutsideViewport =
+                viewportRowIdx === rowOverscanStartIdx - 1 || viewportRowIdx === rowOverscanEndIdx + 1;
+            const rowIdx = isRowOutsideViewport ? selectedRowIdx : viewportRowIdx;
+
+            let rowColumns = viewportColumns;
+            const selectedColumn = columns[selectedIdx];
+            // selectedIdx can be -1 if grouping is enabled
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (selectedColumn !== undefined) {
+                if (isRowOutsideViewport) {
+                    // if the row is outside the viewport then only render the selected cell
+                    rowColumns = [selectedColumn];
+                } else if (selectedRowIdx === rowIdx && !viewportColumns.includes(selectedColumn)) {
+                    // if the row is within the viewport and cell is not, add the selected column to viewport columns
+                    rowColumns =
+                        selectedIdx > viewportColumns[viewportColumns.length - 1].idx
+                            ? [...viewportColumns, selectedColumn]
+                            : [
+                                ...viewportColumns.slice(0, lastFrozenColumnIndex + 1),
+                                selectedColumn,
+                                ...viewportColumns.slice(lastFrozenColumnIndex + 1)
+                            ];
+                }
+            }
+
+            const row = rows[rowIdx];
+            const top = getRowTop(rowIdx) /*+ headerRowHeight*/;
+            if (isGroupRow(row)) {
+                ({ startRowIndex } = row);
+                const isGroupRowSelected =
+                    isSelectable && row.childRows.every((cr) => !!selectedRows && selectedRows.has(rowKeyGetter!(cr)));
+                rowElements.push(
+                    <GroupRowRenderer
+                        aria-level={row.level + 1} // aria-level is 1-based
+                        aria-setsize={row.setSize}
+                        aria-posinset={row.posInSet + 1} // aria-posinset is 1-based
+                        aria-rowindex={headerRowsCount + startRowIndex + 1} // aria-rowindex is 1 based
+                        aria-selected={isSelectable ? isGroupRowSelected : undefined}
+                        key={row.id}
+                        id={row.id}
+                        groupKey={row.groupKey}
+                        viewportColumns={rowColumns}
+                        childRows={row.childRows}
+                        rowIdx={rowIdx}
+                        row={row}
+                        top={top}
+                        height={getRowHeight(rowIdx)}
+                        level={row.level}
+                        isExpanded={row.isExpanded}
+                        selectedCellIdx={selectedRowIdx === rowIdx ? selectedIdx : undefined}
+                        isRowSelected={isGroupRowSelected}
+                        selectGroup={selectGroupLatest}
+                        toggleGroup={toggleGroupLatest}
+                    />
+                );
+                continue;
+            }
+
+            startRowIndex++;
+            let key;
+            let isRowSelected = false;
+            if (typeof rowKeyGetter === 'function') {
+                key = rowKeyGetter(row);
+                isRowSelected = selectedRows?.has(key) ?? false;
+            } else {
+                key = hasGroups ? startRowIndex : rowIdx;
+            }
+
+            if  (!rowRefs.current[rowIdx]) {
+                rowRefs.current[rowIdx] = {current:null};
+            }
+            rowElements.push(
+                <RowRenderer
+                    ref={rowRefs.current[rowIdx] as any}
+                    aria-rowindex={headerRowsCount + (hasGroups ? startRowIndex : rowIdx) + 1} // aria-rowindex is 1 based
+                    aria-selected={isSelectable ? isRowSelected : undefined}
+                    key={key}
+                    rowIdx={rowIdx}
+                    row={row}
+                    viewportColumns={rowColumns}
+                    isRowSelected={isRowSelected}
+                    onRowClick={onRowClick}
+                    onRowDoubleClick={onRowDoubleClick}
+                    rowClass={rowClass}
+                    top={top}
+                    height={getRowHeight(rowIdx)}
+                    copiedCellIdx={
+                        copiedCell !== null && copiedCell.row === row
+                            ? columns.findIndex((c) => c.key === copiedCell.columnKey)
+                            : undefined
+                    }
+                    selectedCellIdx={selectedRowIdx === rowIdx ? selectedIdx : undefined}
+                    draggedOverCellIdx={getDraggedOverCellIdx(rowIdx)}
+                    setDraggedOverRowIdx={isDragging ? setDraggedOverRowIdx : undefined}
+                    lastFrozenColumnIndex={lastFrozenColumnIndex}
+                    onRowChange={handleFormatterRowChangeLatest}
+                    selectCell={selectViewportCellLatest}
+                    selectedCellDragHandle={getDragHandle(rowIdx)}
+                    selectedCellEditor={getCellEditor(rowIdx)}
+                />
             );
-          })}
-        </>
-      )}
-    </div>
-  );
+        }
+
+        return rowElements;
+    }
+
+    // Reset the positions if the current values are no longer valid. This can happen if a column or row is removed
+    if (selectedPosition.idx > maxColIdx || selectedPosition.rowIdx > maxRowIdx) {
+        setSelectedPosition(initialPosition);
+        setDraggedOverRowIdx(undefined);
+    }
+
+    const scrollerMaxHeight = max(totalRowHeight, clientHeight);
+    return (
+        <div
+            role={hasGroups ? 'treegrid' : 'grid'}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
+            aria-describedby={ariaDescribedBy}
+            aria-multiselectable={isSelectable ? true : undefined}
+            aria-colcount={columns.length}
+            aria-rowcount={headerRowsCount + rowsCount + summaryRowsCount}
+            className={clsx(rootClassname, { [viewportDraggingClassname]: isDragging }, className)}
+            style={
+                {
+                    ...style,
+                    '--rdg-header-row-height': `${headerRowHeight}px`,
+                    '--rdg-row-width': `${totalColumnWidth}px`,
+                    '--rdg-summary-row-height': `${summaryRowHeight}px`,
+                    '--rdg-scroller-height': `${scrollerMaxHeight}px`,
+                    overflow:"hidden",
+                    ...layoutCssVars
+                } as unknown as React.CSSProperties
+            }
+            ref={gridRef}
+
+            onKeyDown={handleKeyDown}
+            data-testid={testId}
+        >
+            <HeaderRow
+                left={-scrollLeft}
+                columns={viewportColumns}
+                onColumnResize={handleColumnResize}
+                allRowsSelected={allRowsSelected}
+                onAllRowsSelectionChange={selectAllRowsLatest}
+                sortColumns={sortColumns}
+                onSortColumnsChange={onSortColumnsChange}
+                lastFrozenColumnIndex={lastFrozenColumnIndex}
+                selectedCellIdx={isHeaderRowSelected ? selectedPosition.idx : undefined}
+                selectCell={selectHeaderCellLatest}
+                shouldFocusGrid={!selectedCellIsWithinSelectionBounds}
+                onHeaderContextMenu={gridProps.onHeaderContextMenu}
+            />
+            {rows.length === 0 && noRowsFallback ? (
+                noRowsFallback
+            ) : (
+                <>
+                    <div className="rdg-viewport"
+                         ref={viewportRef}
+                         onScroll={handleScroll}
+                         style={{position:"relative",
+                             height:clientHeight- headerRowHeight, overflow:"scroll",
+                             width: gridWidth,
+                             top:headerRowHeight
+                         }}>
+                        <div className="rdg-canvas" style={{ height: scrollerMaxHeight  }}
+                             onContextMenu={gridProps.onContextMenu}
+                        >
+                            <RowSelectionChangeProvider value={selectRowLatest}>
+                                {getViewportRows()}
+                            </RowSelectionChangeProvider>
+                            {summaryRows?.map((row, rowIdx) => {
+                                const isSummaryRowSelected =
+                                    selectedPosition.rowIdx === headerRowsCount + rows.length + rowIdx - 1;
+                                const summaryRowsLength = summaryRows ? summaryRows.length : 0;
+                                return (
+                                    <SummaryRow
+                                        aria-rowindex={headerRowsCount + rowsCount + rowIdx + 1}
+                                        key={rowIdx}
+                                        rowIdx={rowIdx}
+                                        row={row}
+                                        bottom={summaryRowHeight * (summaryRowsLength - 1 - rowIdx)}
+                                        viewportColumns={viewportColumns}
+                                        lastFrozenColumnIndex={lastFrozenColumnIndex}
+                                        selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
+                                        selectCell={selectSummaryCellLatest}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
 }
 
 function isSamePosition(p1: Position, p2: Position) {
-  return p1.idx === p2.idx && p1.rowIdx === p2.rowIdx;
+    return p1.idx === p2.idx && p1.rowIdx === p2.rowIdx;
 }
 
 export default forwardRef(DataGrid) as <R, SR = unknown, K extends Key = Key>(
-  props: DataGridProps<R, SR, K> & RefAttributes<DataGridHandle>
+    props: DataGridProps<R, SR, K> & RefAttributes<DataGridHandle>
 ) => JSX.Element;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -299,6 +299,13 @@ function DataGrid<R, SR, K extends Key>(gridProps: DataGridProps<R, SR, K>,
         },
         inEditor(){
             return editorRef.current !== null
+        },
+        forceUpdate(){
+            //discard memo for row.
+            rowRefs.current.forEach((rowRef)=>{
+                if  (!rowRef) return;
+                rowRef.current?.updateRow();
+            });
         }
     }));
 
@@ -859,6 +866,9 @@ function DataGrid<R, SR, K extends Key>(gridProps: DataGridProps<R, SR, K>,
                 ? rowOverscanEndIdx + 1
                 : rowOverscanEndIdx;
 
+        //row refs mst contain only rendered rows
+        rowRefs.current = [];
+
         for (let viewportRowIdx = startRowIdx; viewportRowIdx <= endRowIdx; viewportRowIdx++) {
             const isRowOutsideViewport =
                 viewportRowIdx === rowOverscanStartIdx - 1 || viewportRowIdx === rowOverscanEndIdx + 1;
@@ -972,7 +982,8 @@ function DataGrid<R, SR, K extends Key>(gridProps: DataGridProps<R, SR, K>,
         setDraggedOverRowIdx(undefined);
     }
 
-    const scrollerMaxHeight = max(totalRowHeight, clientHeight);
+    const scrollbarHeight = 15;
+    const scrollerMaxHeight = max(totalRowHeight, clientHeight-scrollbarHeight);
     return (
         <div
             role={hasGroups ? 'treegrid' : 'grid'}
@@ -1021,7 +1032,7 @@ function DataGrid<R, SR, K extends Key>(gridProps: DataGridProps<R, SR, K>,
                          ref={viewportRef}
                          onScroll={handleScroll}
                          style={{position:"relative",
-                             height:clientHeight- headerRowHeight, overflow:"scroll",
+                             height:clientHeight, overflow:"auto",
                              width: gridWidth,
                              top:headerRowHeight
                          }}>

--- a/src/DataGridHandle.tsx
+++ b/src/DataGridHandle.tsx
@@ -1,0 +1,10 @@
+import {Maybe, Position} from "./types";
+
+export interface DataGridHandle {
+    element: HTMLDivElement | null;
+    scrollToColumn: (colIdx: number) => void;
+    scrollToRow: (rowIdx: number) => void;
+    selectCell: (position: Position, enableEditor?: Maybe<boolean>) => void;
+    updateRow: (position: Position) => void;
+    inEditor: () => boolean;
+}

--- a/src/DataGridHandle.tsx
+++ b/src/DataGridHandle.tsx
@@ -6,5 +6,6 @@ export interface DataGridHandle {
     scrollToRow: (rowIdx: number) => void;
     selectCell: (position: Position, enableEditor?: Maybe<boolean>) => void;
     updateRow: (position: Position) => void;
+    forceUpdate: () => void;
     inEditor: () => boolean;
 }

--- a/src/DataGridProps.tsx
+++ b/src/DataGridProps.tsx
@@ -1,0 +1,115 @@
+import {Key, MouseEventHandler} from "react";
+import {
+    FillEvent,
+    PasteEvent,
+    Position,
+    RowRendererProps,
+    RowsChangeData,
+    SortColumn
+} from "./types";
+import type {
+    CalculatedColumn,
+    Column,
+    CellNavigationMode,
+    RowHeightArgs,
+    Maybe
+} from './types';
+
+
+type DefaultColumnOptions<R, SR> = Pick<Column<R, SR>,
+    'formatter' | 'minWidth' | 'resizable' | 'sortable'>;
+type SharedDivProps = Pick<React.HTMLAttributes<HTMLDivElement>,
+    'aria-label' | 'aria-labelledby' | 'aria-describedby' | 'className' | 'style'
+    | 'onKeyDown'>;
+
+export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends SharedDivProps {
+    /**
+     * Grid and data Props
+     */
+    /** An array of objects representing each column on the grid */
+    columns: readonly Column<R, SR>[];
+    /** A function called for each rendered row that should return a plain key/value pair object */
+    rows: readonly R[];
+    /**
+     * Rows to be pinned at the bottom of the rows view for summary, the vertical scroll bar will not scroll these rows.
+     * Bottom horizontal scroll bar can move the row left / right. Or a customized row renderer can be used to disabled the scrolling support.
+     */
+    summaryRows?: Maybe<readonly SR[]>;
+    /** The getter should return a unique key for each row */
+    rowKeyGetter?: Maybe<(row: R) => K>;
+    onRowsChange?: Maybe<(rows: R[], data: RowsChangeData<R, SR>) => void>;
+    onCurrentRowChanged?: Maybe<(position: Position) => void>;
+
+    /**
+     * Dimensions props
+     */
+    /**
+     * The height of each row in pixels
+     * @default 35
+     */
+    rowHeight?: Maybe<number | ((args: RowHeightArgs<R>) => number)>;
+    /**
+     * The height of the header row in pixels
+     * @default 35
+     */
+    headerRowHeight?: Maybe<number>;
+    /**
+     * The height of each summary row in pixels
+     * @default 35
+     */
+    summaryRowHeight?: Maybe<number>;
+
+    /**
+     * Feature props
+     */
+    /** Set of selected row keys */
+    selectedRows?: Maybe<ReadonlySet<K>>;
+    /** Function called whenever row selection is changed */
+    onSelectedRowsChange?: Maybe<(selectedRows: Set<K>) => void>;
+    /** Used for multi column sorting */
+    sortColumns?: Maybe<readonly SortColumn[]>;
+    onSortColumnsChange?: Maybe<(sortColumns: SortColumn[]) => void>;
+    defaultColumnOptions?: Maybe<DefaultColumnOptions<R, SR>>;
+    groupBy?: Maybe<readonly string[]>;
+    rowGrouper?: Maybe<(rows: readonly R[], columnKey: string) => Record<string, readonly R[]>>;
+    expandedGroupIds?: Maybe<ReadonlySet<unknown>>;
+    onExpandedGroupIdsChange?: Maybe<(expandedGroupIds: Set<unknown>) => void>;
+    onFill?: Maybe<(event: FillEvent<R>) => R>;
+    onPaste?: Maybe<(event: PasteEvent<R>) => R>;
+
+    /**
+     * Event props
+     */
+    /** Function called whenever a row is clicked */
+    onRowClick?: Maybe<(row: R, column: CalculatedColumn<R, SR>) => void>;
+    /** Function called whenever a row is double clicked */
+    onRowDoubleClick?: Maybe<(row: R, column: CalculatedColumn<R, SR>) => void>;
+    /** Called when the grid is scrolled */
+    onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;
+    /** Called when a column is resized */
+    onColumnResize?: Maybe<(idx: number, width: number) => void>;
+
+    /**
+     * Toggles and modes
+     */
+    /** @default 'NONE' */
+    cellNavigationMode?: Maybe<CellNavigationMode>;
+    /** @default true */
+    enableVirtualization?: Maybe<boolean>;
+
+    /**
+     * Miscellaneous
+     */
+    rowRenderer?: Maybe<React.ComponentType<RowRendererProps<R, SR>>>;
+    noRowsFallback?: React.ReactNode;
+    rowClass?: Maybe<(row: R) => Maybe<string>>;
+    'data-testid'?: Maybe<string>;
+
+    //Slick.Grid migration
+
+    /** When returns 'false' then cell editing request discarded. (imported from Slick.Grid) */
+    onBeforeEditCell?: Maybe<(row: R, column: CalculatedColumn<R, SR>, position: Position) => boolean>;
+    onBeforeCellEditorDestroy?: Maybe<(row: R, column: CalculatedColumn<R, SR>, position: Position) => boolean>;
+    onContextMenu?: MouseEventHandler<HTMLDivElement> | undefined;
+    onHeaderContextMenu?: MouseEventHandler<HTMLDivElement> | undefined;
+}

--- a/src/DragHandle.tsx
+++ b/src/DragHandle.tsx
@@ -1,7 +1,8 @@
 import { css } from '@linaria/core';
 
 import type { CalculatedColumn, FillEvent, Position } from './types';
-import type { DataGridProps, SelectCellState } from './DataGrid';
+import type { SelectCellState } from './DataGrid';
+import {DataGridProps} from "./DataGridProps";
 
 const cellDragHandle = css`
   cursor: move;

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -190,6 +190,7 @@ export default function HeaderCell<R, SR>({
       onFocus={handleFocus}
       onClick={onClick}
       onPointerDown={column.resizable ? onPointerDown : undefined}
+      title={  typeof column.name === "string" ? column.name : ""}
     >
       {getCell()}
     </div>

--- a/src/RowHandle.tsx
+++ b/src/RowHandle.tsx
@@ -1,0 +1,4 @@
+export interface RowHandle {
+    element: HTMLDivElement | null;
+    updateRow: () => void;
+}

--- a/src/editors/ICanCommit.ts
+++ b/src/editors/ICanCommit.ts
@@ -1,0 +1,4 @@
+
+export interface ICanCommit {
+	commit(): void;
+}

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 
 import type { CalculatedColumn, Column, Maybe } from '../types';
-import type { DataGridProps } from '../DataGrid';
 import { ValueFormatter, ToggleGroupFormatter } from '../formatters';
 import { SELECT_COLUMN_KEY } from '../Columns';
 import { floor, max, min } from '../utils';
+import {DataGridProps} from "../DataGridProps";
 
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P];

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -61,7 +61,7 @@ export function useViewportRows<R>({
     };
 
     return groupRows(rawRows, groupBy, 0);
-  }, [groupBy, rowGrouper, rawRows]);
+  }, [groupBy, rowGrouper, rawRows, rawRows.length]);
 
   const [rows, isGroupRow] = useMemo((): [
     ReadonlyArray<R | GroupRow<R>>,
@@ -112,7 +112,7 @@ export function useViewportRows<R>({
     function isGroupRow(row: R | GroupRow<R>): row is GroupRow<R> {
       return allGroupRows.has(row);
     }
-  }, [expandedGroupIds, groupedRows, rawRows]);
+  }, [expandedGroupIds, groupedRows, rawRows, rawRows.length]);
 
   const { totalRowHeight, getRowTop, getRowHeight, findRowIdx } = useMemo(() => {
     if (typeof rowHeight === 'number') {
@@ -165,7 +165,7 @@ export function useViewportRows<R>({
         return 0;
       }
     };
-  }, [isGroupRow, rowHeight, rows]);
+  }, [isGroupRow, rowHeight, rows, rows.length]);
 
   let rowOverscanStartIdx = 0;
   let rowOverscanEndIdx = rows.length - 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default } from './DataGrid';
-export type { DataGridProps, DataGridHandle } from './DataGrid';
+export type {  DataGridHandle } from './DataGrid';
+export type {  DataGridProps } from './DataGridProps';
 export { RowWithRef as Row } from './Row';
 export * from './Columns';
 export * from './formatters';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { default } from './DataGrid';
-export type {  DataGridHandle } from './DataGrid';
+export type {  DataGridHandle } from './DataGridHandle';
 export type {  DataGridProps } from './DataGridProps';
 export { RowWithRef as Row } from './Row';
 export * from './Columns';

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
     readonly editOnClick?: Maybe<boolean>;
     /** @default true */
     readonly commitOnOutsideClick?: Maybe<boolean>;
+    readonly commitOnNavigation?: Maybe<boolean>;
     /** Prevent default to cancel editing */
     readonly onCellKeyDown?: Maybe<(event: React.KeyboardEvent<HTMLDivElement>) => void>;
     /** Control the default cell navigation behavior while the editor is open */
@@ -94,8 +95,9 @@ export interface GroupFormatterProps<TRow, TSummaryRow = unknown> {
 export interface EditorProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TRow;
-  onRowChange: (row: TRow, commitChanges?: boolean) => void;
+  onRowChange: (row: TRow, commitChanges?: boolean, previousRow?:TRow) => void;
   onClose: (commitChanges?: boolean) => void;
+  ref?:{current?:any}|((element:any)=>void);
 }
 
 export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
@@ -122,6 +124,7 @@ export interface CellRendererProps<TRow, TSummaryRow>
   isCellSelected: boolean;
   dragHandle: ReactElement<React.HTMLAttributes<HTMLDivElement>> | undefined;
   onRowChange: (newRow: TRow) => void;
+  version:number
 }
 
 export interface RowRendererProps<TRow, TSummaryRow = unknown>
@@ -153,6 +156,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
 export interface RowsChangeData<R, SR = unknown> {
   indexes: number[];
   column: CalculatedColumn<R, SR>;
+  previousRow?:R;
 }
 
 export interface SelectRowEvent<TRow> {


### PR DESCRIPTION

Hi!

I have some changes. You can use something from it. (Note: Now it under development and can contain the bugs  because we already introduced it in our software, but I think that you can reuse some things from it for main branch)

AV: refactored EditCell, props, layout to use instead of SlickGrid. New rule: only client-code can change data rows.

AV: Header: Refactored  layout to Header/Viewport, added scroll synchronization viewport to Header. Because position:sticky work wrong. And scroll position does not correspond to outer components. (when required scroll sync)
AV: extracted Prop classes to single files. (It's good C++ way header+implementaton)
AV: added experiment with ClassComponent for Cell - CellClass. it more simplified code but same performance.
AV: added extra DataGridProps: onBeforeEditCell, onBeforeCellEditorDestroy, onContextMenu, onHeaderContextMenu, onKeyDown - required for us and implemented in Slick.Grid.
AV: added extra methods to DataGridHandle: updateRow(), inEditor()
AV: fixed keyboard behaviour:  ask client-code for processing keys, skip default behaviour on when modification keys is active
AV: Editor: changed editor behaviour, added interface ICanCommit to work with statefull editor. Editor can commit change or not. But Editor MUST NOT change row directly and 'by-design'. Editor can change row only after ::commit().
AV: Header: every header must have @title. because caption can be bigger than cel size.
AV: DataGrid: introduced 'props' variable because copy-paste (Props/local) is not good idea.
AV: DataGrid: Added caching check for rows.length - Every time copying rows array is not good idea to update components. Because User can loaded 2000-5000 items. But we have changed only 1-2 rows.
AV: DataGrid: changed onRowUpdated() behaviour: sent only updated rows , User have self own unchanged rows.  Added argument:'previousRow' - because we need make diff of changes. Original row we receive from Editor or location.
AV: added ContextMenu handlers.