### PR TITLE
Filtering empty arrays is used to resolve errors reported for column decomposition

### DIFF
--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -81,7 +81,7 @@ export function useCalculatedColumns<R, SR>({
       }
 
       return column;
-    });
+    }).filter(Boolean);
 
     columns.sort(({ key: aKey, frozen: frozenA }, { key: bKey, frozen: frozenB }) => {
       // Sort select column first:


### PR DESCRIPTION
```
 Filtering empty arrays is used to resolve errors reported for column decomposition
```
<img width="908" alt="截屏2022-10-24 18 36 21" src="https://user-images.githubusercontent.com/38446493/197507440-2868a603-805b-45a2-b201-2086fb928f71.png">
