### PR TITLE
Remove `postcss-nested`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "jspdf-autotable": "^3.5.23",
     "lodash-es": "^4.17.21",
     "postcss": "^8.4.25",
-    "postcss-nested": "^6.0.1",
     "prettier": "3.1.1",
     "react": "^18.1.0",
     "react-dnd": "^16.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import { isAbsolute } from 'node:path';
 import wyw from '@wyw-in-js/rollup';
 import postcss from 'rollup-plugin-postcss';
-import postcssNested from 'postcss-nested';
 import { babel } from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json' assert { type: 'json' };
@@ -35,7 +34,6 @@ export default {
       }
     }),
     postcss({
-      plugins: [postcssNested],
       extract: 'styles.css'
     }),
     babel({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './style/layers.css';
+
 export { default, type DataGridProps, type DataGridHandle } from './DataGrid';
 export { default as TreeDataGrid, type TreeDataGridProps } from './TreeDataGrid';
 export { DataGridDefaultRenderersProvider } from './DataGridDefaultRenderersProvider';

--- a/src/style/core.ts
+++ b/src/style/core.ts
@@ -37,72 +37,55 @@ const darkTheme = `
 `;
 
 const root = css`
-  @layer rdg {
-    @layer Defaults,
-      FocusSink,
-      CheckboxInput,
-      CheckboxIcon,
-      CheckboxLabel,
-      Cell,
-      HeaderCell,
-      SummaryCell,
-      EditCell,
-      Row,
-      HeaderRow,
-      SummaryRow,
-      GroupedRow,
-      Root;
+  @layer rdg.Defaults {
+    *,
+    *::before,
+    *::after {
+      box-sizing: inherit;
+    }
+  }
 
-    @layer Defaults {
-      *,
-      *::before,
-      *::after {
-        box-sizing: inherit;
-      }
+  @layer rdg.Root {
+    ${lightTheme}
+    --rdg-selection-color: #66afe9;
+    --rdg-font-size: 14px;
+
+    display: grid;
+
+    color-scheme: var(--rdg-color-scheme, light dark);
+
+    /* https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context */
+    /* We set a stacking context so internal elements don't render on top of external elements. */
+    /* size containment is not used as it could break "width: min-content" for example, and the grid would infinitely resize on Chromium browsers */
+    contain: content;
+    content-visibility: auto;
+    block-size: 350px;
+    border: 1px solid var(--rdg-border-color);
+    box-sizing: border-box;
+    overflow: auto;
+    background-color: var(--rdg-background-color);
+    color: var(--rdg-color);
+    font-size: var(--rdg-font-size);
+
+    /* needed on Firefox to fix scrollbars */
+    &::before {
+      content: '';
+      grid-column: 1/-1;
+      grid-row: 1/-1;
     }
 
-    @layer Root {
-      ${lightTheme}
-      --rdg-selection-color: #66afe9;
-      --rdg-font-size: 14px;
+    &.rdg-dark {
+      --rdg-color-scheme: dark;
+      ${darkTheme}
+    }
 
-      display: grid;
+    &.rdg-light {
+      --rdg-color-scheme: light;
+    }
 
-      color-scheme: var(--rdg-color-scheme, light dark);
-
-      /* https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context */
-      /* We set a stacking context so internal elements don't render on top of external elements. */
-      /* size containment is not used as it could break "width: min-content" for example, and the grid would infinitely resize on Chromium browsers */
-      contain: content;
-      content-visibility: auto;
-      block-size: 350px;
-      border: 1px solid var(--rdg-border-color);
-      box-sizing: border-box;
-      overflow: auto;
-      background-color: var(--rdg-background-color);
-      color: var(--rdg-color);
-      font-size: var(--rdg-font-size);
-
-      /* needed on Firefox to fix scrollbars */
-      &::before {
-        content: '';
-        grid-column: 1/-1;
-        grid-row: 1/-1;
-      }
-
-      &.rdg-dark {
-        --rdg-color-scheme: dark;
+    @media (prefers-color-scheme: dark) {
+      &:not(.rdg-light) {
         ${darkTheme}
-      }
-
-      &.rdg-light {
-        --rdg-color-scheme: light;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        &:not(.rdg-light) {
-          ${darkTheme}
-        }
       }
     }
   }

--- a/src/style/layers.css
+++ b/src/style/layers.css
@@ -1,0 +1,16 @@
+@layer rdg {
+  @layer Defaults,
+    FocusSink,
+    CheckboxInput,
+    CheckboxIcon,
+    CheckboxLabel,
+    Cell,
+    HeaderCell,
+    SummaryCell,
+    EditCell,
+    Row,
+    HeaderRow,
+    SummaryRow,
+    GroupedRow,
+    Root;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import react from '@vitejs/plugin-react';
 import wyw from '@wyw-in-js/vite';
-import postcssNested from 'postcss-nested';
 import { defineConfig } from 'vite';
 
 const isCI = process.env.CI === 'true';
@@ -27,11 +26,6 @@ export default defineConfig({
     }),
     !isTest && wyw({ preprocessor: 'none' })
   ],
-  css: {
-    postcss: {
-      plugins: [postcssNested]
-    }
-  },
   server: {
     open: true
   },


### PR DESCRIPTION
Some output diff:
![image](https://github.com/adazzle/react-data-grid/assets/567105/b23e0240-c8b1-4ad5-a0f3-252645edf940)
![image](https://github.com/adazzle/react-data-grid/assets/567105/039d5e77-3cb4-4682-86e0-da339a62cf54)
![image](https://github.com/adazzle/react-data-grid/assets/567105/cc3773c8-afee-451a-9892-cacd45fc1724)


- Layers order is now at the top of the stylesheet, which I believe is actually the correct way to use layers.
- We will now ship native CSS nesting

https://caniuse.com/css-nesting