### PR TITLE
Add indeterminate state of header checkbox

### DIFF
--- a/src/Columns.tsx
+++ b/src/Columns.tsx
@@ -50,6 +50,7 @@ export const SelectColumn: Column<any, any> = {
         aria-label="Select All"
         isCellSelected={props.isCellSelected}
         value={props.allRowsSelected}
+        isIndeterminate={props.someRowsSelected}
         onChange={props.onAllRowsSelectionChange}
       />
     );

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -304,7 +304,7 @@ function DataGrid<R, SR, K extends Key>(
   );
 
   const allRowsSelected = useMemo((): boolean => {
-    // no rows to select = explicitely unchecked
+    // no rows to select = explicitly unchecked
     const { length } = rawRows;
     return (
       length !== 0 &&
@@ -312,6 +312,17 @@ function DataGrid<R, SR, K extends Key>(
       rowKeyGetter != null &&
       selectedRows.size >= length &&
       rawRows.every((row) => selectedRows.has(rowKeyGetter(row)))
+    );
+  }, [rawRows, selectedRows, rowKeyGetter]);
+
+  const someRowsSelected = useMemo((): boolean => {
+    const { length } = rawRows;
+    return (
+      length !== 0 &&
+      selectedRows != null &&
+      rowKeyGetter != null &&
+      selectedRows.size > 0 &&
+      selectedRows.size < length
     );
   }, [rawRows, selectedRows, rowKeyGetter]);
 
@@ -1221,6 +1232,7 @@ function DataGrid<R, SR, K extends Key>(
           onColumnResize={handleColumnResizeLatest}
           allRowsSelected={allRowsSelected}
           onAllRowsSelectionChange={selectAllRowsLatest}
+          someRowsSelected={someRowsSelected}
           sortColumns={sortColumns}
           onSortColumnsChange={onSortColumnsChangeLatest}
           lastFrozenColumnIndex={lastFrozenColumnIndex}

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -29,6 +29,7 @@ type SharedHeaderRowProps<R, SR> = Pick<
   | 'sortColumns'
   | 'onSortColumnsChange'
   | 'allRowsSelected'
+  | 'someRowsSelected'
   | 'onAllRowsSelectionChange'
   | 'selectCell'
   | 'onColumnResize'
@@ -48,6 +49,7 @@ export default function HeaderCell<R, SR>({
   isCellSelected,
   onColumnResize,
   allRowsSelected,
+  someRowsSelected,
   onAllRowsSelectionChange,
   sortColumns,
   onSortColumnsChange,
@@ -189,6 +191,7 @@ export default function HeaderCell<R, SR>({
         priority,
         onSort,
         allRowsSelected,
+        someRowsSelected,
         onAllRowsSelectionChange,
         isCellSelected
       })}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -16,6 +16,7 @@ type SharedDataGridProps<R, SR, K extends React.Key> = Pick<
 export interface HeaderRowProps<R, SR, K extends React.Key> extends SharedDataGridProps<R, SR, K> {
   columns: readonly CalculatedColumn<R, SR>[];
   allRowsSelected: boolean;
+  someRowsSelected: boolean;
   onAllRowsSelectionChange: (checked: boolean) => void;
   onColumnResize: (column: CalculatedColumn<R, SR>, width: number | 'max-content') => void;
   selectCell: (columnIdx: number) => void;
@@ -50,6 +51,7 @@ const headerRowClassname = `rdg-header-row ${headerRow}`;
 function HeaderRow<R, SR, K extends React.Key>({
   columns,
   allRowsSelected,
+  someRowsSelected,
   onAllRowsSelectionChange,
   onColumnResize,
   sortColumns,
@@ -76,6 +78,7 @@ function HeaderRow<R, SR, K extends React.Key>({
         isCellSelected={selectedCellIdx === column.idx}
         onColumnResize={onColumnResize}
         allRowsSelected={allRowsSelected}
+        someRowsSelected={someRowsSelected}
         onAllRowsSelectionChange={onAllRowsSelectionChange}
         onSortColumnsChange={onSortColumnsChange}
         sortColumns={sortColumns}

--- a/src/formatters/SelectCellFormatter.tsx
+++ b/src/formatters/SelectCellFormatter.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useFocusRef } from '../hooks/useFocusRef';
 import { useDefaultComponents } from '../DataGridDefaultComponentsProvider';
 import type { CheckboxFormatterProps } from '../types';
@@ -6,6 +7,7 @@ type SharedInputProps = Pick<CheckboxFormatterProps, 'disabled' | 'aria-label' |
 
 interface SelectCellFormatterProps extends SharedInputProps {
   isCellSelected: boolean;
+  isIndeterminate?: boolean;
   value: boolean;
   onChange: (value: boolean, isShiftClick: boolean) => void;
 }
@@ -13,6 +15,7 @@ interface SelectCellFormatterProps extends SharedInputProps {
 export function SelectCellFormatter({
   value,
   isCellSelected,
+  isIndeterminate = false,
   disabled,
   onChange,
   'aria-label': ariaLabel,
@@ -20,6 +23,13 @@ export function SelectCellFormatter({
 }: SelectCellFormatterProps) {
   const { ref, tabIndex } = useFocusRef<HTMLInputElement>(isCellSelected);
   const checkboxFormatter = useDefaultComponents()!.checkboxFormatter!;
+
+  useEffect(() => {
+    if (typeof ref.current?.indeterminate === 'boolean') {
+      ref.current.indeterminate = isIndeterminate;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isIndeterminate]);
 
   return (
     <>

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,7 @@ export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
   priority: number | undefined;
   onSort: (ctrlClick: boolean) => void;
   allRowsSelected: boolean;
+  someRowsSelected: boolean;
   onAllRowsSelectionChange: (checked: boolean) => void;
   isCellSelected: boolean;
 }


### PR DESCRIPTION
Added someRowsSelected property to DataGrid to determine if indeterminate

Provide someRowsSelected as a new property to HeaderRendererProps

Automatically set indeterminate property on built-in or overridden checkboxFormatter as long as the ref exists and the ref component has a property named `indeterminate` (e.x. input component)

Fixed typo in comment

resolves #3058


**Note**: the built-in custom select checkbox does have the indeterminate property set, but there are no active styles for this state.

Here are screenshots of the outcome of this feature:

![image](https://user-images.githubusercontent.com/5461649/209473500-ba72efa2-d796-4285-bff3-b712561c7417.png)

![image](https://user-images.githubusercontent.com/5461649/209473544-0c7fa6cc-435b-4a85-adb8-24786e82fb07.png)


![image](https://user-images.githubusercontent.com/5461649/209473533-b6dc90e6-8fcd-45d8-87d8-9447205a12e3.png)

![image](https://user-images.githubusercontent.com/5461649/209473538-5e99a62a-780b-4870-8893-ef1cbb03422e.png)
