### PR TITLE
Conditionally Include Row Data in `onSelectedCellChange` Callback

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -741,7 +741,7 @@ function DataGrid<R, SR, K extends Key>(
     if (onSelectedCellChange && !samePosition) {
       onSelectedCellChange({
         rowIdx: position.rowIdx,
-        row,
+        ...(row && { row }),
         column: columns[position.idx]
       });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,7 +196,7 @@ export type CellKeyDownArgs<TRow, TSummaryRow = unknown> =
 
 export interface CellSelectArgs<TRow, TSummaryRow = unknown> {
   rowIdx: number;
-  row: TRow;
+  row?: TRow;
   column: CalculatedColumn<TRow, TSummaryRow>;
 }
 


### PR DESCRIPTION
## Description
- updated the row type for `CellSelectArgs`
- conditionally include row data on the `onSelectedCellChange` callback

Ref #3580
