### PR TITLE
CI: update nodejs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.4.1'
+          node-version: 22
+          check-latest: true
       - name: set up react 19
         if: matrix.react == 19
         run: |


### PR DESCRIPTION
The issue in 22.5.0 was resolved in 22.5.1 so we can unpin the nodejs version now.