### PR TITLE
bug: name collision in isCellEditable breaks edit feature

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { css } from '@linaria/core';
 
 import { useRovingTabIndex } from './hooks';
-import { createCellEvent, getCellClassname, getCellStyle, isCellEditable } from './utils';
+import { createCellEvent, getCellClassname, getCellStyle, isCellEditableUtil } from './utils';
 import type { CellRendererProps } from './types';
 
 const cellCopied = css`
@@ -51,7 +51,7 @@ function Cell<R, SR>({
     },
     typeof cellClass === 'function' ? cellClass(row) : cellClass
   );
-  const isEditable = isCellEditable(column, row);
+  const isEditable = isCellEditableUtil(column, row);
 
   function selectCellWrapper(openEditor?: boolean) {
     selectCell({ rowIdx, idx: column.idx }, openEditor);

--- a/src/utils/selectedCellUtils.ts
+++ b/src/utils/selectedCellUtils.ts
@@ -20,10 +20,10 @@ export function isSelectedCellEditable<R, SR>({
 }: IsSelectedCellEditableOpts<R, SR>): boolean {
   const column = columns[selectedPosition.idx];
   const row = rows[selectedPosition.rowIdx];
-  return isCellEditable(column, row);
+  return isCellEditableUtil(column, row);
 }
 
-export function isCellEditable<R, SR>(column: CalculatedColumn<R, SR>, row: R): boolean {
+export function isCellEditableUtil<R, SR>(column: CalculatedColumn<R, SR>, row: R): boolean {
   return (
     column.renderEditCell != null &&
     (typeof column.editable === 'function' ? column.editable(row) : column.editable) !== false

--- a/src/utils/selectedCellUtils.ts
+++ b/src/utils/selectedCellUtils.ts
@@ -23,6 +23,7 @@ export function isSelectedCellEditable<R, SR>({
   return isCellEditableUtil(column, row);
 }
 
+// https://github.com/vercel/next.js/issues/56480
 export function isCellEditableUtil<R, SR>(column: CalculatedColumn<R, SR>, row: R): boolean {
   return (
     column.renderEditCell != null &&


### PR DESCRIPTION
# Issue
Under certain conditions when bundled, two identically named functions (`isCellEditable`) can clash.

## How to replicate
1. Import the library into `next@13.5.4` or later
2. Configure an editable cell per the common example
3. `npm run dev` shows expected functionality of cell becoming editable after double click or carriage return
4. `npm run build && npm run start` shows an unexpected outcome, cell edit becomes unreachable in production

Going through the compiled code with some strategic logging shows that the production build version of the code prefers the utility `isCellEditable` rather than the function inside `DataGrid`. As they accept two different arguments sets, this breaks the edit feature.

## Fix
Renaming the utility to `isCellEditableUtil` resolves this issue. If this name isn't preferred, I am open to suggestion and happy to change it.