### PR TITLE
CI: use Node.js `21.x`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '21.2.x'
+          node-version: '21.x'
           check-latest: true
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
21.3 had a bug, but 21.4 should be good.
https://nodejs.org/en/blog/release/v21.4.0