### PR TITLE
add option to enable/disable Virtualization for columns/rows

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -180,7 +180,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * Toggles and modes
    */
   /** @default true */
-  enableVirtualization?: Maybe<boolean>;
+  enableVirtualization?: Maybe<boolean | 'columns' | 'rows'>;
 
   /**
    * Miscellaneous
@@ -309,7 +309,7 @@ function DataGrid<R, SR, K extends Key>(
     getColumnWidth,
     scrollLeft,
     viewportWidth: gridWidth,
-    enableVirtualization
+    enableVirtualization: enableVirtualization === true || enableVirtualization === 'columns'
   });
 
   const topSummaryRowsCount = topSummaryRows?.length ?? 0;
@@ -379,7 +379,7 @@ function DataGrid<R, SR, K extends Key>(
     rowHeight,
     clientHeight,
     scrollTop,
-    enableVirtualization
+    enableVirtualization: enableVirtualization === true || enableVirtualization === 'rows'
   });
 
   const viewportColumns = useViewportColumns({


### PR DESCRIPTION
Sometimes users might need disable Virtualization for columns or rows. By adding 2 new values (`columns` and `rows`) for `enableVirtualization` prop we can now control this behaviour.

1. if typeof `enableVirtualization` === `boolean` - Virtualization is enabled/disabled for columns and rows
2. if `enableVirtualization` === `columns` - Virtualization works only for columns
3. if `enableVirtualization` === `rows` - Virtualization works only for rows