### PR TITLE
External copy paste handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ A number defining the height of summary rows.
 
 ###### `onPaste?: Maybe<(event: PasteEvent<R>) => R>`
 
+###### `handleCopyExternally?: Maybe<() => void>`
+
+Handle the copy event outside of react data grid
+
+###### `handlePasteExternally?: Maybe<() => void>`
+
+Handle the paste event outside of react data grid
+
 ###### `onRowClick?: Maybe<(row: R, column: CalculatedColumn<R, SR>) => void>`
 
 ###### `onRowDoubleClick?: Maybe<(row: R, column: CalculatedColumn<R, SR>) => void>`

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -149,6 +149,8 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   onFill?: Maybe<(event: FillEvent<R>) => R>;
   onCopy?: Maybe<(event: CopyEvent<R>) => void>;
   onPaste?: Maybe<(event: PasteEvent<R>) => R>;
+  handleCopyExternally?: Maybe<() => void>;
+  handlePasteExternally?: Maybe<() => void>;
 
   /**
    * Event props
@@ -216,6 +218,8 @@ function DataGrid<R, SR, K extends Key>(
     onFill,
     onCopy,
     onPaste,
+    handleCopyExternally,
+    handlePasteExternally,
     // Toggles and modes
     cellNavigationMode: rawCellNavigationMode,
     enableVirtualization,
@@ -547,10 +551,12 @@ function DataGrid<R, SR, K extends Key>(
 
     const { key, keyCode } = event;
     const { rowIdx } = selectedPosition;
+    const hasCopyHandler = handleCopyExternally ?? onCopy;
+    const hasPasteHandler = handlePasteExternally ?? onPaste;
 
     if (
       selectedCellIsWithinViewportBounds &&
-      (onPaste != null || onCopy != null) &&
+      (hasPasteHandler != null || hasCopyHandler != null) &&
       isCtrlKeyHeldDown(event) &&
       !isGroupRow(rows[rowIdx]) &&
       selectedPosition.mode === 'SELECT'
@@ -560,11 +566,13 @@ function DataGrid<R, SR, K extends Key>(
       const cKey = 67;
       const vKey = 86;
       if (keyCode === cKey) {
-        handleCopy();
+        const copyHandler = handleCopyExternally ?? handleCopy
+        copyHandler();
         return;
       }
       if (keyCode === vKey) {
-        handlePaste();
+        const pastehandler = handlePasteExternally ?? handlePaste
+        pastehandler();
         return;
       }
     }


### PR DESCRIPTION
This PR adds two callback props for the copy and paste events. The new props allow developers to write their own logic for the copy and paste events. Thereby, allowing the devs to respond to the events as they see fit, by having all of the logic outside of react-data-grid.

The primary limitations of the internal copy/paste logic provided by react-data-grid, is the inability to copy/paste items from external sources by writing to the clipboard. As well as the limitation of only being able to copy one cell at a time. By letting developers write there own logic to these events, these use cases can be addressed by enabling the dev to write their own logic.

Possible use cases for these two props:
- copying values to the clipboard
- pasting values from the clipboard
   - allows the user to paste data that was copied from outside of react-data-grid
- copying from multiple cells
- pasting to multiples cells