### PR TITLE
Fallback for contentBoxSize

### DIFF
--- a/src/hooks/useGridDimensions.ts
+++ b/src/hooks/useGridDimensions.ts
@@ -28,9 +28,17 @@ export function useGridDimensions(): [
     setBlockSize(initialHeight);
 
     const resizeObserver = new ResizeObserver((entries) => {
-      const size = entries[0].contentBoxSize[0];
-      setInlineSize(handleDevicePixelRatio(size.inlineSize));
-      setBlockSize(size.blockSize);
+      const entry = entries[0];
+      if (entry.contentBoxSize) {
+        const size = entry.contentBoxSize[0];
+        setInlineSize(handleDevicePixelRatio(size.inlineSize));
+        setBlockSize(size.blockSize);
+      } else {
+        // Fallback for browsers that don't support contentBoxSize.
+        const rect = entry.contentRect;
+        setInlineSize(handleDevicePixelRatio(rect.width));
+        setBlockSize(rect.height);
+      }
     });
     resizeObserver.observe(gridRef.current!);
 


### PR DESCRIPTION
This PR adds support for browsers that don't have `contentBoxSize`, like iOS Safari prior to iOS 15.4. Fixes errors like `TypeError: undefined is not an object (evaluating 'entries[0].contentBoxSize[0]')`.

To repro, on macOS:
1. Install Xcode.
1. Install https://developer.apple.com/safari/technology-preview/.
1. Go to Window > Devices and Simulators in the menu, and install iOS 13.7 simulator (for example).
1. Run iOS 13.7 simulator, any device.
1. Open Safari (in sim) and navigate to https://adazzle.github.io/react-data-grid.
1. Open Safari Technology Preview
1. In Safari Technology Preview go to Develop > Simulator you ran > adazzle.github.io, then switch to the Console tab when dev tools appears
1. In Safari Technology Preview dev tools, hit command+R to reload. You should see something like this screenshot.

<img width="1025" alt="Screen Shot 2022-08-01 at 8 22 13 PM" src="https://user-images.githubusercontent.com/86958/182284920-185138e0-fe33-43f0-a0cd-8c2baef54fed.png">

I tested this PR against my own app, but you should also be able to confirm the fix with steps like those above.

For reference: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentRect.