### PR TITLE
Allow rowClass to be applied positionally by row index.

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -179,7 +179,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * Miscellaneous
    */
   renderers?: Maybe<Renderers<R, SR>>;
-  rowClass?: Maybe<(row: R) => Maybe<string>>;
+  rowClass?: Maybe<(row: R, rowIdx: number) => Maybe<string>>;
   /** @default 'ltr' */
   direction?: Maybe<Direction>;
   'data-testid'?: Maybe<string>;

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -50,7 +50,7 @@ function Row<R, SR>(
     {
       [rowSelectedClassname]: selectedCellIdx === -1
     },
-    rowClass?.(row),
+    rowClass?.(row, rowIdx),
     className
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,7 @@ export interface RowRendererProps<TRow, TSummaryRow = unknown>
   selectedCellDragHandle: ReactElement<React.HTMLAttributes<HTMLDivElement>> | undefined;
   skipCellFocusRef: MutableRefObject<boolean>;
   onRowChange: (column: CalculatedColumn<TRow, TSummaryRow>, rowIdx: number, newRow: TRow) => void;
-  rowClass: Maybe<(row: TRow) => Maybe<string>>;
+  rowClass: Maybe<(row: TRow, rowIdx: number) => Maybe<string>>;
   setDraggedOverRowIdx: ((overRowIdx: number) => void) | undefined;
   selectCell: (position: Position, enableEditor?: Maybe<boolean>) => void;
 }

--- a/website/demos/AllFeatures.tsx
+++ b/website/demos/AllFeatures.tsx
@@ -213,7 +213,7 @@ export default function AllFeatures({ direction }: Props) {
       selectedRows={selectedRows}
       onSelectedRowsChange={setSelectedRows}
       className="fill-grid"
-      rowClass={(row) => (row.id.includes('7') ? highlightClassname : undefined)}
+      rowClass={(row, index) => (row.id.includes('7') || index === 0 ? highlightClassname : undefined)}
       direction={direction}
       onCellClick={(args, event) => {
         if (args.column.key === 'title') {

--- a/website/demos/AllFeatures.tsx
+++ b/website/demos/AllFeatures.tsx
@@ -213,7 +213,9 @@ export default function AllFeatures({ direction }: Props) {
       selectedRows={selectedRows}
       onSelectedRowsChange={setSelectedRows}
       className="fill-grid"
-      rowClass={(row, index) => (row.id.includes('7') || index === 0 ? highlightClassname : undefined)}
+      rowClass={(row, index) =>
+        row.id.includes('7') || index === 0 ? highlightClassname : undefined
+      }
       direction={direction}
       onCellClick={(args, event) => {
         if (args.column.key === 'title') {


### PR DESCRIPTION
This pull request allows rowClass to send an additional parameter `row index`, this will allow classes to be added positionally. The current capability of adding classes by looking at the values will continue to work with no breaking changes.
    
An example of adding rowClass based on row index has been added to the AllFeatures demo.

Previous to this change I had to use a css pseudo class like .rdg-row:nth-child(14) to make the 14th row have a certain css behavior. And was unable to get the last row to have a css class as I could not get nth-last-child or last-child to work.

@amanmahajan7 @nstepien , please let me know if anything else needs to be updated as I am happy to make changes.
Thank you for your work on this great component!