### PR TITLE
Avoid subpixel column positioning

### DIFF
--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -4,7 +4,7 @@ import type { CalculatedColumn, Column, Maybe } from '../types';
 import type { DataGridProps } from '../DataGrid';
 import { ValueFormatter, ToggleGroupFormatter } from '../formatters';
 import { SELECT_COLUMN_KEY } from '../Columns';
-import { floor, max, min } from '../utils';
+import { floor, max, min, round } from '../utils';
 
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
@@ -151,9 +151,6 @@ export function useCalculatedColumns<R, SR>({
       }
     }
 
-    const unallocatedWidth = viewportWidth - allocatedWidth;
-    const unallocatedColumnWidth = unallocatedWidth / unassignedColumnsCount;
-
     for (const column of columns) {
       let width: number;
       if (columnMetrics.has(column)) {
@@ -161,7 +158,12 @@ export function useCalculatedColumns<R, SR>({
         columnMetric.left = left;
         ({ width } = columnMetric);
       } else {
+        // avoid decimals as subpixel positioning can lead to cell borders not being displayed
+        const unallocatedWidth = viewportWidth - allocatedWidth;
+        const unallocatedColumnWidth = round(unallocatedWidth / unassignedColumnsCount);
         width = clampColumnWidth(unallocatedColumnWidth, column, minColumnWidth);
+        allocatedWidth += width;
+        unassignedColumnsCount--;
         columnMetrics.set(column, { width, left });
       }
       totalColumnWidth += width;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,7 @@ export * from './domUtils';
 export * from './keyboardUtils';
 export * from './selectedCellUtils';
 
-export const { min, max, floor, sign } = Math;
+export const { min, max, round, floor, sign } = Math;
 
 export function assertIsValidKeyGetter<R, K extends React.Key>(
   keyGetter: unknown


### PR DESCRIPTION
The grid will now naturally alternate widths to fill the grid, without using subpixel positioning, which fixes the issue where cell borders would sometimes disappear in Chrome.

Example with the "Cell Navigation" demo, all the column widths are now integers.
![image](https://user-images.githubusercontent.com/567105/151248962-40431bdd-1523-41b2-a78a-fc8a1211c71d.png)