### PR TITLE
docs(readme): update Quick Start section to reflect named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install react-data-grid
 ```jsx
 import 'react-data-grid/lib/styles.css';
 
-import DataGrid from 'react-data-grid';
+import { DataGrid } from 'react-data-grid';
 
 const columns = [
   { key: 'id', name: 'ID' },


### PR DESCRIPTION
This commit updates README.md Quick Start section to align with current package exports. Remove default export example as the package now uses named export.