### PR TITLE
ci: disable Jekyll processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   test:
@@ -64,6 +60,7 @@ jobs:
           git rm -r .
           git checkout gh-pages -- old
           mv ../dist/* .
+          touch .nojekyll
           git add .
           git commit -m "gh-pages deployment" || echo "Nothing to commit"
           git push -f https://adazzle:${{secrets.GITHUB_TOKEN}}@github.com/adazzle/react-data-grid.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           git worktree add gh-pages gh-pages
           cd gh-pages
           git rm -r .
-          git checkout gh-pages -- old
           mv ../dist/* .
           touch .nojekyll
           git add .

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@
 
 - [Examples website](https://adazzle.github.io/react-data-grid/)
   - [Source code](website)
-- [Old website for react-data-grid v6](https://adazzle.github.io/react-data-grid/old/)
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 


### PR DESCRIPTION
gh pages is currently not serving files/directories starting with an underscore, adding a `.nojekyll` file fixes that.
For reference: https://github.blog/news-insights/bypassing-jekyll-on-github-pages/

Broken file:
https://github.com/adazzle/react-data-grid/blob/gh-pages/assets/_commonjsHelpers-BosuxZz1.js
https://adazzle.github.io/react-data-grid/assets/_commonjsHelpers-BosuxZz1.js