### PR TITLE
Fix case sensitivity issue with `dragDropKey` in `onDrop` function

### DIFF
--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -224,8 +224,8 @@ export default function HeaderCell<R, SR>({
 
   function onDrop(event: React.DragEvent<HTMLDivElement>) {
     setIsOver(false);
-    if (event.dataTransfer.types.includes(dragDropKey)) {
-      const sourceKey = event.dataTransfer.getData(dragDropKey);
+    if (event.dataTransfer.types.includes(dragDropKey.toLowerCase())) {
+      const sourceKey = event.dataTransfer.getData(dragDropKey.toLowerCase());
       if (sourceKey !== column.key) {
         event.preventDefault();
         onColumnsReorder?.(sourceKey, column.key);


### PR DESCRIPTION
## Summary: 
This PR addresses an issue where the onDrop function was not being triggered due to case sensitivity between event.dataTransfer.types and dragDropKey.

## Fix:
The dragDropKey is now normalized to lowercase before comparison, ensuring consistent behavior regardless of case discrepancies.

## Changes:

Modified the onDrop function to normalize dragDropKey to lowercase when checking event.dataTransfer.types and retrieving dataTransfer data.

## Testing:
Verified that the onDrop function is now correctly triggered and reordering works as expected.