### PR TITLE
useColumnWidths: trigger fewer re-renders when resizing columns

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -375,7 +375,7 @@ function DataGrid<R, SR, K extends Key>(
     isGroupRow
   });
 
-  const { handleColumnResize, getGridTemplateColumns } = useColumnWidths(
+  const { gridTemplateColumns, handleColumnResize } = useColumnWidths(
     columns,
     viewportColumns,
     templateColumns,
@@ -1148,7 +1148,7 @@ function DataGrid<R, SR, K extends Key>(
                   bottomSummaryRowsCount * summaryRowHeight
                 }px`
               : undefined,
-          gridTemplateColumns: getGridTemplateColumns(),
+          gridTemplateColumns,
           gridTemplateRows: templateRows,
           '--rdg-header-row-height': `${headerRowHeight}px`,
           '--rdg-summary-row-height': `${summaryRowHeight}px`,

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -41,13 +41,12 @@ export function useColumnWidths<R, SR>(
 
   useLayoutEffect(() => {
     prevGridWidthRef.current = gridWidth;
-
-    if (columnsToMeasure.length === 0) return;
-
     updateMeasuredWidths(columnsToMeasure);
   });
 
   function updateMeasuredWidths(columnsToMeasure: readonly string[]) {
+    if (columnsToMeasure.length === 0) return;
+
     setMeasuredColumnWidths((measuredColumnWidths) => {
       const newMeasuredColumnWidths = new Map(measuredColumnWidths);
       let hasChanges = false;

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -84,7 +84,8 @@ export function useColumnWidths<R, SR>(
     }
 
     gridRef.current!.style.gridTemplateColumns = newTemplateColumns.join(' ');
-    const measuredWidth = measureColumnWidth(gridRef, resizingKey)!;
+    const measuredWidth =
+      typeof nextWidth === 'number' ? nextWidth : measureColumnWidth(gridRef, resizingKey)!;
 
     // TODO: remove
     // need flushSync to keep frozen column offsets in sync

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { flushSync } from 'react-dom';
 
 import type { CalculatedColumn, StateSetter } from '../types';
@@ -17,120 +17,98 @@ export function useColumnWidths<R, SR>(
   setMeasuredColumnWidths: StateSetter<ReadonlyMap<string, number>>,
   onColumnResize: DataGridProps<R, SR>['onColumnResize']
 ) {
-  const [autoResizeColumn, setAutoResizeColumn] = useState<CalculatedColumn<R, SR> | null>(null);
   const prevGridWidthRef = useRef(gridWidth);
   const columnsCanFlex: boolean = columns.length === viewportColumns.length;
   // Allow columns to flex again when...
   const ignorePreviouslyMeasuredColumns: boolean =
-    // there is enough space for columns to flex and...
-    columnsCanFlex &&
-    // the grid has resized, or a column is being `max-content`-sized.
-    (gridWidth !== prevGridWidthRef.current || autoResizeColumn !== null);
+    // there is enough space for columns to flex and the grid was resized
+    columnsCanFlex && gridWidth !== prevGridWidthRef.current;
+  const newTemplateColumns = [...templateColumns];
+  const columnsToMeasure: string[] = [];
 
-  const columnsToMeasure = viewportColumns.filter(
-    ({ key, width }) =>
-      !resizedColumnWidths.has(key) &&
-      (ignorePreviouslyMeasuredColumns || !measuredColumnWidths.has(key)) &&
+  for (const column of viewportColumns) {
+    const { key, idx, width } = column;
+
+    if (
       typeof width === 'string' &&
-      key !== autoResizeColumn?.key
-  );
+      (ignorePreviouslyMeasuredColumns || !measuredColumnWidths.has(key)) &&
+      !resizedColumnWidths.has(key)
+    ) {
+      newTemplateColumns[idx] = width;
+      columnsToMeasure.push(key);
+    }
+  }
+
+  const gridTemplateColumns = newTemplateColumns.join(' ');
 
   useLayoutEffect(() => {
     prevGridWidthRef.current = gridWidth;
 
     if (columnsToMeasure.length === 0) return;
 
+    updateMeasuredWiths(columnsToMeasure);
+  });
+
+  function updateMeasuredWiths(columnsToMeasure: readonly string[]) {
     setMeasuredColumnWidths((measuredColumnWidths) => {
       const newMeasuredColumnWidths = new Map(measuredColumnWidths);
       let hasChanges = false;
 
-      for (const { key } of columnsToMeasure) {
+      for (const key of columnsToMeasure) {
         const measuredWidth = measureColumnWidth(gridRef, key);
         hasChanges ||= measuredWidth !== measuredColumnWidths.get(key);
-        newMeasuredColumnWidths.set(key, measuredWidth);
+        if (measuredWidth === undefined) {
+          newMeasuredColumnWidths.delete(key);
+        } else {
+          newMeasuredColumnWidths.set(key, measuredWidth);
+        }
       }
 
       return hasChanges ? newMeasuredColumnWidths : measuredColumnWidths;
     });
-  });
-
-  function resetMeasuredColumnWidths() {
-    if (!columnsCanFlex) return;
-
-    setMeasuredColumnWidths((measuredColumnWidths) => {
-      const newMeasuredColumnWidths = new Map(measuredColumnWidths);
-      for (const column of columns) {
-        if (!resizedColumnWidths.has(column.key) && typeof column.width === 'string') {
-          newMeasuredColumnWidths.delete(column.key);
-        }
-      }
-      return newMeasuredColumnWidths;
-    });
   }
 
-  function handleColumnResize(column: CalculatedColumn<R, SR>, width: number | 'max-content') {
-    const { key, idx } = column;
+  function handleColumnResize(column: CalculatedColumn<R, SR>, nextWidth: number | 'max-content') {
+    const { key: resizingKey } = column;
+    const newTemplateColumns = [...templateColumns];
+    const columnsToMeasure: string[] = [];
 
-    if (width === 'max-content') {
-      flushSync(() => {
-        // Clear resized and measured width of the resized column
-        setResizedColumnWidths((resizedColumnWidths) => {
-          const newResizedColumnWidths = new Map(resizedColumnWidths);
-          newResizedColumnWidths.delete(key);
-          return newResizedColumnWidths;
-        });
-        setMeasuredColumnWidths((measuredColumnWidths) => {
-          const newMeasuredColumnWidths = new Map(measuredColumnWidths);
-          newMeasuredColumnWidths.delete(key);
-          return newMeasuredColumnWidths;
-        });
-        setAutoResizeColumn(column);
-      });
+    for (const { key, idx, width } of viewportColumns) {
+      if (resizingKey === key) {
+        const width = typeof nextWidth === 'number' ? `${nextWidth}px` : nextWidth;
+        newTemplateColumns[idx] = width;
+      } else if (columnsCanFlex && typeof width === 'string' && !resizedColumnWidths.has(key)) {
+        newTemplateColumns[idx] = width;
+        columnsToMeasure.push(key);
+      }
+    }
 
-      const measuredWidth = measureColumnWidth(gridRef, key);
+    gridRef.current!.style.gridTemplateColumns = newTemplateColumns.join(' ');
+    const measuredWidth = measureColumnWidth(gridRef, resizingKey)!;
 
+    // TODO: remove
+    // need flushSync to keep frozen column offsets in sync
+    // we may be able to use `startTransition` or even `requestIdleCallback` instead
+    flushSync(() => {
       setResizedColumnWidths((resizedColumnWidths) => {
         const newResizedColumnWidths = new Map(resizedColumnWidths);
-        newResizedColumnWidths.set(key, measuredWidth);
+        newResizedColumnWidths.set(resizingKey, measuredWidth);
         return newResizedColumnWidths;
       });
-
-      setAutoResizeColumn(null);
-      onColumnResize?.(idx, measuredWidth);
-      return;
-    }
-
-    resetMeasuredColumnWidths();
-    setResizedColumnWidths((resizedColumnWidths) => {
-      const newResizedColumnWidths = new Map(resizedColumnWidths);
-      newResizedColumnWidths.set(key, width);
-      return newResizedColumnWidths;
+      updateMeasuredWiths(columnsToMeasure);
     });
 
-    onColumnResize?.(idx, width);
-  }
-
-  function getGridTemplateColumns() {
-    const newTemplateColumns = [...templateColumns];
-    for (const column of columnsToMeasure) {
-      newTemplateColumns[column.idx] = column.width as string;
-    }
-
-    if (autoResizeColumn !== null) {
-      newTemplateColumns[autoResizeColumn.idx] = 'max-content';
-    }
-
-    return newTemplateColumns.join(' ');
+    onColumnResize?.(column.idx, measuredWidth);
   }
 
   return {
-    handleColumnResize,
-    getGridTemplateColumns
+    gridTemplateColumns,
+    handleColumnResize
   } as const;
 }
 
 function measureColumnWidth(gridRef: React.RefObject<HTMLDivElement>, key: string) {
   const selector = `[data-measuring-cell-key="${CSS.escape(key)}"]`;
-  const measuringCell = gridRef.current!.querySelector(selector)!;
-  return measuringCell.getBoundingClientRect().width;
+  const measuringCell = gridRef.current!.querySelector(selector);
+  return measuringCell?.getBoundingClientRect().width;
 }

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -46,10 +46,10 @@ export function useColumnWidths<R, SR>(
 
     if (columnsToMeasure.length === 0) return;
 
-    updateMeasuredWiths(columnsToMeasure);
+    updateMeasuredWidths(columnsToMeasure);
   });
 
-  function updateMeasuredWiths(columnsToMeasure: readonly string[]) {
+  function updateMeasuredWidths(columnsToMeasure: readonly string[]) {
     setMeasuredColumnWidths((measuredColumnWidths) => {
       const newMeasuredColumnWidths = new Map(measuredColumnWidths);
       let hasChanges = false;
@@ -96,7 +96,7 @@ export function useColumnWidths<R, SR>(
         newResizedColumnWidths.set(resizingKey, measuredWidth);
         return newResizedColumnWidths;
       });
-      updateMeasuredWiths(columnsToMeasure);
+      updateMeasuredWidths(columnsToMeasure);
     });
 
     onColumnResize?.(column.idx, measuredWidth);

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -26,9 +26,7 @@ export function useColumnWidths<R, SR>(
   const newTemplateColumns = [...templateColumns];
   const columnsToMeasure: string[] = [];
 
-  for (const column of viewportColumns) {
-    const { key, idx, width } = column;
-
+  for (const { key, idx, width } of viewportColumns) {
     if (
       typeof width === 'string' &&
       (ignorePreviouslyMeasuredColumns || !measuredColumnWidths.has(key)) &&


### PR DESCRIPTION
We may be able to adopt a similar strategy to update `grid-template-columns` when the grid resizes, would need some more refactoring though. Not as important IMO anyway.