### PR TITLE
Remove `:is()`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/website/demos/Animation.tsx
+++ b/website/demos/Animation.tsx
@@ -15,7 +15,8 @@ const rangeClassname = css`
 const transitionClassname = css`
   transition: grid-template-rows 0.5s ease;
 
-  > :is(.rdg-header-row, .rdg-row) {
+  > .rdg-header-row,
+  > .rdg-row {
     transition: line-height 0.5s ease;
   }
 `;


### PR DESCRIPTION
Using `:is()` is less valuable now that we ship with native CSS nesting.