### PR TITLE
Tweak React 19 CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: set up react 19
         if: matrix.react == 19
         run: |
-          node .\.github\workflows\patch-react19.js
+          node ./.github/workflows/patch-react19.js
           cat package.json
       - name: npm install
         run: npm i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         react: [18, 19]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
-          check-latest: true
+          node-version: '22.4.1'
       - name: set up react 19
         if: matrix.react == 19
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,11 @@ jobs:
         with:
           node-version: '22.x'
           check-latest: true
-      - name: Set up git user
-        run: |
-          git config --global user.email 'action@github.com'
-          git config --global user.name 'GitHub Action'
-      - name: merge react 19 branch
+      - name: set up react 19
         if: matrix.react == 19
         run: |
-          git fetch origin react19
-          git merge origin/react19 -X theirs --allow-unrelated-histories
-          git fetch origin main
-          git diff origin/main
+          node .\.github\workflows\patch-react19.js
+          cat package.json
       - name: npm install
         run: npm i
       - name: Biome
@@ -51,7 +45,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium
       - name: Test
-        run: npm --run test
+        run: node --run test
         timeout-minutes: 4
       - name: Upload coverage
         if: matrix.react == 18
@@ -61,6 +55,8 @@ jobs:
       - name: Deploy gh-pages
         if: matrix.react == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
+          git config --global user.email 'action@github.com'
+          git config --global user.name 'GitHub Action'
           git fetch origin gh-pages
           git worktree add gh-pages gh-pages
           cd gh-pages

--- a/.github/workflows/patch-react19.js
+++ b/.github/workflows/patch-react19.js
@@ -1,0 +1,15 @@
+import fs from 'node:fs/promises';
+
+const pkgText = await fs.readFile('./package.json', 'utf8');
+const pkg = JSON.parse(pkgText);
+
+pkg.devDependencies['@types/react'] = 'npm:types-react@rc';
+pkg.devDependencies['@types/react-dom'] = 'npm:types-react-dom@rc';
+pkg.devDependencies.react = 'rc';
+pkg.devDependencies['react-dom'] = 'rc';
+pkg.overrides = {
+  '@types/react': 'npm:types-react@rc',
+  '@types/react-dom': 'npm:types-react-dom@rc'
+};
+
+fs.writeFile('./package.json', JSON.stringify(pkg, null, 2));


### PR DESCRIPTION
This is a safer approach to patch in React 19 deps without running into merge conflicts, or merging in unrelated changes from the `react19` branch.

This will allow us to continue work on the `react19` branch, so we can try out dropping support for React 18.