### PR TITLE
Fix `repository` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "react",
     "data grid"
   ],
-  "repository": "github:adazzle/react-data-grid",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adazzle/react-data-grid.git"
+  },
   "bugs": "https://github.com/adazzle/react-data-grid/issues",
   "type": "module",
   "exports": {


### PR DESCRIPTION
I got this when I did the last publish:
```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/adazzle/react-data-grid.git"
```
so I ran `npm pkg fix` and committed the changes