### PR TITLE
Add `onSelectedCellChange` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ A number defining the height of summary rows.
 
 ###### `onCellKeyDown?: Maybe<(args: CellKeyDownArgs<R, SR>, event: CellKeyboardEvent) => void>`
 
-###### `onCellSelected?: Maybe<(args: CellSelectArgs<R, SR>) => void>;`
+###### `onSelectedCellChange?: Maybe<(args: CellSelectArgs<R, SR>) => void>;`
 
 Triggered when a cell is selected by click, double click, right click, Page{Up|Down|Left|Right} key, Tab key, or any other actions.
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ A number defining the height of summary rows.
 
 ###### `onCellKeyDown?: Maybe<(args: CellKeyDownArgs<R, SR>, event: CellKeyboardEvent) => void>`
 
+###### `onCellSelected?: Maybe<(args: CellSelectArgs<R, SR>) => void>;`
+
+Triggered when a cell is selected by click, double click, right click, Page{Up|Down|Left|Right} key, Tab key, or any other actions.
+
+Arguments:
+
+- `args.idx`: `number` - column index
+- `args.rowIdx`: `number` - row index
+- `args.row`: `R` - row object of the currently selected cell
+- `args.column`: `CalculatedColumn<TRow, TSummaryRow>` - column object of the currently selected cell
+
 ###### `onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>`
 
 ###### `onColumnResize?: Maybe<(idx: number, width: number) => void>`

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ Triggered when the selected cell is changed.
 
 Arguments:
 
-- `args.idx`: `number` - column index
 - `args.rowIdx`: `number` - row index
 - `args.row`: `R` - row object of the currently selected cell
 - `args.column`: `CalculatedColumn<TRow, TSummaryRow>` - column object of the currently selected cell

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ A number defining the height of summary rows.
 
 ###### `onSelectedCellChange?: Maybe<(args: CellSelectArgs<R, SR>) => void>;`
 
