### PR TITLE
Fix viewport columns for header and summary rows

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -977,6 +977,7 @@ function DataGrid<R, SR, K extends Key>(
   function getRowViewportColumns(rowIdx: number) {
     const selectedColumn = columns[selectedPosition.idx];
     if (
+      // idx can be -1 if grouping is enabled
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       selectedColumn !== undefined &&
       selectedPosition.rowIdx === rowIdx &&

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -974,6 +974,26 @@ function DataGrid<R, SR, K extends Key>(
     );
   }
 
+  function getRowViewportColumns(rowIdx: number) {
+    const selectedColumn = columns[selectedPosition.idx];
+    if (
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      selectedColumn !== undefined &&
+      selectedPosition.rowIdx === rowIdx &&
+      !viewportColumns.includes(selectedColumn)
+    ) {
+      // Add the selected column to viewport columns if the cell is not within the viewport
+      return selectedPosition.idx > viewportColumns[viewportColumns.length - 1].idx
+        ? [...viewportColumns, selectedColumn]
+        : [
+            ...viewportColumns.slice(0, lastFrozenColumnIndex + 1),
+            selectedColumn,
+            ...viewportColumns.slice(lastFrozenColumnIndex + 1)
+          ];
+    }
+    return viewportColumns;
+  }
+
   function getViewportRows() {
     const rowElements = [];
     let startRowIndex = 0;
@@ -1001,16 +1021,9 @@ function DataGrid<R, SR, K extends Key>(
         if (isRowOutsideViewport) {
           // if the row is outside the viewport then only render the selected cell
           rowColumns = [selectedColumn];
-        } else if (selectedRowIdx === rowIdx && !viewportColumns.includes(selectedColumn)) {
+        } else {
           // if the row is within the viewport and cell is not, add the selected column to viewport columns
-          rowColumns =
-            selectedIdx > viewportColumns[viewportColumns.length - 1].idx
-              ? [...viewportColumns, selectedColumn]
-              : [
-                  ...viewportColumns.slice(0, lastFrozenColumnIndex + 1),
-                  selectedColumn,
-                  ...viewportColumns.slice(lastFrozenColumnIndex + 1)
-                ];
+          rowColumns = getRowViewportColumns(rowIdx);
         }
       }
 
@@ -1157,7 +1170,7 @@ function DataGrid<R, SR, K extends Key>(
       )}
       <DataGridDefaultComponentsProvider value={defaultGridComponents}>
         <HeaderRow
-          columns={viewportColumns}
+          columns={getRowViewportColumns(-1)}
           onColumnResize={handleColumnResize}
           allRowsSelected={allRowsSelected}
           onAllRowsSelectionChange={selectAllRowsLatest}
@@ -1178,8 +1191,8 @@ function DataGrid<R, SR, K extends Key>(
             </RowSelectionChangeProvider>
             {summaryRows?.map((row, rowIdx) => {
               const gridRowStart = headerRowsCount + rows.length + rowIdx + 1;
-              const isSummaryRowSelected =
-                selectedPosition.rowIdx === headerRowsCount + rows.length + rowIdx - 1;
+              const summaryRowIdx = headerRowsCount + rows.length + rowIdx - 1;
+              const isSummaryRowSelected = selectedPosition.rowIdx === summaryRowIdx;
               const top =
                 clientHeight > totalRowHeight
                   ? gridHeight - summaryRowHeight * (summaryRows.length - rowIdx)
@@ -1198,7 +1211,7 @@ function DataGrid<R, SR, K extends Key>(
                   row={row}
                   top={top}
                   bottom={bottom}
-                  viewportColumns={viewportColumns}
+                  viewportColumns={getRowViewportColumns(summaryRowIdx)}
                   lastFrozenColumnIndex={lastFrozenColumnIndex}
                   selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
                   selectCell={selectSummaryCellLatest}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -984,7 +984,7 @@ function DataGrid<R, SR, K extends Key>(
       !viewportColumns.includes(selectedColumn)
     ) {
       // Add the selected column to viewport columns if the cell is not within the viewport
-      return selectedPosition.idx > viewportColumns[viewportColumns.length - 1].idx
+      return selectedPosition.idx > colOverscanEndIdx
         ? [...viewportColumns, selectedColumn]
         : [
             ...viewportColumns.slice(0, lastFrozenColumnIndex + 1),


### PR DESCRIPTION
This is needed to tab into the grid. Currently the selected cell is rendered for the viewport rows but not for the header and summary rows