### PR TITLE
Add onSelectedCellChange, cellRenderer, foucus on mouse down

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -49,11 +49,11 @@ function Cell<R, SR>(
   function setRef(element: HTMLDivElement | null) {
     ref?.(element);
 
-    if(typeof refComponent === 'function') { 
+    if (typeof refComponent === 'function') {
       refComponent(element);
-    } else if(typeof refComponent === 'object' && refComponent !== null) {
+    } else if (typeof refComponent === 'object' && refComponent !== null) {
       //@ts-expect-error ref mutation
-      refComponent.current = element
+      refComponent.current = element;
     }
   }
 
@@ -75,11 +75,11 @@ function Cell<R, SR>(
   function handleMouseDown(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper(column.editorOptions?.editOnClick);
     onRowClick?.(row, column);
-    onMouseDown?.(event)
+    onMouseDown?.(event);
   }
 
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {
-    onClick?.(event)
+    onClick?.(event);
   }
 
   function handleContextMenu(event: React.MouseEvent<HTMLDivElement>) {
@@ -90,7 +90,7 @@ function Cell<R, SR>(
   function handleDoubleClick(event: React.MouseEvent<HTMLDivElement>) {
     selectCellWrapper(true);
     onRowDoubleClick?.(row, column);
-    onDoubleClick?.(event)
+    onDoubleClick?.(event);
   }
 
   function handleFocus(event: React.FocusEvent<HTMLDivElement, Element>) {

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -73,12 +73,12 @@ function Cell<R, SR>(
   }
 
   function handleMouseDown(event: React.MouseEvent<HTMLDivElement>) {
+    selectCellWrapper(column.editorOptions?.editOnClick);
+    onRowClick?.(row, column);
     onMouseDown?.(event)
   }
 
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {
-    selectCellWrapper(column.editorOptions?.editOnClick);
-    onRowClick?.(row, column);
     onClick?.(event)
   }
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -61,6 +61,7 @@ import type {
   Components,
   Direction
 } from './types';
+import Cell from './Cell';
 
 export interface SelectCellState extends Position {
   readonly mode: 'SELECT';
@@ -243,6 +244,7 @@ function DataGrid<R, SR, K extends Key>(
   rowHeight ??= 35;
   const headerRowHeight = rawHeaderRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
   const summaryRowHeight = rawSummaryRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
+  const CellRenderer = components?.cellRenderer ?? defaultComponents?.cellRenderer ?? Cell;
   const RowRenderer = components?.rowRenderer ?? defaultComponents?.rowRenderer ?? Row;
   const sortIcon = components?.sortIcon ?? defaultComponents?.sortIcon ?? SortIcon;
   const checkboxFormatter =
@@ -287,12 +289,13 @@ function DataGrid<R, SR, K extends Key>(
   const leftKey = isRtl ? 'ArrowRight' : 'ArrowLeft';
   const rightKey = isRtl ? 'ArrowLeft' : 'ArrowRight';
 
-  const defaultGridComponents = useMemo(
+  const defaultGridComponents = useMemo<Maybe<Components<R, SR>>>(
     () => ({
       sortIcon,
-      checkboxFormatter
+      checkboxFormatter,
+      cellRenderer: CellRenderer
     }),
-    [sortIcon, checkboxFormatter]
+    [sortIcon, checkboxFormatter, CellRenderer]
   );
 
   const allRowsSelected = useMemo((): boolean => {

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -138,7 +138,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   /** Set of selected row keys */
   selectedRows?: Maybe<ReadonlySet<K>>;
   /** Function called whenever cell selection is changed */
-  onSelectedCellChange?: Maybe<(selectedCell: Position) => void>
+  onSelectedCellChange?: Maybe<(selectedCell: Position) => void>;
   /** Function called whenever row selection is changed */
   onSelectedRowsChange?: Maybe<(selectedRows: Set<K>) => void>;
   /** Used for multi column sorting */

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -136,6 +136,8 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    */
   /** Set of selected row keys */
   selectedRows?: Maybe<ReadonlySet<K>>;
+  /** Function called whenever cell selection is changed */
+  onSelectedCellChange?: Maybe<(selectedCell: Position) => void>
   /** Function called whenever row selection is changed */
   onSelectedRowsChange?: Maybe<(selectedRows: Set<K>) => void>;
   /** Used for multi column sorting */
@@ -200,6 +202,7 @@ function DataGrid<R, SR, K extends Key>(
     summaryRowHeight: rawSummaryRowHeight,
     // Feature props
     selectedRows,
+    onSelectedCellChange,
     onSelectedRowsChange,
     sortColumns,
     onSortColumnsChange,
@@ -732,6 +735,8 @@ function DataGrid<R, SR, K extends Key>(
     } else {
       setSelectedPosition({ ...position, mode: 'SELECT' });
     }
+
+    onSelectedCellChange?.(position);
   }
 
   function scrollToColumn(idx: number): void {

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -7,6 +7,7 @@ import { RowSelectionProvider, useLatestFunc } from './hooks';
 import { getColSpan, getRowStyle } from './utils';
 import { rowClassname, rowSelectedClassname } from './style';
 import type { RowRendererProps } from './types';
+import { useDefaultComponents } from './DataGridDefaultComponentsProvider';
 
 function Row<R, SR>(
   {
@@ -34,6 +35,9 @@ function Row<R, SR>(
   }: RowRendererProps<R, SR>,
   ref: React.Ref<HTMLDivElement>
 ) {
+  const defaultComponents = useDefaultComponents<R, SR>();
+  const CellRenderer = defaultComponents?.cellRenderer ?? Cell;
+
   const handleRowChange = useLatestFunc((newRow: R) => {
     onRowChange(rowIdx, newRow);
   });
@@ -69,7 +73,7 @@ function Row<R, SR>(
       cells.push(selectedCellEditor);
     } else {
       cells.push(
-        <Cell
+        <CellRenderer
           key={column.key}
           column={column}
           colSpan={colSpan}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default, type DataGridProps, type DataGridHandle } from './DataGrid';
 export { DataGridDefaultComponentsProvider } from './DataGridDefaultComponentsProvider';
+export { default as Cell } from './Cell';
 export { default as Row } from './Row';
 export * from './Columns';
 export * from './formatters';

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,7 @@ export interface Components<TRow, TSummaryRow> {
     | ForwardRefExoticComponent<CheckboxFormatterProps & RefAttributes<HTMLOrSVGElement>>
     | ComponentType<CheckboxFormatterProps>
   >;
+  cellRenderer?: Maybe<ComponentType<CellRendererProps<TRow, TSummaryRow>>>;
   rowRenderer?: Maybe<ComponentType<RowRendererProps<TRow, TSummaryRow>>>;
   noRowsFallback?: Maybe<React.ReactNode>;
 }


### PR DESCRIPTION
In our product we need `onSelectedCellChange` to track focused cell.
Also we need `cellRenderer` to custumize cells.
"focus on click" related to some issues with "onClick" actions. (for example we have menu button in cells)

It will be cool if you be able to accept this editings.