### PR TITLE
Default column width for all columns in the table

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -73,7 +73,7 @@ interface EditCellState<R> extends Position {
 
 type DefaultColumnOptions<R, SR> = Pick<
   Column<R, SR>,
-  'formatter' | 'minWidth' | 'resizable' | 'sortable'
+  'formatter' | 'minWidth' | 'width' | 'resizable' | 'sortable'
 >;
 
 const initialPosition: SelectCellState = {


### PR DESCRIPTION
Allows the client to set a default width for all columns that don't have a specified width.
Related issue: #2837 