### PR TITLE
Column resizing: handle coalesced pointer move events

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,7 +5,7 @@ import type { BrowserCommand } from 'vitest/node';
 const resizeColumn: BrowserCommand<[resizeBy: number]> = async (context, resizeBy) => {
   const page = context.page;
   const frame = await context.frame();
-  const resizeHandle = frame.locator('[role="columnheader"][aria-colindex="2"]  div');
+  const resizeHandle = frame.locator('[role="columnheader"][aria-colindex="2"] div');
   const { x, y } = (await resizeHandle.boundingBox())!;
   await resizeHandle.hover({
     position: { x: 5, y: 5 }


### PR DESCRIPTION
Our column resize test are [flaky](https://github.com/adazzle/react-data-grid/actions/runs/10724678950/job/29740854268?pr=3592) in CI, which lead me to rethink this part of the codebase.

I think what's happening is that when we run the following code
```js
  await page.mouse.down();
  await page.mouse.move(x + resizeBy + 5, y);
  await page.mouse.up();
```
playwright may not wait for pointer events to be dispatched before executing the next command,
so `mouse.up()` would run before the next render frame/before the `pointermove` event is dispatched,
so the `pointermove` event may be coalesced into the `lostpointercapture` event.

An alternative could be to add pauses between each mouse commands,
but handling the final pointer position does make sense, and is the right thing to do.

I couldn't reproduce the flaky test locally, so this is all theoretical.

https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/getCoalescedEvents