### PR TITLE
feat: minimum rows to render

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -212,6 +212,11 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   enableVirtualization?: Maybe<boolean>;
 
   /**
+   * The minimum number of rows to render when virtualization is enabled
+   */
+  minimumRowsToRender?: Maybe<number>;
+
+  /**
    * Miscellaneous
    */
   renderers?: Maybe<Renderers<NoInfer<R>, NoInfer<SR>>>;
@@ -264,6 +269,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     onPaste,
     // Toggles and modes
     enableVirtualization: rawEnableVirtualization,
+    minimumRowsToRender: rawMinimumRowsToRender,
     // Miscellaneous
     renderers,
     className,
@@ -297,6 +303,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     renderers?.renderCheckbox ?? defaultRenderers?.renderCheckbox ?? defaultRenderCheckbox;
   const noRowsFallback = renderers?.noRowsFallback ?? defaultRenderers?.noRowsFallback;
   const enableVirtualization = rawEnableVirtualization ?? true;
+  const minimumRowsToRender = rawMinimumRowsToRender ?? 30;
   const direction = rawDirection ?? 'ltr';
 
   /**
@@ -423,7 +430,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     rowHeight,
     clientHeight,
     scrollTop,
-    enableVirtualization
+    enableVirtualization,
+    minimumRowsToRender
   });
 
   const viewportColumns = useViewportColumns({

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -8,6 +8,7 @@ interface ViewportRowsArgs<R> {
   clientHeight: number;
   scrollTop: number;
   enableVirtualization: boolean;
+  minimumRowsToRender: number;
 }
 
 export function useViewportRows<R>({
@@ -15,7 +16,8 @@ export function useViewportRows<R>({
   rowHeight,
   clientHeight,
   scrollTop,
-  enableVirtualization
+  enableVirtualization,
+  minimumRowsToRender
 }: ViewportRowsArgs<R>) {
   const { totalRowHeight, gridTemplateRows, getRowTop, getRowHeight, findRowIdx } = useMemo(() => {
     if (typeof rowHeight === 'number') {
@@ -81,6 +83,18 @@ export function useViewportRows<R>({
     const rowVisibleEndIdx = findRowIdx(scrollTop + clientHeight);
     rowOverscanStartIdx = max(0, rowVisibleStartIdx - overscanThreshold);
     rowOverscanEndIdx = min(rows.length - 1, rowVisibleEndIdx + overscanThreshold);
+
+    const extraRows = max(0, minimumRowsToRender - (rowOverscanEndIdx - rowOverscanStartIdx + 1));
+
+    if (extraRows > 0) {
+      const extraOnSide = floor(extraRows / 2);
+      const startRowsShift = rowOverscanStartIdx - extraOnSide;
+      rowOverscanStartIdx = max(0, startRowsShift);
+      rowOverscanEndIdx = min(
+        rows.length - 1,
+        rowOverscanEndIdx + extraOnSide - min(0, startRowsShift)
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
#3742

This PR adds `minimumRowsToRender` property to the `DataGrid` component.
This property specifies a minimal amount of rows that will be rendered.

Example:
table with 100 rows
scroll at start
viewport visible rows: 10
minimumRowsToRender: 30; 

This will render 0-30 rows.