### PR TITLE
dependabot: configure groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,29 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+      react-dnd:
+        patterns:
+          - 'react-dnd'
+          - 'react-dnd-html5-backend'
+      babel:
+        patterns:
+          - '@babel/*'
+      linaria:
+        patterns:
+          - '@linaria/*'
+          - '@wyw-in-js/*'
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
I had this bookmarked for way too long...