### PR TITLE
Add back `--rdg-header-row-height`

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1076,6 +1076,7 @@ function DataGrid<R, SR, K extends Key>(
               : undefined,
           gridTemplateColumns,
           gridTemplateRows: templateRows,
+          '--rdg-header-row-height': `${headerRowHeight}px`,
           '--rdg-scroll-height': `${scrollHeight}px`,
           '--rdg-sign': isRtl ? -1 : 1,
           ...layoutCssVars


### PR DESCRIPTION
This variable is still used
https://github.com/adazzle/react-data-grid/blob/main/src/utils/styleUtils.ts#L17