### PR TITLE
feat: scrolling uses smooth transition effects by default

### DIFF
--- a/src/ScrollToCell.tsx
+++ b/src/ScrollToCell.tsx
@@ -11,18 +11,20 @@ export interface PartialPosition {
 export default function ScrollToCell({
   scrollToPosition: { idx, rowIdx },
   gridElement,
-  setScrollToCellPosition
+  setScrollToCellPosition,
+  scrollIntoViewOptions
 }: {
   scrollToPosition: PartialPosition;
   gridElement: HTMLDivElement;
   setScrollToCellPosition: (cell: null) => void;
+  scrollIntoViewOptions?: boolean | ScrollIntoViewOptions | undefined;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     // scroll until the cell is completely visible
     // this is needed if the grid has auto-sized columns
-    scrollIntoView(ref.current);
+    scrollIntoView(ref.current, scrollIntoViewOptions);
   });
 
   useLayoutEffect(() => {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -4,6 +4,15 @@ export function stopPropagation(event: React.SyntheticEvent) {
   event.stopPropagation();
 }
 
-export function scrollIntoView(element: Maybe<Element>) {
-  element?.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' });
+export function scrollIntoView(
+  element: Maybe<Element>,
+  coverOptions?: boolean | ScrollIntoViewOptions
+) {
+  let options: boolean | ScrollIntoViewOptions = { inline: 'nearest', block: 'nearest' };
+  if (typeof coverOptions === 'boolean') {
+    options = coverOptions;
+  } else if(typeof coverOptions === 'object') {
+    options = Object.assign(options, coverOptions);
+  }
+  element?.scrollIntoView(options);
 }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -5,5 +5,5 @@ export function stopPropagation(event: React.SyntheticEvent) {
 }
 
 export function scrollIntoView(element: Maybe<Element>) {
-  element?.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+  element?.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' });
 }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -8,11 +8,13 @@ export function scrollIntoView(
   element: Maybe<Element>,
   coverOptions?: boolean | ScrollIntoViewOptions
 ) {
-  let options: boolean | ScrollIntoViewOptions = { inline: 'nearest', block: 'nearest' };
-  if (typeof coverOptions === 'boolean') {
-    options = coverOptions;
-  } else if(typeof coverOptions === 'object') {
-    options = Object.assign(options, coverOptions);
+  if(element?.scrollIntoView) {
+    let options: typeof coverOptions = { inline: 'nearest', block: 'nearest' };
+    if (typeof coverOptions === 'boolean') {
+      options = coverOptions;
+    } else if(typeof coverOptions === 'object') {
+      options = Object.assign(options, coverOptions);
+    }
+    element.scrollIntoView(options);
   }
-  element?.scrollIntoView(options);
 }

--- a/website/demos/ScrollToCell.tsx
+++ b/website/demos/ScrollToCell.tsx
@@ -41,7 +41,7 @@ export default function ScrollToCell({ direction }: Props) {
   }
 
   function scrollToCell() {
-    gridRef.current!.scrollToCell({ idx, rowIdx });
+    gridRef.current!.scrollToCell({ idx, rowIdx }, { behavior: 'smooth' }); // smooth transition
   }
 
   return (


### PR DESCRIPTION
Great open source project, I made some changes, want to make the scrolling default with transition animation, hope you can accept my PR, thanks in advance:

like: `7.0.0-beta.30` effect

https://github.com/adazzle/react-data-grid/assets/32004925/5e58c5b9-dd0d-4874-b056-cbd79ca2ecc6

