### PR TITLE
Re-export useFocusRef

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export * from './Columns';
 export * from './formatters';
 export { default as textEditor } from './editors/textEditor';
 export { default as headerRenderer } from './headerRenderer';
-export { useRowSelection } from './hooks';
+export { useFocusRef, useRowSelection } from './hooks';
 export type {
   Column,
   CalculatedColumn,

--- a/website/demos/HeaderFilters.tsx
+++ b/website/demos/HeaderFilters.tsx
@@ -2,10 +2,9 @@ import { createContext, useContext, useMemo, useState } from 'react';
 import { css } from '@linaria/core';
 import { faker } from '@faker-js/faker';
 
-import DataGrid from '../../src';
+import DataGrid, { useFocusRef } from '../../src';
 import type { Column, HeaderRendererProps } from '../../src';
 import type { Omit } from '../../src/types';
-import { useFocusRef } from '../../src/hooks';
 import type { Props } from './types';
 
 const rootClassname = css`

--- a/website/demos/components/Formatters/CellExpanderFormatter.tsx
+++ b/website/demos/components/Formatters/CellExpanderFormatter.tsx
@@ -1,5 +1,5 @@
 import { css } from '@linaria/core';
-import { useFocusRef } from '../../../../src/hooks';
+import { useFocusRef } from '../../../../src';
 
 const cellExpandClassname = css`
   /* needed on chrome */

--- a/website/demos/components/Formatters/ChildRowDeleteButton.tsx
+++ b/website/demos/components/Formatters/ChildRowDeleteButton.tsx
@@ -1,5 +1,5 @@
 import { css } from '@linaria/core';
-import { useFocusRef } from '../../../../src/hooks';
+import { useFocusRef } from '../../../../src';
 
 const childRowActionCrossClassname = css`
   &::before,


### PR DESCRIPTION
Fixes https://github.com/adazzle/react-data-grid/issues/2834