### PR TITLE
:new: Update width only if it isn't exactly the previous value

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -14,6 +14,8 @@
   ],
   "plugins": [
     "@babel/transform-runtime",
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-optional-chaining",
     ["optimize-clsx", { "functionNames": ["getCellClassname"] }]
   ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -14,8 +14,8 @@
   ],
   "plugins": [
     "@babel/transform-runtime",
-    "@babel/plugin-proposal-nullish-coalescing-operator",
-    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-transform-nullish-coalescing-operator",
+    "@babel/plugin-transform-optional-chaining",
     ["optimize-clsx", { "functionNames": ["getCellClassname"] }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid",
-  "version": "7.0.0-beta.11-2",
+  "version": "7.0.0-beta.11-3",
   "license": "MIT",
   "description": "Feature-rich and customizable data grid React component",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-grid",
-  "version": "7.0.0-beta.11",
+  "version": "7.0.0-beta.11-2",
   "license": "MIT",
   "description": "Feature-rich and customizable data grid React component",
   "keywords": [
@@ -98,7 +98,7 @@
     "react-dom": "^17.0.2",
     "react-refresh": "^0.11.0",
     "react-router-dom": "^6.2.1",
-    "rollup": "^2.63.0",
+    "rollup": "^2.75.7",
     "rollup-plugin-postcss": "^4.0.2",
     "style-loader": "^3.3.1",
     "typescript": "~4.6.2",

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -431,7 +431,7 @@ function DataGrid<R, SR, K extends Key>(
   useImperativeHandle(ref, () => ({
     element: gridRef.current,
     scrollToColumn(idx: number) {
-      scrollToCell({ idx });
+      scrollToCell({ idx, rowIdx: lastSelectedRowIdx.current || 0 });
     },
     scrollToRow(rowIdx: number) {
       const { current } = gridRef;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -69,6 +69,7 @@ interface EditCellState<R> extends Position {
   readonly mode: 'EDIT';
   readonly row: R;
   readonly originalRow: R;
+  readonly isMouseClick: boolean;
 }
 
 type DefaultColumnOptions<R, SR> = Pick<
@@ -689,7 +690,8 @@ function DataGrid<R, SR, K extends Key>(
         rowIdx,
         mode: 'EDIT',
         row,
-        originalRow: row
+        originalRow: row,
+        isMouseClick: false
       }));
     }
   }
@@ -726,7 +728,7 @@ function DataGrid<R, SR, K extends Key>(
 
     if (enableEditor && isCellEditable(position)) {
       const row = rows[position.rowIdx] as R;
-      setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row });
+      setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row, isMouseClick: true });
     } else if (isSamePosition(selectedPosition, position)) {
       // Avoid re-renders if the selected cell state is the same
       // TODO: replace with a #record? https://github.com/microsoft/TypeScript/issues/39831
@@ -970,6 +972,7 @@ function DataGrid<R, SR, K extends Key>(
         scrollToCell={() => {
           scrollToCell(selectedPosition);
         }}
+        isMouseClick={'isMouseClick' in selectedPosition && selectedPosition.isMouseClick}
       />
     );
   }

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -40,6 +40,7 @@ export default function EditCell<R, SR>({
   column,
   colSpan,
   row,
+  isMouseClick,
   onRowChange,
   closeEditor,
   scrollToCell
@@ -119,7 +120,13 @@ export default function EditCell<R, SR>({
     >
       {column.editor != null && (
         <>
-          <column.editor column={column} row={row} onRowChange={onRowChange} onClose={onClose} />
+          <column.editor
+            column={column}
+            row={row}
+            onRowChange={onRowChange}
+            onClose={onClose}
+            isMouseClick={isMouseClick}
+          />
           {column.editorOptions?.renderFormatter && (
             <column.formatter column={column} row={row} isCellSelected onRowChange={onRowChange} />
           )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export interface GroupFormatterProps<TRow, TSummaryRow = unknown> {
 export interface EditorProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TRow;
+  isMouseClick: boolean;
   onRowChange: (row: TRow, commitChanges?: boolean) => void;
   onClose: (commitChanges?: boolean) => void;
 }
@@ -110,10 +111,10 @@ export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
 
 export interface CellRendererProps<TRow, TSummaryRow>
   extends Pick<
-      RowRendererProps<TRow, TSummaryRow>,
-      'onRowClick' | 'onRowDoubleClick' | 'selectCell'
-    >,
-    Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
+  RowRendererProps<TRow, TSummaryRow>,
+  'onRowClick' | 'onRowDoubleClick' | 'selectCell'
+  >,
+  Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   colSpan: number | undefined;
   row: TRow;
@@ -214,8 +215,8 @@ export interface SortIconProps {
 
 export interface CheckboxFormatterProps
   extends Pick<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    'aria-label' | 'aria-labelledby' | 'checked' | 'tabIndex' | 'disabled'
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'aria-label' | 'aria-labelledby' | 'checked' | 'tabIndex' | 'disabled'
   > {
   onChange: (checked: boolean, shift: boolean) => void;
 }


### PR DESCRIPTION
We are having issues with the width sidebar jumping back and forth in some specific cases. The useGridDimensions keeps re-rendering and updating the width in a loop. This PR makes sure that the previous value is also kept in the state so that if there is a state pattern like this:

1. width = 100
2. width = 107
3. width = 100

Then it just doesn't set the width of 100 in step 3 again, preventing the infinite rendering loop. If you resize your screen as a user or snap it via the OS, the table resizing still works fine since there are more events being triggered in that case, compared to the sidebar appearing and disappearing.

WITH TWITCHING BEFORE THIS FIX:
https://user-images.githubusercontent.com/10929022/161064356-d2053799-beac-41fb-a8a2-17b1ba855806.mp4

WITHOUT TWITCHING AFTER THIS FIX:
https://user-images.githubusercontent.com/10929022/161064370-ad11a323-3850-44b9-82dc-b93998acd342.mp4

