### PR TITLE
Include KeyboardEvent to onCopy and onPaste callbacks

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -543,11 +543,11 @@ function DataGrid<R, SR, K extends Key>(
       const cKey = 67;
       const vKey = 86;
       if (keyCode === cKey) {
-        handleCopy();
+        handleCopy(event);
         return;
       }
       if (keyCode === vKey) {
-        handlePaste();
+        handlePaste(event);
         return;
       }
     }
@@ -599,15 +599,15 @@ function DataGrid<R, SR, K extends Key>(
     updateRow(columns[selectedPosition.idx], selectedPosition.rowIdx, selectedPosition.row);
   }
 
-  function handleCopy() {
+  function handleCopy(event: KeyboardEvent<HTMLDivElement>) {
     const { idx, rowIdx } = selectedPosition;
     const sourceRow = rows[rowIdx];
     const sourceColumnKey = columns[idx].key;
     setCopiedCell({ row: sourceRow, columnKey: sourceColumnKey });
-    onCopy?.({ sourceRow, sourceColumnKey });
+    onCopy?.({ event, sourceRow, sourceColumnKey });
   }
 
-  function handlePaste() {
+  function handlePaste(event: KeyboardEvent<HTMLDivElement>) {
     if (!onPaste || !onRowsChange || copiedCell === null || !isCellEditable(selectedPosition)) {
       return;
     }
@@ -617,6 +617,7 @@ function DataGrid<R, SR, K extends Key>(
     const targetRow = rows[rowIdx];
 
     const updatedTargetRow = onPaste({
+      event,
       sourceRow: copiedCell.row,
       sourceColumnKey: copiedCell.columnKey,
       targetRow,

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,11 +212,13 @@ export interface FillEvent<TRow> {
 }
 
 export interface CopyEvent<TRow> {
+  event: React.KeyboardEvent<HTMLDivElement>;
   sourceColumnKey: string;
   sourceRow: TRow;
 }
 
 export interface PasteEvent<TRow> {
+  event: React.KeyboardEvent<HTMLDivElement>;
   sourceColumnKey: string;
   sourceRow: TRow;
   targetColumnKey: string;


### PR DESCRIPTION
Users may need to stop propagation or prevent default or otherwise utilize the source event

There is a bug where I have a cell  renderer with a button which opens a modal and shows another table in the modal. The `onCopy` event is fired in the table from the modal then fired again from the base table, so the base table is what gets added to the clipboard.

Having the ability to `stopPropagation` and `preventDefault` solve this issue by making sure that the event does not get fired on both tables.