### PR TITLE
Hide drag handle if all the cells in a column are readonly

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -839,6 +839,10 @@ function DataGrid<R, SR, K extends Key>(
     }
 
     const column = columns[selectedPosition.idx];
+    if (column.renderEditCell == null || column.editable === false) {
+      return;
+    }
+
     const columnWidth = getColumnWidth(column);
 
     return (


### PR DESCRIPTION
Fixes https://github.com/adazzle/react-data-grid/issues/3350