### PR TITLE
ESLint: enable @typescript-eslint/consistent-type-exports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -522,7 +522,10 @@ const rules = {
     { assertionStyle: 'as', objectLiteralTypeAssertions: 'never' }
   ],
   '@typescript-eslint/consistent-type-definitions': [1, 'interface'],
-  '@typescript-eslint/consistent-type-exports': 0,
+  '@typescript-eslint/consistent-type-exports': [
+    1,
+    { fixMixedExportsWithInlineTypeSpecifier: true }
+  ],
   '@typescript-eslint/consistent-type-imports': 1,
   '@typescript-eslint/explicit-function-return-type': 0,
   '@typescript-eslint/explicit-member-accessibility': 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-export { default } from './DataGrid';
-export type { DataGridProps, DataGridHandle } from './DataGrid';
+export { default, type DataGridProps, type DataGridHandle } from './DataGrid';
 export { RowWithRef as Row } from './Row';
 export * from './Columns';
 export * from './formatters';


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-exports.md

I haven't changed this one, as both syntax are allowed, and it'd be a lot of `type` specifiers.
```tsx
export type {
  // ...
} from './types';
```