### PR TITLE
Add sortStatus renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ This prop can be used to override the internal renderers. The prop accepts an ob
 ```tsx
 interface Renderers<TRow, TSummaryRow> {
   sortIcon?: Maybe<(props: SortIconProps) => ReactNode>;
+  sortPriority?: Maybe<(props: SortPriorityProps) => ReactNode>;
   checkboxFormatter?: Maybe<
     (props: CheckboxFormatterProps, ref: Ref<HTMLInputElement>) => ReactNode
   >;

--- a/README.md
+++ b/README.md
@@ -205,8 +205,7 @@ This prop can be used to override the internal renderers. The prop accepts an ob
 
 ```tsx
 interface Renderers<TRow, TSummaryRow> {
-  sortIcon?: Maybe<(props: SortIconProps) => ReactNode>;
-  sortPriority?: Maybe<(props: SortPriorityProps) => ReactNode>;
+  sortStatus?: Maybe<(props: SortStatusProps) => ReactNode>;
   checkboxFormatter?: Maybe<
     (props: CheckboxFormatterProps, ref: Ref<HTMLInputElement>) => ReactNode
   >;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -26,6 +26,7 @@ import SummaryRow from './SummaryRow';
 import EditCell from './EditCell';
 import DragHandle from './DragHandle';
 import { default as defaultSortIcon } from './sortIcon';
+import { default as defaultSortPriority } from './sortPriority';
 import { checkboxFormatter as defaultCheckboxFormatter } from './formatters';
 import {
   DataGridDefaultComponentsProvider,
@@ -247,6 +248,7 @@ function DataGrid<R, SR, K extends Key>(
   const rowRenderer =
     renderers?.rowRenderer ?? defaultComponents?.rowRenderer ?? defaultRowRenderer;
   const sortIcon = renderers?.sortIcon ?? defaultComponents?.sortIcon ?? defaultSortIcon;
+  const sortPriority = renderers?.sortPriority ?? defaultComponents?.sortPriority ?? defaultSortPriority;
   const checkboxFormatter =
     renderers?.checkboxFormatter ??
     defaultComponents?.checkboxFormatter ??
@@ -295,9 +297,10 @@ function DataGrid<R, SR, K extends Key>(
   const defaultGridComponents = useMemo(
     () => ({
       sortIcon,
+      sortPriority,
       checkboxFormatter
     }),
-    [sortIcon, checkboxFormatter]
+    [sortIcon, sortPriority, checkboxFormatter]
   );
 
   const allRowsSelected = useMemo((): boolean => {
@@ -1274,3 +1277,4 @@ function isSamePosition(p1: Position, p2: Position) {
 export default forwardRef(DataGrid) as <R, SR = unknown, K extends Key = Key>(
   props: DataGridProps<R, SR, K> & RefAttributes<DataGridHandle>
 ) => JSX.Element;
+

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -248,7 +248,8 @@ function DataGrid<R, SR, K extends Key>(
   const rowRenderer =
     renderers?.rowRenderer ?? defaultComponents?.rowRenderer ?? defaultRowRenderer;
   const sortIcon = renderers?.sortIcon ?? defaultComponents?.sortIcon ?? defaultSortIcon;
-  const sortPriority = renderers?.sortPriority ?? defaultComponents?.sortPriority ?? defaultSortPriority;
+  const sortPriority =
+    renderers?.sortPriority ?? defaultComponents?.sortPriority ?? defaultSortPriority;
   const checkboxFormatter =
     renderers?.checkboxFormatter ??
     defaultComponents?.checkboxFormatter ??
@@ -1277,4 +1278,3 @@ function isSamePosition(p1: Position, p2: Position) {
 export default forwardRef(DataGrid) as <R, SR = unknown, K extends Key = Key>(
   props: DataGridProps<R, SR, K> & RefAttributes<DataGridHandle>
 ) => JSX.Element;
-

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -26,8 +26,7 @@ import GroupRowRenderer from './GroupRow';
 import SummaryRow from './SummaryRow';
 import EditCell from './EditCell';
 import DragHandle from './DragHandle';
-import { default as defaultSortIcon } from './sortIcon';
-import { default as defaultSortPriority } from './sortPriority';
+import { default as defaultSortStatus } from './sortStatus';
 import { checkboxFormatter as defaultCheckboxFormatter } from './formatters';
 import {
   DataGridDefaultComponentsProvider,
@@ -248,9 +247,7 @@ function DataGrid<R, SR, K extends Key>(
   const summaryRowHeight = rawSummaryRowHeight ?? (typeof rowHeight === 'number' ? rowHeight : 35);
   const rowRenderer =
     renderers?.rowRenderer ?? defaultComponents?.rowRenderer ?? defaultRowRenderer;
-  const sortIcon = renderers?.sortIcon ?? defaultComponents?.sortIcon ?? defaultSortIcon;
-  const sortPriority =
-    renderers?.sortPriority ?? defaultComponents?.sortPriority ?? defaultSortPriority;
+  const sortStatus = renderers?.sortStatus ?? defaultComponents?.sortStatus ?? defaultSortStatus;
   const checkboxFormatter =
     renderers?.checkboxFormatter ??
     defaultComponents?.checkboxFormatter ??
@@ -298,11 +295,10 @@ function DataGrid<R, SR, K extends Key>(
 
   const defaultGridComponents = useMemo(
     () => ({
-      sortIcon,
-      sortPriority,
+      sortStatus,
       checkboxFormatter
     }),
-    [sortIcon, sortPriority, checkboxFormatter]
+    [sortStatus, checkboxFormatter]
   );
 
   const allRowsSelected = useMemo((): boolean => {

--- a/src/headerRenderer.tsx
+++ b/src/headerRenderer.tsx
@@ -61,7 +61,7 @@ function SortableHeaderCell<R, SR>({
   children,
   isCellSelected
 }: SortableHeaderCellProps<R, SR>) {
-  const sortIcon = useDefaultComponents<R, SR>()!.sortIcon!;
+  const { sortIcon, sortPriority } = useDefaultComponents<R, SR>()!;
   const { ref, tabIndex } = useFocusRef<HTMLSpanElement>(isCellSelected);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLSpanElement>) {
@@ -86,8 +86,8 @@ function SortableHeaderCell<R, SR>({
     >
       <span className={headerSortNameClassname}>{children}</span>
       <span>
-        {sortIcon({ sortDirection })}
-        {priority}
+        {sortIcon!({ sortDirection })}
+        {sortPriority!({ priority })}
       </span>
     </span>
   );

--- a/src/headerRenderer.tsx
+++ b/src/headerRenderer.tsx
@@ -61,7 +61,7 @@ function SortableHeaderCell<R, SR>({
   children,
   isCellSelected
 }: SortableHeaderCellProps<R, SR>) {
-  const { sortIcon, sortPriority } = useDefaultComponents<R, SR>()!;
+  const sortStatus = useDefaultComponents<R, SR>()!.sortStatus!;
   const { ref, tabIndex } = useFocusRef<HTMLSpanElement>(isCellSelected);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLSpanElement>) {
@@ -85,10 +85,7 @@ function SortableHeaderCell<R, SR>({
       onKeyDown={handleKeyDown}
     >
       <span className={headerSortNameClassname}>{children}</span>
-      <span>
-        {sortIcon!({ sortDirection })}
-        {sortPriority!({ priority })}
-      </span>
+      <span>{sortStatus({ sortDirection, priority })}</span>
     </span>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './Columns';
 export * from './formatters';
 export { default as textEditor } from './editors/textEditor';
 export { default as headerRenderer } from './headerRenderer';
+export { sortIcon, sortPriority } from './sortStatus';
 export { useFocusRef, useRowSelection } from './hooks';
 export type {
   Column,
@@ -28,5 +29,6 @@ export type {
   RowHeightArgs,
   CheckboxFormatterProps,
   SortIconProps,
-  SortPriorityProps
+  SortPriorityProps,
+  SortStatusProps
 } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,5 +27,6 @@ export type {
   ColSpanArgs,
   RowHeightArgs,
   CheckboxFormatterProps,
-  SortIconProps
+  SortIconProps,
+  SortPriorityProps
 } from './types';

--- a/src/sortPriority.ts
+++ b/src/sortPriority.ts
@@ -1,5 +1,0 @@
-import type { SortPriorityProps } from './types';
-
-export default function sortPriority({ priority }: SortPriorityProps) {
-  return priority;
-}

--- a/src/sortPriority.ts
+++ b/src/sortPriority.ts
@@ -1,0 +1,5 @@
+import type { SortPriorityProps } from './types';
+
+export default function sortPriority({ priority }: SortPriorityProps) {
+  return priority;
+}

--- a/src/sortStatus.tsx
+++ b/src/sortStatus.tsx
@@ -1,5 +1,5 @@
 import { css } from '@linaria/core';
-import type { SortIconProps } from './types';
+import type { SortStatusProps, SortIconProps, SortPriorityProps } from './types';
 
 const arrow = css`
   fill: currentColor;
@@ -11,7 +11,16 @@ const arrow = css`
 
 const arrowClassname = `rdg-sort-arrow ${arrow}`;
 
-export default function sortIcon({ sortDirection }: SortIconProps) {
+export default function sortStatus({ sortDirection, priority }: SortStatusProps) {
+  return (
+    <>
+      {sortIcon({ sortDirection })}
+      {sortPriority({ priority })}
+    </>
+  );
+}
+
+export function sortIcon({ sortDirection }: SortIconProps) {
   if (sortDirection === undefined) return null;
 
   return (
@@ -19,4 +28,8 @@ export default function sortIcon({ sortDirection }: SortIconProps) {
       <path d={sortDirection === 'ASC' ? 'M0 8 6 0 12 8' : 'M0 0 6 8 12 0'} />
     </svg>
   );
+}
+
+export function sortPriority({ priority }: SortPriorityProps) {
+  return priority;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,10 @@ export interface SortIconProps {
   sortDirection: SortDirection | undefined;
 }
 
+export interface SortPriorityProps {
+  priority: number | undefined;
+}
+
 export interface CheckboxFormatterProps
   extends Pick<
     React.InputHTMLAttributes<HTMLInputElement>,
@@ -223,6 +227,7 @@ export interface CheckboxFormatterProps
 
 export interface Renderers<TRow, TSummaryRow> {
   sortIcon?: Maybe<(props: SortIconProps) => ReactNode>;
+  sortPriority?: Maybe<(props: SortPriorityProps) => ReactNode>;
   checkboxFormatter?: Maybe<
     (props: CheckboxFormatterProps, ref: RefObject<HTMLInputElement>) => ReactNode
   >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,7 +217,7 @@ export interface SortPriorityProps {
   priority: number | undefined;
 }
 
-export interface SortStatusProps extends SortIconProps, SortPriorityProps {};
+export interface SortStatusProps extends SortIconProps, SortPriorityProps {}
 
 export interface CheckboxFormatterProps
   extends Pick<

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,7 +217,7 @@ export interface SortPriorityProps {
   priority: number | undefined;
 }
 
-export type SortStatusProps = SortIconProps & SortPriorityProps;
+export interface SortStatusProps extends SortIconProps, SortPriorityProps {};
 
 export interface CheckboxFormatterProps
   extends Pick<

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,8 @@ export interface SortPriorityProps {
   priority: number | undefined;
 }
 
+export type SortStatusProps = SortIconProps & SortPriorityProps;
+
 export interface CheckboxFormatterProps
   extends Pick<
     React.InputHTMLAttributes<HTMLInputElement>,
@@ -226,8 +228,7 @@ export interface CheckboxFormatterProps
 }
 
 export interface Renderers<TRow, TSummaryRow> {
-  sortIcon?: Maybe<(props: SortIconProps) => ReactNode>;
-  sortPriority?: Maybe<(props: SortPriorityProps) => ReactNode>;
+  sortStatus?: Maybe<(props: SortStatusProps) => ReactNode>;
   checkboxFormatter?: Maybe<
     (props: CheckboxFormatterProps, ref: RefObject<HTMLInputElement>) => ReactNode
   >;

--- a/test/renderers.test.tsx
+++ b/test/renderers.test.tsx
@@ -2,13 +2,13 @@ import { StrictMode, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import DataGrid, { DataGridDefaultComponentsProvider, SelectColumn } from '../src';
+import DataGrid, { DataGridDefaultComponentsProvider, SelectColumn, sortIcon } from '../src';
 import type {
   Column,
   DataGridProps,
   CheckboxFormatterProps,
   SortColumn,
-  SortPriorityProps
+  SortStatusProps
 } from '../src';
 import { getHeaderCells, getRows, setup } from './utils';
 
@@ -52,12 +52,22 @@ function globalCheckboxFormatter(
   return <div ref={ref}>Global checkbox</div>;
 }
 
-function globalSortPriority({ priority }: SortPriorityProps) {
-  return <span data-testid="global-sort-priority">{priority}</span>;
+function globalSortStatus({ sortDirection, priority }: SortStatusProps) {
+  return (
+    <>
+      {sortIcon({ sortDirection })}
+      <span data-testid="global-sort-priority">{priority}</span>
+    </>
+  );
 }
 
-function sortPriority({ priority }: SortPriorityProps) {
-  return <span data-testid="local-sort-priority">{priority}</span>;
+function sortStatus({ sortDirection, priority }: SortStatusProps) {
+  return (
+    <>
+      {sortIcon({ sortDirection })}
+      <span data-testid="local-sort-priority">{priority}</span>;
+    </>
+  );
 }
 
 function TestGrid<R, SR, K extends React.Key>(props: DataGridProps<R, SR, K>) {
@@ -73,7 +83,7 @@ function setupProvider<R, SR, K extends React.Key>(props: DataGridProps<R, SR, K
         value={{
           noRowsFallback: <GlobalNoRowsFallback />,
           checkboxFormatter: globalCheckboxFormatter,
-          sortPriority: globalSortPriority
+          sortStatus: globalSortStatus
         }}
       >
         <TestGrid {...props} />
@@ -164,7 +174,7 @@ test('sortPriority defined using both providers', async () => {
 });
 
 test('sortPriority defined using both providers and renderers', async () => {
-  setupProvider({ columns, rows: [], renderers: { sortPriority } });
+  setupProvider({ columns, rows: [], renderers: { sortStatus } });
 
   const [, headerCell2, headerCell3] = getHeaderCells();
   const user = userEvent.setup();

--- a/test/renderers.test.tsx
+++ b/test/renderers.test.tsx
@@ -1,9 +1,16 @@
-import { StrictMode } from 'react';
+import { StrictMode, useState } from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import DataGrid, { DataGridDefaultComponentsProvider, SelectColumn } from '../src';
-import type { Column, DataGridProps, CheckboxFormatterProps } from '../src';
-import { getRows, setup } from './utils';
+import type {
+  Column,
+  DataGridProps,
+  CheckboxFormatterProps,
+  SortColumn,
+  SortPriorityProps
+} from '../src';
+import { getHeaderCells, getRows, setup } from './utils';
 
 interface Row {
   id: number;
@@ -12,8 +19,14 @@ interface Row {
 const columns: readonly Column<Row>[] = [
   SelectColumn,
   {
-    key: 'col',
-    name: 'Column'
+    key: 'col1',
+    name: 'Column1',
+    sortable: true
+  },
+  {
+    key: 'col2',
+    name: 'Column2',
+    sortable: true
   }
 ];
 
@@ -39,16 +52,31 @@ function globalCheckboxFormatter(
   return <div ref={ref}>Global checkbox</div>;
 }
 
+function globalSortPriority({ priority }: SortPriorityProps) {
+  return <span data-testid="global-sort-priority">{priority}</span>;
+}
+
+function sortPriority({ priority }: SortPriorityProps) {
+  return <span data-testid="local-sort-priority">{priority}</span>;
+}
+
+function TestGrid<R, SR, K extends React.Key>(props: DataGridProps<R, SR, K>) {
+  const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
+
+  return <DataGrid {...props} sortColumns={sortColumns} onSortColumnsChange={setSortColumns} />;
+}
+
 function setupProvider<R, SR, K extends React.Key>(props: DataGridProps<R, SR, K>) {
   return render(
     <StrictMode>
       <DataGridDefaultComponentsProvider
         value={{
           noRowsFallback: <GlobalNoRowsFallback />,
-          checkboxFormatter: globalCheckboxFormatter
+          checkboxFormatter: globalCheckboxFormatter,
+          sortPriority: globalSortPriority
         }}
       >
-        <DataGrid {...props} />
+        <TestGrid {...props} />
       </DataGridDefaultComponentsProvider>
     </StrictMode>
   );
@@ -117,4 +145,36 @@ test('checkbox defined using both provider and renderers', () => {
   expect(getRows()).toHaveLength(0);
   expect(screen.getByText('Local checkbox')).toBeInTheDocument();
   expect(screen.queryByText('Global checkbox')).not.toBeInTheDocument();
+});
+
+test('sortPriority defined using both providers', async () => {
+  setupProvider({ columns, rows: [] });
+
+  const [, headerCell2, headerCell3] = getHeaderCells();
+  const user = userEvent.setup();
+  await user.click(headerCell2.firstElementChild!);
+  await user.keyboard('{Control>}');
+  await user.click(headerCell3.firstElementChild!);
+
+  const p = screen.getAllByTestId('global-sort-priority');
+  expect(p[0]).toHaveTextContent('1');
+  expect(p[1]).toHaveTextContent('2');
+
+  expect(screen.queryByTestId('local-sort-priority')).not.toBeInTheDocument();
+});
+
+test('sortPriority defined using both providers and renderers', async () => {
+  setupProvider({ columns, rows: [], renderers: { sortPriority } });
+
+  const [, headerCell2, headerCell3] = getHeaderCells();
+  const user = userEvent.setup();
+  await user.click(headerCell3.firstElementChild!);
+  await user.keyboard('{Control>}');
+  await user.click(headerCell2.firstElementChild!);
+
+  const p = screen.getAllByTestId('local-sort-priority');
+  expect(p[0]).toHaveTextContent('2');
+  expect(p[1]).toHaveTextContent('1');
+
+  expect(screen.queryByTestId('global-sort-priority')).not.toBeInTheDocument();
 });

--- a/test/renderers.test.tsx
+++ b/test/renderers.test.tsx
@@ -65,7 +65,7 @@ function sortStatus({ sortDirection, priority }: SortStatusProps) {
   return (
     <>
       {sortIcon({ sortDirection })}
-      <span data-testid="local-sort-priority">{priority}</span>;
+      <span data-testid="local-sort-priority">{priority}</span>
     </>
   );
 }

--- a/website/demos/CustomizableComponents.tsx
+++ b/website/demos/CustomizableComponents.tsx
@@ -2,7 +2,13 @@ import { useMemo, useState } from 'react';
 import { css } from '@linaria/core';
 
 import DataGrid, { SelectColumn, textEditor } from '../../src';
-import type { Column, CheckboxFormatterProps, SortColumn, SortIconProps } from '../../src';
+import type {
+  Column,
+  CheckboxFormatterProps,
+  SortColumn,
+  SortIconProps,
+  SortPriorityProps
+} from '../../src';
 import type { Props } from './types';
 
 const selectCellClassname = css`
@@ -13,6 +19,11 @@ const selectCellClassname = css`
   > input {
     margin: 0;
   }
+`;
+
+const sortPriorityClassname = css`
+  color: grey;
+  margin-left: 2px;
 `;
 
 interface Row {
@@ -104,7 +115,7 @@ export default function CustomizableComponents({ direction }: Props) {
       onSortColumnsChange={setSortColumns}
       selectedRows={selectedRows}
       onSelectedRowsChange={setSelectedRows}
-      renderers={{ sortIcon, checkboxFormatter }}
+      renderers={{ sortIcon, sortPriority, checkboxFormatter }}
       direction={direction}
     />
   );
@@ -123,6 +134,10 @@ function checkboxFormatter(
 
 function sortIcon({ sortDirection }: SortIconProps) {
   return sortDirection !== undefined ? <>{sortDirection === 'ASC' ? '\u2B9D' : '\u2B9F'} </> : null;
+}
+
+function sortPriority({ priority }: SortPriorityProps) {
+  return <span className={sortPriorityClassname}>{priority}</span>;
 }
 
 function rowKeyGetter(row: Row) {

--- a/website/demos/CustomizableComponents.tsx
+++ b/website/demos/CustomizableComponents.tsx
@@ -130,7 +130,7 @@ function sortStatus({ sortDirection, priority }: SortStatusProps) {
   return (
     <>
       {sortDirection !== undefined ? (sortDirection === 'ASC' ? '\u2B9D' : '\u2B9F') : null}
-      <span className={sortPriorityClassname}>{priority}</span>;
+      <span className={sortPriorityClassname}>{priority}</span>
     </>
   );
 }

--- a/website/demos/CustomizableComponents.tsx
+++ b/website/demos/CustomizableComponents.tsx
@@ -2,13 +2,7 @@ import { useMemo, useState } from 'react';
 import { css } from '@linaria/core';
 
 import DataGrid, { SelectColumn, textEditor } from '../../src';
-import type {
-  Column,
-  CheckboxFormatterProps,
-  SortColumn,
-  SortIconProps,
-  SortPriorityProps
-} from '../../src';
+import type { Column, CheckboxFormatterProps, SortColumn, SortStatusProps } from '../../src';
 import type { Props } from './types';
 
 const selectCellClassname = css`
@@ -115,7 +109,7 @@ export default function CustomizableComponents({ direction }: Props) {
       onSortColumnsChange={setSortColumns}
       selectedRows={selectedRows}
       onSelectedRowsChange={setSelectedRows}
-      renderers={{ sortIcon, sortPriority, checkboxFormatter }}
+      renderers={{ sortStatus, checkboxFormatter }}
       direction={direction}
     />
   );
@@ -132,14 +126,14 @@ function checkboxFormatter(
   return <input type="checkbox" ref={ref} {...props} onChange={handleChange} />;
 }
 
-function sortIcon({ sortDirection }: SortIconProps) {
-  return sortDirection !== undefined ? <>{sortDirection === 'ASC' ? '\u2B9D' : '\u2B9F'} </> : null;
+function sortStatus({ sortDirection, priority }: SortStatusProps) {
+  return (
+    <>
+      {sortDirection !== undefined ? (sortDirection === 'ASC' ? '\u2B9D' : '\u2B9F') : null}
+      <span className={sortPriorityClassname}>{priority}</span>;
+    </>
+  );
 }
-
-function sortPriority({ priority }: SortPriorityProps) {
-  return <span className={sortPriorityClassname}>{priority}</span>;
-}
-
 function rowKeyGetter(row: Row) {
   return row.id;
 }


### PR DESCRIPTION
Fixes https://github.com/adazzle/react-data-grid/issues/3000

This replaces `sortIcon` renderer. Now both icon and priority can be customized using the new `sortStatus` renderer