### PR TITLE
Replace most box-shadows with border/outline

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1033,6 +1033,7 @@ function DataGrid<R, SR, K extends Key>(
             viewportColumns={rowColumns}
             childRows={row.childRows}
             rowIdx={rowIdx}
+            lastFrozenColumnIndex={lastFrozenColumnIndex}
             row={row}
             gridRowStart={gridRowStart}
             height={getRowHeight(rowIdx)}

--- a/src/GroupRow.tsx
+++ b/src/GroupRow.tsx
@@ -2,7 +2,13 @@ import { memo } from 'react';
 import clsx from 'clsx';
 import { css } from '@linaria/core';
 
-import { cell, cellFrozenLast, rowClassname, rowSelectedClassname } from './style';
+import {
+  cell,
+  cellFrozenLast,
+  rowClassname,
+  rowSelectedClassname,
+  rowSelectedWithFrozenCell
+} from './style';
 import { SELECT_COLUMN_KEY } from './Columns';
 import GroupCell from './GroupCell';
 import type { CalculatedColumn, GroupRow, Omit } from './types';
@@ -16,6 +22,7 @@ export interface GroupRowRendererProps<R, SR>
   viewportColumns: readonly CalculatedColumn<R, SR>[];
   childRows: readonly R[];
   rowIdx: number;
+  lastFrozenColumnIndex: number;
   row: GroupRow<R>;
   gridRowStart: number;
   height: number;
@@ -45,6 +52,7 @@ function GroupedRow<R, SR>({
   viewportColumns,
   childRows,
   rowIdx,
+  lastFrozenColumnIndex,
   row,
   gridRowStart,
   height,
@@ -56,6 +64,7 @@ function GroupedRow<R, SR>({
   toggleGroup,
   ...props
 }: GroupRowRendererProps<R, SR>) {
+  const isRowFocused = selectedCellIdx === -1;
   // Select is always the first column
   const idx = viewportColumns[0].key === SELECT_COLUMN_KEY ? level + 1 : level;
 
@@ -74,7 +83,8 @@ function GroupedRow<R, SR>({
           groupRowClassname,
           `rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'}`,
           {
-            [rowSelectedClassname]: selectedCellIdx === -1
+            [rowSelectedClassname]: isRowFocused,
+            [rowSelectedWithFrozenCell]: isRowFocused && lastFrozenColumnIndex !== -1
           }
         )}
         onClick={handleSelectGroup}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -6,7 +6,7 @@ import HeaderCell from './HeaderCell';
 import type { CalculatedColumn, Direction } from './types';
 import { getColSpan, getRowStyle } from './utils';
 import type { DataGridProps } from './DataGrid';
-import { cell, cellFrozen, rowSelectedClassname } from './style';
+import { cell, cellFrozen, rowSelectedClassname, rowSelectedWithFrozenCell } from './style';
 
 type SharedDataGridProps<R, SR, K extends React.Key> = Pick<
   DataGridProps<R, SR, K>,
@@ -58,6 +58,7 @@ function HeaderRow<R, SR, K extends React.Key>({
   shouldFocusGrid,
   direction
 }: HeaderRowProps<R, SR, K>) {
+  const isRowFocused = selectedCellIdx === -1;
   const cells = [];
   for (let index = 0; index < columns.length; index++) {
     const column = columns[index];
@@ -89,7 +90,8 @@ function HeaderRow<R, SR, K extends React.Key>({
       role="row"
       aria-rowindex={1} // aria-rowindex is 1 based
       className={clsx(headerRowClassname, {
-        [rowSelectedClassname]: selectedCellIdx === -1
+        [rowSelectedClassname]: isRowFocused,
+        [rowSelectedWithFrozenCell]: isRowFocused && lastFrozenColumnIndex !== -1
       })}
       style={getRowStyle(1)}
     >

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import Cell from './Cell';
 import { RowSelectionProvider, useLatestFunc } from './hooks';
 import { getColSpan, getRowStyle } from './utils';
-import { rowClassname, rowSelectedClassname } from './style';
+import { rowClassname, rowSelectedClassname, rowSelectedWithFrozenCell } from './style';
 import type { RowRendererProps } from './types';
 
 function Row<R, SR>(
@@ -43,11 +43,14 @@ function Row<R, SR>(
     onMouseEnter?.(event);
   }
 
+  const isRowFocused = selectedCellIdx === -1;
+
   className = clsx(
     rowClassname,
     `rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'}`,
     {
-      [rowSelectedClassname]: selectedCellIdx === -1
+      [rowSelectedClassname]: isRowFocused,
+      [rowSelectedWithFrozenCell]: isRowFocused && lastFrozenColumnIndex !== -1
     },
     rowClass?.(row),
     className

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import clsx from 'clsx';
 import { css } from '@linaria/core';
 
-import { cell, row, rowClassname, rowSelectedClassname } from './style';
+import { cell, row, rowClassname, rowSelectedClassname, rowSelectedWithFrozenCell } from './style';
 import { getColSpan, getRowStyle } from './utils';
 import SummaryCell from './SummaryCell';
 import type { CalculatedColumn, RowRendererProps } from './types';
@@ -51,6 +51,7 @@ function SummaryRow<R, SR>({
   selectCell,
   'aria-rowindex': ariaRowIndex
 }: SummaryRowProps<R, SR>) {
+  const isRowFocused = selectedCellIdx === -1;
   const cells = [];
   for (let index = 0; index < viewportColumns.length; index++) {
     const column = viewportColumns[index];
@@ -81,9 +82,10 @@ function SummaryRow<R, SR>({
         rowClassname,
         `rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'}`,
         summaryRowClassname,
-        { [summaryRowBorderClassname]: rowIdx === 0 },
         {
-          [rowSelectedClassname]: selectedCellIdx === -1
+          [summaryRowBorderClassname]: rowIdx === 0,
+          [rowSelectedClassname]: isRowFocused,
+          [rowSelectedWithFrozenCell]: isRowFocused && lastFrozenColumnIndex !== -1
         }
       )}
       style={

--- a/src/formatters/CheckboxFormatter.tsx
+++ b/src/formatters/CheckboxFormatter.tsx
@@ -30,7 +30,8 @@ const checkbox = css`
   background-color: var(--rdg-background-color);
   .${checkboxInput}:checked + & {
     background-color: var(--rdg-checkbox-color);
-    box-shadow: inset 0px 0px 0px 4px var(--rdg-background-color);
+    outline: 4px solid var(--rdg-background-color);
+    outline-offset: -6px;
   }
   .${checkboxInput}:focus + & {
     border-color: var(--rdg-checkbox-focus-color);

--- a/src/style/cell.ts
+++ b/src/style/cell.ts
@@ -17,7 +17,8 @@ export const cell = css`
   outline: none;
 
   &[aria-selected='true'] {
-    box-shadow: inset 0 0 0 2px var(--rdg-selection-color);
+    outline: 2px solid var(--rdg-selection-color);
+    outline-offset: -2px;
   }
 `;
 
@@ -39,7 +40,7 @@ export const cellFrozen = css`
 export const cellFrozenClassname = `rdg-cell-frozen ${cellFrozen}`;
 
 export const cellFrozenLast = css`
-  box-shadow: var(--rdg-frozen-cell-box-shadow);
+  box-shadow: calc(2px * var(--rdg-sign)) 0 5px -2px rgba(136, 136, 136, 0.3);
 `;
 
 export const cellFrozenLastClassname = `rdg-cell-frozen-last ${cellFrozenLast}`;

--- a/src/style/core.ts
+++ b/src/style/core.ts
@@ -36,7 +36,6 @@ const darkTheme = `
 const root = css`
   ${lightTheme}
   --rdg-selection-color: #66afe9;
-  --rdg-frozen-cell-box-shadow: calc(2px * var(--rdg-sign)) 0 5px -2px rgba(136, 136, 136, 0.3);
   --rdg-font-size: 14px;
 
   display: grid;

--- a/src/style/row.ts
+++ b/src/style/row.ts
@@ -1,7 +1,5 @@
 import { css } from '@linaria/core';
 
-import { cell, cellFrozenLast } from '../style';
-
 export const row = css`
   display: contents;
   line-height: var(--rdg-row-height);
@@ -22,27 +20,28 @@ export const row = css`
 
 export const rowClassname = `rdg-row ${row}`;
 
-const topBoxShadow = 'inset 0 2px 0 0 var(--rdg-selection-color)';
-const rightBoxShadow = 'inset calc(-2px * var(--rdg-sign)) 0 0 0 var(--rdg-selection-color)';
-const bottomBoxShadow = 'inset 0 -2px 0 0 var(--rdg-selection-color)';
-const leftBoxShadow = 'inset calc(2px * var(--rdg-sign)) 0 0 0 var(--rdg-selection-color)';
-
 const rowSelected = css`
-  outline: none;
-
-  > .${cell} {
-    box-shadow: ${topBoxShadow}, ${bottomBoxShadow};
-    &:first-child {
-      box-shadow: ${topBoxShadow}, ${bottomBoxShadow}, ${leftBoxShadow};
-    }
-    &:last-child {
-      box-shadow: ${topBoxShadow}, ${bottomBoxShadow}, ${rightBoxShadow};
-    }
-  }
-
-  > .${cellFrozenLast} {
-    box-shadow: ${topBoxShadow}, ${bottomBoxShadow}, var(--rdg-frozen-cell-box-shadow);
+  &::after {
+    content: '';
+    grid-column: 1 / -1;
+    grid-row-start: var(--rdg-grid-row-start);
+    border: 2px solid var(--rdg-selection-color);
+    pointer-events: none;
+    z-index: 2;
   }
 `;
 
 export const rowSelectedClassname = `rdg-row-selected ${rowSelected}`;
+
+export const rowSelectedWithFrozenCell = css`
+  &::before {
+    content: '';
+    grid-column-start: 1;
+    grid-row-start: var(--rdg-grid-row-start);
+    position: sticky;
+    inset-inline-start: 0;
+    border-inline-start: 2px solid var(--rdg-selection-color);
+    pointer-events: none;
+    z-index: 2;
+  }
+`;

--- a/website/demos/CustomizableComponents.tsx
+++ b/website/demos/CustomizableComponents.tsx
@@ -1,8 +1,19 @@
 import { useMemo, useState, forwardRef } from 'react';
+import { css } from '@linaria/core';
 
 import DataGrid, { SelectColumn, TextEditor } from '../../src';
 import type { Column, CheckboxFormatterProps, SortColumn, SortIconProps } from '../../src';
 import type { Props } from './types';
+
+const selectCellClassname = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  > input {
+    margin: 0;
+  }
+`;
 
 interface Row {
   id: number;
@@ -28,7 +39,11 @@ function createRows(): readonly Row[] {
 }
 
 const columns: readonly Column<Row>[] = [
-  SelectColumn,
+  {
+    ...SelectColumn,
+    headerCellClass: selectCellClassname,
+    cellClass: selectCellClassname
+  },
   {
     key: 'id',
     name: 'ID',


### PR DESCRIPTION
`box-shadow` is typically less efficient to raster, so this might make the grid ever so slightly more efficient.
I think we can do something similar with the last-frozen-cell shadow by overlaying a single div over the whole grid with a linear gradient.

Cell before / after:
![image](https://user-images.githubusercontent.com/567105/153518667-aaf156af-2869-4b9f-a210-a2baa7750064.png)
![image](https://user-images.githubusercontent.com/567105/153518683-9287663d-efe4-451c-a86f-d280f88846a9.png)

Row before / after:
![image](https://user-images.githubusercontent.com/567105/153518730-0f47584c-b503-4626-8b19-bfe10ee57302.png)
![image](https://user-images.githubusercontent.com/567105/153518743-b92a0b14-4003-4d4c-a227-7cd32bc6e453.png)

Checked checkbox before / after (identical):
![image](https://user-images.githubusercontent.com/567105/153518866-bcfb7c21-b49b-4fa6-8763-693d2cd950e5.png)
![image](https://user-images.githubusercontent.com/567105/153518880-83cc82d8-5c32-439c-8a06-50612f287242.png)
