### PR TITLE
Use `rowIdx` instead of `row` to select cell

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -32,6 +32,7 @@ function Cell<R, SR>({
   isCopied,
   isDraggedOver,
   row,
+  rowIdx,
   dragHandle,
   skipCellFocusRef,
   onClick,
@@ -54,7 +55,7 @@ function Cell<R, SR>({
   );
 
   function selectCellWrapper(openEditor?: boolean) {
-    selectCell(row, column, openEditor);
+    selectCell(rowIdx, column, openEditor);
   }
 
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -111,7 +111,6 @@ function Cell<R, SR>({
           {column.formatter({
             column,
             row,
-            rowIdx,
             isCellSelected,
             onRowChange: handleRowChange
           })}

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -55,7 +55,7 @@ function Cell<R, SR>({
   );
 
   function selectCellWrapper(openEditor?: boolean) {
-    selectCell(rowIdx, column, openEditor);
+    selectCell({ rowIdx, idx: column.idx }, openEditor);
   }
 
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -111,6 +111,7 @@ function Cell<R, SR>({
           {column.formatter({
             column,
             row,
+            rowIdx,
             isCellSelected,
             onRowChange: handleRowChange
           })}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -392,11 +392,7 @@ function DataGrid<R, SR, K extends Key>(
   const onCellContextMenuLatest = useLatestFunc(onCellContextMenu);
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
-  const selectCellLatest = useLatestFunc(
-    (rowIdx, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
-      selectCell({ rowIdx, idx: column.idx }, enableEditor);
-    }
-  );
+  const selectCellLatest = useLatestFunc(selectCell);
   const selectGroupLatest = useLatestFunc((rowIdx: number) => {
     selectCell({ rowIdx, idx: -1 });
   });

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -392,7 +392,11 @@ function DataGrid<R, SR, K extends Key>(
   const onCellContextMenuLatest = useLatestFunc(onCellContextMenu);
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
-  const selectCellLatest = useLatestFunc(selectCell);
+  const selectCellLatest = useLatestFunc(
+    (rowIdx: number, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
+      selectCell({ rowIdx, idx: column.idx }, enableEditor);
+    }
+  );
   const selectGroupLatest = useLatestFunc((rowIdx: number) => {
     selectCell({ rowIdx, idx: -1 });
   });

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -987,9 +987,6 @@ function DataGrid<R, SR, K extends Key>(
         //
         // Otherwise commitEditorChanges may be called before the cell state is changed to
         // SELECT and this results in onRowChange getting called twice.
-        //
-        // Sometimes rows prop is changed before selectCell is called and this results in
-        // rows.indexOf(row) returning -1 so incorrect cell gets selected
         flushSync(() => {
           updateRow(column, selectedPosition.rowIdx, row);
           closeEditor();

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1261,7 +1261,7 @@ function DataGrid<R, SR, K extends Key>(
                 <SummaryRow
                   aria-rowindex={gridRowStart}
                   key={rowIdx}
-                  rowIdx={rowIdx}
+                  rowIdx={summaryRowIdx}
                   gridRowStart={gridRowStart}
                   row={row}
                   top={top}
@@ -1294,7 +1294,7 @@ function DataGrid<R, SR, K extends Key>(
                 <SummaryRow
                   aria-rowindex={headerAndTopSummaryRowsCount + rowsCount + rowIdx + 1}
                   key={rowIdx}
-                  rowIdx={rowIdx}
+                  rowIdx={summaryRowIdx}
                   gridRowStart={gridRowStart}
                   row={row}
                   top={top}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -392,11 +392,7 @@ function DataGrid<R, SR, K extends Key>(
   const onCellContextMenuLatest = useLatestFunc(onCellContextMenu);
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
-  const selectCellLatest = useLatestFunc(
-    (rowIdx: number, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
-      selectCell({ rowIdx, idx: column.idx }, enableEditor);
-    }
-  );
+  const selectCellLatest = useLatestFunc(selectCell);
   const selectGroupLatest = useLatestFunc((rowIdx: number) => {
     selectCell({ rowIdx, idx: -1 });
   });

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -393,8 +393,7 @@ function DataGrid<R, SR, K extends Key>(
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
   const selectViewportCellLatest = useLatestFunc(
-    (row: R, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
-      const rowIdx = rows.indexOf(row);
+    (rowIdx, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
       selectCell({ rowIdx, idx: column.idx }, enableEditor);
     }
   );

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -392,7 +392,7 @@ function DataGrid<R, SR, K extends Key>(
   const onCellContextMenuLatest = useLatestFunc(onCellContextMenu);
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
-  const selectViewportCellLatest = useLatestFunc(
+  const selectCellLatest = useLatestFunc(
     (rowIdx, column: CalculatedColumn<R, SR>, enableEditor: Maybe<boolean>) => {
       selectCell({ rowIdx, idx: column.idx }, enableEditor);
     }
@@ -403,18 +403,6 @@ function DataGrid<R, SR, K extends Key>(
   const selectHeaderCellLatest = useLatestFunc((idx: number) => {
     selectCell({ rowIdx: minRowIdx, idx });
   });
-  const selectTopSummaryCellLatest = useLatestFunc(
-    (summaryRow: SR, column: CalculatedColumn<R, SR>) => {
-      const rowIdx = topSummaryRows!.indexOf(summaryRow);
-      selectCell({ rowIdx: rowIdx + minRowIdx + 1, idx: column.idx });
-    }
-  );
-  const selectBottomSummaryCellLatest = useLatestFunc(
-    (summaryRow: SR, column: CalculatedColumn<R, SR>) => {
-      const rowIdx = bottomSummaryRows!.indexOf(summaryRow) + rows.length;
-      selectCell({ rowIdx, idx: column.idx });
-    }
-  );
   const toggleGroupLatest = useLatestFunc(toggleGroup);
 
   /**
@@ -1155,7 +1143,7 @@ function DataGrid<R, SR, K extends Key>(
           setDraggedOverRowIdx: isDragging ? setDraggedOverRowIdx : undefined,
           lastFrozenColumnIndex,
           onRowChange: handleFormatterRowChangeLatest,
-          selectCell: selectViewportCellLatest,
+          selectCell: selectCellLatest,
           selectedCellDragHandle: getDragHandle(rowIdx),
           selectedCellEditor: getCellEditor(rowIdx),
           skipCellFocusRef
@@ -1285,7 +1273,7 @@ function DataGrid<R, SR, K extends Key>(
                   viewportColumns={getRowViewportColumns(summaryRowIdx)}
                   lastFrozenColumnIndex={lastFrozenColumnIndex}
                   selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
-                  selectCell={selectTopSummaryCellLatest}
+                  selectCell={selectCellLatest}
                 />
               );
             })}
@@ -1318,7 +1306,7 @@ function DataGrid<R, SR, K extends Key>(
                   viewportColumns={getRowViewportColumns(summaryRowIdx)}
                   lastFrozenColumnIndex={lastFrozenColumnIndex}
                   selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
-                  selectCell={selectBottomSummaryCellLatest}
+                  selectCell={selectCellLatest}
                 />
               );
             })}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1261,7 +1261,7 @@ function DataGrid<R, SR, K extends Key>(
                 <SummaryRow
                   aria-rowindex={gridRowStart}
                   key={rowIdx}
-                  rowIdx={rowIdx}
+                  rowIdx={summaryRowIdx}
                   gridRowStart={gridRowStart}
                   row={row}
                   top={top}
@@ -1295,7 +1295,7 @@ function DataGrid<R, SR, K extends Key>(
                 <SummaryRow
                   aria-rowindex={headerAndTopSummaryRowsCount + rowsCount + rowIdx + 1}
                   key={rowIdx}
-                  rowIdx={rowIdx}
+                  rowIdx={summaryRowIdx}
                   gridRowStart={gridRowStart}
                   row={row}
                   top={top}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1261,15 +1261,16 @@ function DataGrid<R, SR, K extends Key>(
                 <SummaryRow
                   aria-rowindex={gridRowStart}
                   key={rowIdx}
-                  rowIdx={summaryRowIdx}
+                  rowIdx={rowIdx}
                   gridRowStart={gridRowStart}
                   row={row}
                   top={top}
                   bottom={undefined}
-                  lastTopRowIdx={topSummaryRowsCount - 1}
                   viewportColumns={getRowViewportColumns(summaryRowIdx)}
                   lastFrozenColumnIndex={lastFrozenColumnIndex}
                   selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
+                  isTop
+                  showBorder={rowIdx === topSummaryRowsCount - 1}
                   selectCell={selectCellLatest}
                 />
               );
@@ -1294,15 +1295,16 @@ function DataGrid<R, SR, K extends Key>(
                 <SummaryRow
                   aria-rowindex={headerAndTopSummaryRowsCount + rowsCount + rowIdx + 1}
                   key={rowIdx}
-                  rowIdx={summaryRowIdx}
+                  rowIdx={rowIdx}
                   gridRowStart={gridRowStart}
                   row={row}
                   top={top}
                   bottom={bottom}
-                  lastTopRowIdx={undefined}
                   viewportColumns={getRowViewportColumns(summaryRowIdx)}
                   lastFrozenColumnIndex={lastFrozenColumnIndex}
                   selectedCellIdx={isSummaryRowSelected ? selectedPosition.idx : undefined}
+                  isTop={false}
+                  showBorder={rowIdx === 0}
                   selectCell={selectCellLatest}
                 />
               );

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -155,7 +155,7 @@ export default function EditCell<R, SR>({
             onClose
           })}
           {column.editorOptions?.renderFormatter &&
-            column.formatter({ column, row, rowIdx, isCellSelected: true, onRowChange })}
+            column.formatter({ column, row, isCellSelected: true, onRowChange })}
         </>
       )}
     </div>

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -155,7 +155,7 @@ export default function EditCell<R, SR>({
             onClose
           })}
           {column.editorOptions?.renderFormatter &&
-            column.formatter({ column, row, isCellSelected: true, onRowChange })}
+            column.formatter({ column, row, rowIdx, isCellSelected: true, onRowChange })}
         </>
       )}
     </div>

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -75,6 +75,7 @@ function Row<R, SR>(
           column={column}
           colSpan={colSpan}
           row={row}
+          rowIdx={rowIdx}
           isCopied={copiedCellIdx === idx}
           isDraggedOver={draggedOverCellIdx === idx}
           isCellSelected={isCellSelected}

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -54,7 +54,7 @@ function SummaryCell<R, SR>({
       onClick={onClick}
       onFocus={onFocus}
     >
-      {column.summaryFormatter?.({ column, row, rowIdx, isCellSelected })}
+      {column.summaryFormatter?.({ column, row, isCellSelected })}
     </div>
   );
 }

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -12,10 +12,10 @@ export const summaryCellClassname = css`
   }
 `;
 
-interface SharedCellRendererProps<R, SR>
-  extends Pick<CellRendererProps<R, SR>, 'column' | 'colSpan' | 'isCellSelected'> {
-  selectCell: (row: SR, column: CalculatedColumn<R, SR>) => void;
-}
+type SharedCellRendererProps<R, SR> = Pick<
+  CellRendererProps<R, SR>,
+  'rowIdx' | 'column' | 'colSpan' | 'isCellSelected' | 'selectCell'
+>;
 
 interface SummaryCellProps<R, SR> extends SharedCellRendererProps<R, SR> {
   row: SR;
@@ -25,6 +25,7 @@ function SummaryCell<R, SR>({
   column,
   colSpan,
   row,
+  rowIdx,
   isCellSelected,
   selectCell
 }: SummaryCellProps<R, SR>) {
@@ -37,7 +38,7 @@ function SummaryCell<R, SR>({
   );
 
   function onClick() {
-    selectCell(row, column);
+    selectCell(rowIdx, column);
   }
 
   return (
@@ -53,7 +54,7 @@ function SummaryCell<R, SR>({
       onClick={onClick}
       onFocus={onFocus}
     >
-      {column.summaryFormatter?.({ column, row, isCellSelected })}
+      {column.summaryFormatter?.({ column, row, rowIdx, isCellSelected })}
     </div>
   );
 }

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { css } from '@linaria/core';
 
 import { getCellStyle, getCellClassname } from './utils';
-import type { CalculatedColumn, CellRendererProps } from './types';
+import type { CellRendererProps } from './types';
 import { useRovingCellRef } from './hooks';
 
 export const summaryCellClassname = css`

--- a/src/SummaryCell.tsx
+++ b/src/SummaryCell.tsx
@@ -38,7 +38,7 @@ function SummaryCell<R, SR>({
   );
 
   function onClick() {
-    selectCell(rowIdx, column);
+    selectCell({ rowIdx, idx: column.idx });
   }
 
   return (

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -44,7 +44,7 @@ const topSummaryRow = css`
   }
 `;
 
-const topSummaryRowBorderClassname = css`
+export const topSummaryRowBorderClassname = css`
   @layer rdg.SummaryRow {
     > .${cell} {
       border-block-end: 2px solid var(--rdg-summary-border-color);
@@ -52,7 +52,7 @@ const topSummaryRowBorderClassname = css`
   }
 `;
 
-const bottomSummaryRowBorderClassname = css`
+export const bottomSummaryRowBorderClassname = css`
   @layer rdg.SummaryRow {
     > .${cell} {
       border-block-start: 2px solid var(--rdg-summary-border-color);

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -5,11 +5,11 @@ import { css } from '@linaria/core';
 import { cell, cellFrozen, rowClassname, rowSelectedClassname } from './style';
 import { getColSpan, getRowStyle } from './utils';
 import SummaryCell from './SummaryCell';
-import type { CalculatedColumn, RowRendererProps } from './types';
+import type { RowRendererProps } from './types';
 
 type SharedRowRendererProps<R, SR> = Pick<
   RowRendererProps<R, SR>,
-  'viewportColumns' | 'rowIdx' | 'gridRowStart'
+  'viewportColumns' | 'rowIdx' | 'gridRowStart' | 'selectCell'
 >;
 
 interface SummaryRowProps<R, SR> extends SharedRowRendererProps<R, SR> {
@@ -20,7 +20,6 @@ interface SummaryRowProps<R, SR> extends SharedRowRendererProps<R, SR> {
   lastFrozenColumnIndex: number;
   selectedCellIdx: number | undefined;
   lastTopRowIdx: number | undefined;
-  selectCell: (row: SR, column: CalculatedColumn<R, SR>) => void;
 }
 
 const summaryRow = css`
@@ -94,6 +93,7 @@ function SummaryRow<R, SR>({
         column={column}
         colSpan={colSpan}
         row={row}
+        rowIdx={rowIdx}
         isCellSelected={isCellSelected}
         selectCell={selectCell}
       />

--- a/src/SummaryRow.tsx
+++ b/src/SummaryRow.tsx
@@ -19,7 +19,8 @@ interface SummaryRowProps<R, SR> extends SharedRowRendererProps<R, SR> {
   bottom: number | undefined;
   lastFrozenColumnIndex: number;
   selectedCellIdx: number | undefined;
-  lastTopRowIdx: number | undefined;
+  isTop: boolean;
+  showBorder: boolean;
 }
 
 const summaryRow = css`
@@ -73,7 +74,8 @@ function SummaryRow<R, SR>({
   bottom,
   lastFrozenColumnIndex,
   selectedCellIdx,
-  lastTopRowIdx,
+  isTop,
+  showBorder,
   selectCell,
   'aria-rowindex': ariaRowIndex
 }: SummaryRowProps<R, SR>) {
@@ -100,8 +102,6 @@ function SummaryRow<R, SR>({
     );
   }
 
-  const isTop = lastTopRowIdx !== undefined;
-
   return (
     <div
       role="row"
@@ -113,8 +113,8 @@ function SummaryRow<R, SR>({
         {
           [rowSelectedClassname]: selectedCellIdx === -1,
           [topSummaryRowClassname]: isTop,
-          [topSummaryRowBorderClassname]: isTop && lastTopRowIdx === rowIdx,
-          [bottomSummaryRowBorderClassname]: !isTop && rowIdx === 0,
+          [topSummaryRowBorderClassname]: isTop && showBorder,
+          [bottomSummaryRowBorderClassname]: !isTop && showBorder,
           'rdg-bottom-summary-row': !isTop
         }
       )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface Position {
 export interface FormatterProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TRow;
+  rowIdx: number;
   isCellSelected: boolean;
   onRowChange: (row: TRow) => void;
 }
@@ -77,6 +78,7 @@ export interface FormatterProps<TRow, TSummaryRow = unknown> {
 export interface SummaryFormatterProps<TSummaryRow, TRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TSummaryRow;
+  rowIdx: number;
   isCellSelected: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,14 +106,16 @@ export interface HeaderRendererProps<TRow, TSummaryRow = unknown> {
 }
 
 export interface CellRendererProps<TRow, TSummaryRow>
-  extends Pick<RowRendererProps<TRow, TSummaryRow>, 'selectCell' | 'skipCellFocusRef'>,
+  extends Pick<
+      RowRendererProps<TRow, TSummaryRow>,
+      'row' | 'rowIdx' | 'selectCell' | 'skipCellFocusRef'
+    >,
     Omit<
       React.HTMLAttributes<HTMLDivElement>,
       'style' | 'children' | 'onClick' | 'onDoubleClick' | 'onContextMenu'
     > {
   column: CalculatedColumn<TRow, TSummaryRow>;
   colSpan: number | undefined;
-  row: TRow;
   isCopied: boolean;
   isDraggedOver: boolean;
   isCellSelected: boolean;
@@ -183,7 +185,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
   rowClass: Maybe<(row: TRow) => Maybe<string>>;
   setDraggedOverRowIdx: ((overRowIdx: number) => void) | undefined;
   selectCell: (
-    row: TRow,
+    rowIdx: number,
     column: CalculatedColumn<TRow, TSummaryRow>,
     enableEditor?: Maybe<boolean>
   ) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,11 +184,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
   onRowChange: (column: CalculatedColumn<TRow, TSummaryRow>, rowIdx: number, newRow: TRow) => void;
   rowClass: Maybe<(row: TRow) => Maybe<string>>;
   setDraggedOverRowIdx: ((overRowIdx: number) => void) | undefined;
-  selectCell: (
-    rowIdx: number,
-    column: CalculatedColumn<TRow, TSummaryRow>,
-    enableEditor?: Maybe<boolean>
-  ) => void;
+  selectCell: (position: Position, enableEditor?: Maybe<boolean>) => void;
 }
 
 export interface RowsChangeData<R, SR = unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,6 @@ export interface Position {
 export interface FormatterProps<TRow, TSummaryRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TRow;
-  rowIdx: number;
   isCellSelected: boolean;
   onRowChange: (row: TRow) => void;
 }
@@ -78,7 +77,6 @@ export interface FormatterProps<TRow, TSummaryRow = unknown> {
 export interface SummaryFormatterProps<TSummaryRow, TRow = unknown> {
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TSummaryRow;
-  rowIdx: number;
   isCellSelected: boolean;
 }
 

--- a/test/column/summaryFormatter.test.tsx
+++ b/test/column/summaryFormatter.test.tsx
@@ -1,5 +1,9 @@
 import type { Column } from '../../src';
-import { setup, getCells } from '../utils';
+import {
+  bottomSummaryRowBorderClassname,
+  topSummaryRowBorderClassname
+} from '../../src/SummaryRow';
+import { setup, getCells, getRows } from '../utils';
 
 interface SummaryRow {
   id: number;
@@ -46,4 +50,14 @@ test('summaryFormatter', () => {
   expect(cells[3]).toBeEmptyDOMElement();
   expect(cells[5]).toBeEmptyDOMElement();
   expect(cells[7]).toBeEmptyDOMElement();
+
+  const rows = getRows();
+  expect(rows[0]).not.toHaveClass(topSummaryRowBorderClassname);
+  expect(rows[0]).not.toHaveClass(bottomSummaryRowBorderClassname);
+  expect(rows[1]).toHaveClass(topSummaryRowBorderClassname);
+  expect(rows[1]).not.toHaveClass(bottomSummaryRowBorderClassname);
+  expect(rows[2]).toHaveClass(bottomSummaryRowBorderClassname);
+  expect(rows[2]).not.toHaveClass(topSummaryRowBorderClassname);
+  expect(rows[3]).not.toHaveClass(bottomSummaryRowBorderClassname);
+  expect(rows[3]).not.toHaveClass(topSummaryRowBorderClassname);
 });


### PR DESCRIPTION
Sometimes `rows` prop is changed before `selectCell` is called. This results in `rows.indexOf(row)` returning -1 and incorrect cell gets selected.