### PR TITLE
fixes #2761 - context-menu The right-click menu is not closed

### DIFF
--- a/website/demos/ContextMenu.tsx
+++ b/website/demos/ContextMenu.tsx
@@ -132,7 +132,12 @@ function rowKeyGetter(row: Row) {
 function rowRenderer(key: React.Key, props: RowRendererProps<Row>) {
   return (
     // @ts-expect-error
-    <ContextMenuTrigger key={key} id="grid-context-menu" collect={() => ({ rowIdx: props.rowIdx })}>
+    <ContextMenuTrigger
+      key={key}
+      holdToDisplay={-1}
+      id="grid-context-menu"
+      collect={() => ({ rowIdx: props.rowIdx })}
+    >
       <GridRow {...props} />
     </ContextMenuTrigger>
   );


### PR DESCRIPTION
- Users can now close the context-menu by clicking outside.