### PR TITLE
Pass column in `onColumnResize`

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -187,7 +187,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   /** Called when the grid is scrolled */
   onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;
   /** Called when a column is resized */
-  onColumnResize?: Maybe<(idx: number, width: number) => void>;
+  onColumnResize?: Maybe<(column: CalculatedColumn<R, SR>, width: number) => void>;
   /** Called when a column is reordered */
   onColumnsReorder?: Maybe<(sourceColumnKey: string, targetColumnKey: string) => void>;
 

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -96,7 +96,7 @@ export function useColumnWidths<R, SR>(
       updateMeasuredWidths(columnsToMeasure);
     });
 
-    onColumnResize?.(column.idx, measuredWidth);
+    onColumnResize?.(column, measuredWidth);
   }
 
   return {

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -64,12 +64,16 @@ test('cannot not resize or auto resize column when resizable is not specified', 
 });
 
 test('should resize column when dragging the handle', async () => {
-  setup<Row, unknown>({ columns, rows: [] });
+  const onColumnResize = vi.fn();
+  setup<Row, unknown>({ columns, rows: [], onColumnResize });
   const [, col2] = getHeaderCells();
   const grid = getGrid();
+  expect(onColumnResize).not.toHaveBeenCalled();
   await expect.element(grid).toHaveStyle({ gridTemplateColumns: '100px 200px' });
   await resize({ column: col2.element(), resizeBy: -50 });
   await expect.element(grid).toHaveStyle({ gridTemplateColumns: '100px 150px' });
+  expect(onColumnResize).toHaveBeenCalledTimes(1);
+  expect(onColumnResize).toHaveBeenCalledWith(expect.objectContaining(columns[1]), 150);
 });
 
 test('should use the maxWidth if specified', async () => {


### PR DESCRIPTION
Fixes https://github.com/adazzle/react-data-grid/issues/3331