-Triggered when a cell is selected by click, double click, right click, Page{Up|Down|Left|Right} key, Tab key, or any other actions.
+Triggered when the selected cell is changed.
 
 Arguments:
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -693,7 +693,6 @@ function DataGrid<R, SR, K extends Key>(
     commitEditorChanges();
 
     const row = rows[position.rowIdx];
-    const column = columns[position.idx];
     const samePosition = isSamePosition(selectedPosition, position);
 
     if (enableEditor && isCellEditable(position)) {
@@ -707,6 +706,7 @@ function DataGrid<R, SR, K extends Key>(
     }
 
     if (onCellSelected && !samePosition) {
+      const column = columns[position.idx];
       onCellSelected({
         idx: position.idx,
         rowIdx: position.rowIdx,

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -707,7 +707,6 @@ function DataGrid<R, SR, K extends Key>(
 
     if (onSelectedCellChange && !samePosition) {
       onSelectedCellChange({
-        idx: position.idx,
         rowIdx: position.rowIdx,
         row,
         column: columns[position.idx]

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -168,7 +168,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   onCellContextMenu?: Maybe<(args: CellClickArgs<R, SR>, event: CellMouseEvent) => void>;
   onCellKeyDown?: Maybe<(args: CellKeyDownArgs<R, SR>, event: CellKeyboardEvent) => void>;
   /** Function called whenever a cell is selected */
-  onCellSelected?: Maybe<(args: CellSelectArgs<R, SR>) => void>;
+  onSelectedCellChange?: Maybe<(args: CellSelectArgs<R, SR>) => void>;
   /** Called when the grid is scrolled */
   onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;
   /** Called when a column is resized */
@@ -224,7 +224,7 @@ function DataGrid<R, SR, K extends Key>(
     onCellDoubleClick,
     onCellContextMenu,
     onCellKeyDown,
-    onCellSelected,
+    onSelectedCellChange,
     onScroll,
     onColumnResize,
     onFill,
@@ -705,9 +705,9 @@ function DataGrid<R, SR, K extends Key>(
       setSelectedPosition({ ...position, mode: 'SELECT' });
     }
 
-    if (onCellSelected && !samePosition) {
+    if (onSelectedCellChange && !samePosition) {
       const column = columns[position.idx];
-      onCellSelected({
+      onSelectedCellChange({
         idx: position.idx,
         rowIdx: position.rowIdx,
         row,

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -167,7 +167,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   /** Function called whenever a cell is right clicked */
   onCellContextMenu?: Maybe<(args: CellClickArgs<R, SR>, event: CellMouseEvent) => void>;
   onCellKeyDown?: Maybe<(args: CellKeyDownArgs<R, SR>, event: CellKeyboardEvent) => void>;
-  /** Function called whenever a cell is selected */
+  /** Function called whenever cell selection is changed */
   onSelectedCellChange?: Maybe<(args: CellSelectArgs<R, SR>) => void>;
   /** Called when the grid is scrolled */
   onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -35,6 +35,7 @@ import type {
   CellKeyDownArgs,
   CellMouseEvent,
   CellNavigationMode,
+  CellSelectArgs,
   Column,
   ColumnOrColumnGroup,
   CopyEvent,
@@ -166,6 +167,8 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   /** Function called whenever a cell is right clicked */
   onCellContextMenu?: Maybe<(args: CellClickArgs<R, SR>, event: CellMouseEvent) => void>;
   onCellKeyDown?: Maybe<(args: CellKeyDownArgs<R, SR>, event: CellKeyboardEvent) => void>;
+  /** Function called whenever a cell is selected */
+  onCellSelected?: Maybe<(args: CellSelectArgs<R, SR>) => void>;
   /** Called when the grid is scrolled */
   onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;
   /** Called when a column is resized */
@@ -221,6 +224,7 @@ function DataGrid<R, SR, K extends Key>(
     onCellDoubleClick,
     onCellContextMenu,
     onCellKeyDown,
+    onCellSelected,
     onScroll,
     onColumnResize,
     onFill,
@@ -688,15 +692,27 @@ function DataGrid<R, SR, K extends Key>(
     if (!isCellWithinSelectionBounds(position)) return;
     commitEditorChanges();
 
+    const row = rows[position.rowIdx];
+    const column = columns[position.idx];
+    const samePosition = isSamePosition(selectedPosition, position);
+
     if (enableEditor && isCellEditable(position)) {
-      const row = rows[position.rowIdx];
       setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row });
-    } else if (isSamePosition(selectedPosition, position)) {
+    } else if (samePosition) {
       // Avoid re-renders if the selected cell state is the same
       scrollIntoView(getCellToScroll(gridRef.current!));
     } else {
       shouldFocusCellRef.current = true;
       setSelectedPosition({ ...position, mode: 'SELECT' });
+    }
+
+    if (onCellSelected && !samePosition) {
+      onCellSelected({
+        idx: position.idx,
+        rowIdx: position.rowIdx,
+        row,
+        column
+      });
     }
   }
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -706,12 +706,11 @@ function DataGrid<R, SR, K extends Key>(
     }
 
     if (onSelectedCellChange && !samePosition) {
-      const column = columns[position.idx];
       onSelectedCellChange({
         idx: position.idx,
         rowIdx: position.rowIdx,
         row,
-        column
+        column: columns[position.idx]
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,5 +39,6 @@ export type {
   CellMouseEvent,
   CellClickArgs,
   CellKeyDownArgs,
-  CellKeyboardEvent
+  CellKeyboardEvent,
+  CellSelectArgs
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,6 @@ export type CellKeyDownArgs<TRow, TSummaryRow = unknown> =
   | EditCellKeyDownArgs<TRow, TSummaryRow>;
 
 export interface CellSelectArgs<TRow, TSummaryRow = unknown> {
-  idx: number;
   rowIdx: number;
   row: TRow;
   column: CalculatedColumn<TRow, TSummaryRow>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,13 @@ export type CellKeyDownArgs<TRow, TSummaryRow = unknown> =
   | SelectCellKeyDownArgs<TRow, TSummaryRow>
   | EditCellKeyDownArgs<TRow, TSummaryRow>;
 
+export interface CellSelectArgs<TRow, TSummaryRow = unknown> {
+  idx: number;
+  rowIdx: number;
+  row: TRow;
+  column: CalculatedColumn<TRow, TSummaryRow>;
+}
+
 export interface BaseRenderRowProps<TRow, TSummaryRow = unknown>
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'children'>,
     Pick<

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -119,7 +119,7 @@ describe('Events', () => {
     expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('should call onSelectedCellChange when cell is clicked', async () => {
+  it('should call onSelectedCellChange when cell selection is changed', async () => {
     let idx: number;
     let rowIdx: number;
     let row: Row;

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import DataGrid from '../src';
-import type { Column, DataGridProps } from '../src';
+import type { CalculatedColumn, Column, DataGridProps } from '../src';
 import { getCellsAtRowIndex, render } from './utils';
 
 interface Row {
@@ -118,11 +118,162 @@ describe('Events', () => {
     await userEvent.pointer({ target: getCellsAtRowIndex(0)[1], keys: '[MouseRight]' });
     expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
   });
+
+  it('should call onCellSelected when cell is clicked', async () => {
+    let idx;
+    let rowIdx;
+    let row;
+    let column: CalculatedColumn<Row> | undefined;
+
+    render(
+      <EventTest
+        onCellSelected={(args) => {
+          idx = args.idx;
+          rowIdx = args.rowIdx;
+          row = args.row;
+          column = args.column;
+        }}
+      />
+    );
+    await userEvent.click(getCellsAtRowIndex(0)[0]);
+
+    expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
+    expect(idx).toBe(0);
+    expect(rowIdx).toBe(0);
+    expect(row).toStrictEqual({
+      col1: 1,
+      col2: 'a1'
+    });
+    expect(column?.key).toBe('col1');
+  });
+
+  it('should call onCellSelected when cell is double clicked', async () => {
+    let idx;
+    let rowIdx;
+    let row;
+    let column: CalculatedColumn<Row> | undefined;
+
+    render(
+      <EventTest
+        onCellSelected={(args) => {
+          idx = args.idx;
+          rowIdx = args.rowIdx;
+          row = args.row;
+          column = args.column;
+        }}
+      />
+    );
+    await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
+
+    expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
+    expect(idx).toBe(0);
+    expect(rowIdx).toBe(0);
+    expect(row).toStrictEqual({
+      col1: 1,
+      col2: 'a1'
+    });
+    expect(column?.key).toBe('col1');
+  });
+
+  it('should call onCellSelected when cell is right-clicked', async () => {
+    let idx;
+    let rowIdx;
+    let row;
+    let column: CalculatedColumn<Row> | undefined;
+
+    render(
+      <EventTest
+        onCellSelected={(args) => {
+          idx = args.idx;
+          rowIdx = args.rowIdx;
+          row = args.row;
+          column = args.column;
+        }}
+      />
+    );
+    await userEvent.pointer({ target: getCellsAtRowIndex(0)[0], keys: '[MouseLeft]' });
+
+    expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
+    expect(idx).toBe(0);
+    expect(rowIdx).toBe(0);
+    expect(row).toStrictEqual({
+      col1: 1,
+      col2: 'a1'
+    });
+    expect(column?.key).toBe('col1');
+  });
+
+  it('should call onCellSelected when selected cell is moved by ←↑→↓ keys', async () => {
+    let idx;
+    let rowIdx;
+    let row;
+    let column: CalculatedColumn<Row> | undefined;
+
+    render(
+      <EventTest
+        onCellSelected={(args) => {
+          idx = args.idx;
+          rowIdx = args.rowIdx;
+          row = args.row;
+          column = args.column;
+        }}
+      />
+    );
+    await userEvent.click(getCellsAtRowIndex(0)[0]);
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(getCellsAtRowIndex(1)[0]).toHaveAttribute('aria-selected', 'true');
+    expect(idx).toBe(0);
+    expect(rowIdx).toBe(1);
+    expect(row).toStrictEqual({
+      col1: 2,
+      col2: 'a2'
+    });
+    expect(column?.key).toBe('col1');
+  });
+
+  it('should call onCellSelected when selected cell is moved by tab keys', async () => {
+    let idx;
+    let rowIdx;
+    let row;
+    let column: CalculatedColumn<Row> | undefined;
+
+    render(
+      <EventTest
+        onCellSelected={(args) => {
+          idx = args.idx;
+          rowIdx = args.rowIdx;
+          row = args.row;
+          column = args.column;
+        }}
+      />
+    );
+    await userEvent.click(getCellsAtRowIndex(0)[0]);
+    await userEvent.keyboard('{Tab}');
+
+    expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
+    expect(idx).toBe(1);
+    expect(rowIdx).toBe(0);
+    expect(row).toStrictEqual({
+      col1: 1,
+      col2: 'a1'
+    });
+    expect(column?.key).toBe('col2');
+  });
+
+  it('should call onCellSelected only once when cell is double clicked', async () => {
+    let timesToBeCalled = 0;
+
+    render(<EventTest onCellSelected={() => timesToBeCalled++} />);
+    await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
+
+    expect(timesToBeCalled).toBe(1);
+  });
 });
 
 type EventProps = Pick<
   DataGridProps<Row>,
-  'onCellClick' | 'onCellDoubleClick' | 'onCellContextMenu'
+  'onCellClick' | 'onCellDoubleClick' | 'onCellContextMenu' | 'onCellSelected'
 >;
 
 function EventTest(props: EventProps) {

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -172,7 +172,6 @@ describe('Events', () => {
     expect(onSelectedCellChange).toHaveBeenCalledTimes(5);
   });
 });
-});
 
 type EventProps = Pick<
   DataGridProps<Row>,

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -120,9 +120,9 @@ describe('Events', () => {
   });
 
   it('should call onCellSelected when cell is clicked', async () => {
-    let idx;
-    let rowIdx;
-    let row;
+    let idx: number;
+    let rowIdx: number;
+    let row: Row;
     let column: CalculatedColumn<Row> | undefined;
 
     render(
@@ -135,130 +135,38 @@ describe('Events', () => {
         }}
       />
     );
-    await userEvent.click(getCellsAtRowIndex(0)[0]);
 
-    expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
-    expect(idx).toBe(0);
-    expect(rowIdx).toBe(0);
-    expect(row).toStrictEqual({
-      col1: 1,
-      col2: 'a1'
-    });
-    expect(column?.key).toBe('col1');
-  });
+    const expectOnCellSelectedFired = () => {
+      expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
+      expect(idx).toBe(1);
+      expect(rowIdx).toBe(0);
+      expect(row).toStrictEqual({
+        col1: 1,
+        col2: 'a1'
+      });
+      expect(column?.key).toBe('col2');
+    };
 
-  it('should call onCellSelected when cell is double clicked', async () => {
-    let idx;
-    let rowIdx;
-    let row;
-    let column: CalculatedColumn<Row> | undefined;
+    // Selected by click
+    await userEvent.click(getCellsAtRowIndex(0)[1]);
+    expectOnCellSelectedFired();
 
-    render(
-      <EventTest
-        onCellSelected={(args) => {
-          idx = args.idx;
-          rowIdx = args.rowIdx;
-          row = args.row;
-          column = args.column;
-        }}
-      />
-    );
-    await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
+    // Selected by double click
+    await userEvent.dblClick(getCellsAtRowIndex(0)[1]);
+    expectOnCellSelectedFired();
 
-    expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
-    expect(idx).toBe(0);
-    expect(rowIdx).toBe(0);
-    expect(row).toStrictEqual({
-      col1: 1,
-      col2: 'a1'
-    });
-    expect(column?.key).toBe('col1');
-  });
+    // Selected by right-click
+    await userEvent.pointer({ target: getCellsAtRowIndex(0)[1], keys: '[MouseRight]' });
+    expectOnCellSelectedFired();
 
-  it('should call onCellSelected when cell is right-clicked', async () => {
-    let idx;
-    let rowIdx;
-    let row;
-    let column: CalculatedColumn<Row> | undefined;
+    // Selected by ←↑→↓ keys
+    await userEvent.click(getCellsAtRowIndex(1)[1]);
+    await userEvent.keyboard('{ArrowUp}');
+    expectOnCellSelectedFired();
 
-    render(
-      <EventTest
-        onCellSelected={(args) => {
-          idx = args.idx;
-          rowIdx = args.rowIdx;
-          row = args.row;
-          column = args.column;
-        }}
-      />
-    );
-    await userEvent.pointer({ target: getCellsAtRowIndex(0)[0], keys: '[MouseRight]' });
-
-    expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
-    expect(idx).toBe(0);
-    expect(rowIdx).toBe(0);
-    expect(row).toStrictEqual({
-      col1: 1,
-      col2: 'a1'
-    });
-    expect(column?.key).toBe('col1');
-  });
-
-  it('should call onCellSelected when selected cell is moved by ←↑→↓ keys', async () => {
-    let idx;
-    let rowIdx;
-    let row;
-    let column: CalculatedColumn<Row> | undefined;
-
-    render(
-      <EventTest
-        onCellSelected={(args) => {
-          idx = args.idx;
-          rowIdx = args.rowIdx;
-          row = args.row;
-          column = args.column;
-        }}
-      />
-    );
-    await userEvent.click(getCellsAtRowIndex(0)[0]);
-    await userEvent.keyboard('{ArrowDown}');
-
-    expect(getCellsAtRowIndex(1)[0]).toHaveAttribute('aria-selected', 'true');
-    expect(idx).toBe(0);
-    expect(rowIdx).toBe(1);
-    expect(row).toStrictEqual({
-      col1: 2,
-      col2: 'a2'
-    });
-    expect(column?.key).toBe('col1');
-  });
-
-  it('should call onCellSelected when selected cell is moved by tab keys', async () => {
-    let idx;
-    let rowIdx;
-    let row;
-    let column: CalculatedColumn<Row> | undefined;
-
-    render(
-      <EventTest
-        onCellSelected={(args) => {
-          idx = args.idx;
-          rowIdx = args.rowIdx;
-          row = args.row;
-          column = args.column;
-        }}
-      />
-    );
+    // Selected by tab key
     await userEvent.click(getCellsAtRowIndex(0)[0]);
     await userEvent.keyboard('{Tab}');
-
-    expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
-    expect(idx).toBe(1);
-    expect(rowIdx).toBe(0);
-    expect(row).toStrictEqual({
-      col1: 1,
-      col2: 'a1'
-    });
-    expect(column?.key).toBe('col2');
   });
 
   it('should call onCellSelected only once when cell is double clicked', async () => {

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -119,7 +119,7 @@ describe('Events', () => {
     expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('should call onCellSelected when cell is clicked', async () => {
+  it('should call onSelectedCellChange when cell is clicked', async () => {
     let idx: number;
     let rowIdx: number;
     let row: Row;
@@ -127,7 +127,7 @@ describe('Events', () => {
 
     render(
       <EventTest
-        onCellSelected={(args) => {
+        onSelectedCellChange={(args) => {
           idx = args.idx;
           rowIdx = args.rowIdx;
           row = args.row;
@@ -169,10 +169,10 @@ describe('Events', () => {
     await userEvent.keyboard('{Tab}');
   });
 
-  it('should call onCellSelected only once when cell is double clicked', async () => {
+  it('should call onSelectedCellChange only once when cell is double clicked', async () => {
     let timesToBeCalled = 0;
 
-    render(<EventTest onCellSelected={() => timesToBeCalled++} />);
+    render(<EventTest onSelectedCellChange={() => timesToBeCalled++} />);
     await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
 
     expect(timesToBeCalled).toBe(1);
@@ -181,7 +181,7 @@ describe('Events', () => {
 
 type EventProps = Pick<
   DataGridProps<Row>,
-  'onCellClick' | 'onCellDoubleClick' | 'onCellContextMenu' | 'onCellSelected'
+  'onCellClick' | 'onCellDoubleClick' | 'onCellContextMenu' | 'onSelectedCellChange'
 >;
 
 function EventTest(props: EventProps) {

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -124,51 +124,54 @@ describe('Events', () => {
 
     render(<EventTest onSelectedCellChange={onSelectedCellChange} />);
 
-    const expectOnCellSelectedFired = () => {
-      expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
-      expect(onSelectedCellChange).toHaveBeenLastCalledWith({
-        rowIdx: 0,
-        row: {
-          col1: 1,
-          col2: 'a1'
-        },
-        column: expect.objectContaining({
-          idx: 1,
-          key: 'col2'
-        })
-      });
-    };
+    expect(onSelectedCellChange).not.toHaveBeenCalled();
 
     // Selected by click
     await userEvent.click(getCellsAtRowIndex(0)[1]);
-    expectOnCellSelectedFired();
+    expect(onSelectedCellChange).toHaveBeenCalledWith({
+      column: expect.objectContaining(columns[1]),
+      row: rows[0],
+      rowIdx: 0
+    });
+    expect(onSelectedCellChange).toHaveBeenCalledTimes(1);
 
     // Selected by double click
-    await userEvent.dblClick(getCellsAtRowIndex(0)[1]);
-    expectOnCellSelectedFired();
+    await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
+    expect(onSelectedCellChange).toHaveBeenCalledWith({
+      column: expect.objectContaining(columns[0]),
+      row: rows[0],
+      rowIdx: 0
+    });
+    expect(onSelectedCellChange).toHaveBeenCalledTimes(2);
 
     // Selected by right-click
-    await userEvent.pointer({ target: getCellsAtRowIndex(0)[1], keys: '[MouseRight]' });
-    expectOnCellSelectedFired();
+    await userEvent.pointer({ target: getCellsAtRowIndex(1)[0], keys: '[MouseRight]' });
+    expect(onSelectedCellChange).toHaveBeenCalledWith({
+      column: expect.objectContaining(columns[0]),
+      row: rows[1],
+      rowIdx: 1
+    });
+    expect(onSelectedCellChange).toHaveBeenCalledTimes(3);
 
     // Selected by ←↑→↓ keys
-    await userEvent.click(getCellsAtRowIndex(1)[1]);
     await userEvent.keyboard('{ArrowUp}');
-    expectOnCellSelectedFired();
+    expect(onSelectedCellChange).toHaveBeenCalledWith({
+      column: expect.objectContaining(columns[0]),
+      row: rows[0],
+      rowIdx: 0
+    });
+    expect(onSelectedCellChange).toHaveBeenCalledTimes(4);
 
     // Selected by tab key
-    await userEvent.click(getCellsAtRowIndex(0)[0]);
     await userEvent.keyboard('{Tab}');
+    expect(onSelectedCellChange).toHaveBeenCalledWith({
+      column: expect.objectContaining(columns[1]),
+      row: rows[0],
+      rowIdx: 0
+    });
+    expect(onSelectedCellChange).toHaveBeenCalledTimes(5);
   });
-
-  it('should call onSelectedCellChange only once when cell is double clicked', async () => {
-    const onSelectedCellChange = vi.fn();
-
-    render(<EventTest onSelectedCellChange={onSelectedCellChange} />);
-    await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
-
-    expect(onSelectedCellChange).toHaveBeenCalledTimes(1);
-  });
+});
 });
 
 type EventProps = Pick<

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -191,7 +191,7 @@ describe('Events', () => {
         }}
       />
     );
-    await userEvent.pointer({ target: getCellsAtRowIndex(0)[0], keys: '[MouseLeft]' });
+    await userEvent.pointer({ target: getCellsAtRowIndex(0)[0], keys: '[MouseRight]' });
 
     expect(getCellsAtRowIndex(0)[0]).toHaveAttribute('aria-selected', 'true');
     expect(idx).toBe(0);

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import DataGrid from '../src';
-import type { CalculatedColumn, Column, DataGridProps } from '../src';
+import type { Column, DataGridProps } from '../src';
 import { getCellsAtRowIndex, render } from './utils';
 
 interface Row {
@@ -120,29 +120,23 @@ describe('Events', () => {
   });
 
   it('should call onSelectedCellChange when cell selection is changed', async () => {
-    let rowIdx: number;
-    let row: Row;
-    let column: CalculatedColumn<Row> | undefined;
+    const onSelectedCellChange = vi.fn();
 
-    render(
-      <EventTest
-        onSelectedCellChange={(args) => {
-          rowIdx = args.rowIdx;
-          row = args.row;
-          column = args.column;
-        }}
-      />
-    );
+    render(<EventTest onSelectedCellChange={onSelectedCellChange} />);
 
     const expectOnCellSelectedFired = () => {
       expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
-      expect(column?.idx).toBe(1);
-      expect(rowIdx).toBe(0);
-      expect(row).toStrictEqual({
-        col1: 1,
-        col2: 'a1'
+      expect(onSelectedCellChange).toHaveBeenLastCalledWith({
+        rowIdx: 0,
+        row: {
+          col1: 1,
+          col2: 'a1'
+        },
+        column: expect.objectContaining({
+          idx: 1,
+          key: 'col2'
+        })
       });
-      expect(column?.key).toBe('col2');
     };
 
     // Selected by click
@@ -168,12 +162,12 @@ describe('Events', () => {
   });
 
   it('should call onSelectedCellChange only once when cell is double clicked', async () => {
-    let timesToBeCalled = 0;
+    const onSelectedCellChange = vi.fn();
 
-    render(<EventTest onSelectedCellChange={() => timesToBeCalled++} />);
+    render(<EventTest onSelectedCellChange={onSelectedCellChange} />);
     await userEvent.dblClick(getCellsAtRowIndex(0)[0]);
 
-    expect(timesToBeCalled).toBe(1);
+    expect(onSelectedCellChange).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/events.test.tsx
+++ b/test/events.test.tsx
@@ -120,7 +120,6 @@ describe('Events', () => {
   });
 
   it('should call onSelectedCellChange when cell selection is changed', async () => {
-    let idx: number;
     let rowIdx: number;
     let row: Row;
     let column: CalculatedColumn<Row> | undefined;
@@ -128,7 +127,6 @@ describe('Events', () => {
     render(
       <EventTest
         onSelectedCellChange={(args) => {
-          idx = args.idx;
           rowIdx = args.rowIdx;
           row = args.row;
           column = args.column;
@@ -138,7 +136,7 @@ describe('Events', () => {
 
     const expectOnCellSelectedFired = () => {
       expect(getCellsAtRowIndex(0)[1]).toHaveAttribute('aria-selected', 'true');
-      expect(idx).toBe(1);
+      expect(column?.idx).toBe(1);
       expect(rowIdx).toBe(0);
       expect(row).toStrictEqual({
         col1: 1,


### PR DESCRIPTION
Closes #3090

This PR adds ~~`onCellSelected`~~ `onSelectedCellChange` event to the `<DataGrid>` component.
You can get column index, row index, row object and column object when the cell is selected by click, double click, right-click, Page{Up|Down|Left|Right} key, tab key, or any other actions.

```html
    <DataGrid
      ...
      onSelectedCellChange={ ({ rowIdx, row, column }) => console.log(rowIdx, row, column) }
    />
```