### PR TITLE
Enable the Rome formatter for `.js`/`.cjs` files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@
 /lib
 /node_modules
 /package-lock.json
+*.js
+*.cjs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "rome.rome"
+  },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/rome.json
+++ b/rome.json
@@ -4,7 +4,7 @@
     "ignore": ["./coverage/**/*", "./dist/**/*", "./lib/**/*"]
   },
   "formatter": {
-    "enabled": false,
+    "ignore": ["*.ts", "*.tsx"],
     "indentStyle": "space",
     "lineWidth": 100
   },


### PR DESCRIPTION
We can't enable Rome formatting in `.ts`/`.tsx` files as we're likely to use linaria there, and Rome doesn't yet support formatting CSS-in-JS, or CSS at all.
Prettier will not format `.js` files anymore, but it'll keep formatting everything else.