### PR TITLE
Fix double-click to auto-size columns

### DIFF
--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -119,7 +119,6 @@ export default function HeaderCell<R, SR>({
     const headerCell = currentTarget.parentElement!;
     const { right, left } = headerCell.getBoundingClientRect();
     const offset = isRtl ? event.clientX - left : right - event.clientX;
-    let hasDoubleClicked = false;
 
     function onPointerMove(event: PointerEvent) {
       const { width, right, left } = headerCell.getBoundingClientRect();
@@ -130,27 +129,21 @@ export default function HeaderCell<R, SR>({
       }
     }
 
-    function onDoubleClick() {
-      hasDoubleClicked = true;
-      onColumnResize(column, 'max-content');
-    }
-
     function onLostPointerCapture(event: PointerEvent) {
       // Handle final pointer position that may have been skipped by coalesced pointer move events.
-      // Skip move pointer handling if the user double-clicked.
-      if (!hasDoubleClicked) {
-        onPointerMove(event);
-      }
+      onPointerMove(event);
 
       currentTarget.removeEventListener('pointermove', onPointerMove);
-      currentTarget.removeEventListener('dblclick', onDoubleClick);
       currentTarget.removeEventListener('lostpointercapture', onLostPointerCapture);
     }
 
     currentTarget.setPointerCapture(pointerId);
     currentTarget.addEventListener('pointermove', onPointerMove);
-    currentTarget.addEventListener('dblclick', onDoubleClick);
     currentTarget.addEventListener('lostpointercapture', onLostPointerCapture);
+  }
+
+  function onDoubleClick() {
+    onColumnResize(column, 'max-content');
   }
 
   function onSort(ctrlClick: boolean) {
@@ -304,6 +297,7 @@ export default function HeaderCell<R, SR>({
           className={resizeHandleClassname}
           onClick={stopPropagation}
           onPointerDown={onPointerDown}
+          onDoubleClick={onDoubleClick}
         />
       )}
     </div>

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { css } from '@linaria/core';
 
 import { useRovingTabIndex } from './hooks';
@@ -85,6 +85,7 @@ export default function HeaderCell<R, SR>({
   direction,
   dragDropKey
 }: HeaderCellProps<R, SR>) {
+  const hasDoubleClickedRef = useRef(false);
   const [isDragging, setIsDragging] = useState(false);
   const [isOver, setIsOver] = useState(false);
   const isRtl = direction === 'rtl';
@@ -119,6 +120,7 @@ export default function HeaderCell<R, SR>({
     const headerCell = currentTarget.parentElement!;
     const { right, left } = headerCell.getBoundingClientRect();
     const offset = isRtl ? event.clientX - left : right - event.clientX;
+    hasDoubleClickedRef.current = false;
 
     function onPointerMove(event: PointerEvent) {
       const { width, right, left } = headerCell.getBoundingClientRect();
@@ -131,7 +133,9 @@ export default function HeaderCell<R, SR>({
 
     function onLostPointerCapture(event: PointerEvent) {
       // Handle final pointer position that may have been skipped by coalesced pointer move events.
-      onPointerMove(event);
+      if (!hasDoubleClickedRef.current) {
+        onPointerMove(event);
+      }
 
       currentTarget.removeEventListener('pointermove', onPointerMove);
       currentTarget.removeEventListener('lostpointercapture', onLostPointerCapture);
@@ -143,6 +147,7 @@ export default function HeaderCell<R, SR>({
   }
 
   function onDoubleClick() {
+    hasDoubleClickedRef.current = true;
     onColumnResize(column, 'max-content');
   }
 

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -133,6 +133,7 @@ export default function HeaderCell<R, SR>({
 
     function onLostPointerCapture(event: PointerEvent) {
       // Handle final pointer position that may have been skipped by coalesced pointer move events.
+      // Skip move pointer handling if the user double-clicked.
       if (!hasDoubleClickedRef.current) {
         onPointerMove(event);
       }

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -1,4 +1,4 @@
-import { commands, userEvent } from '@vitest/browser/context';
+import { commands, page } from '@vitest/browser/context';
 
 import type { Column } from '../../../src';
 import { resizeHandleClassname } from '../../../src/HeaderCell';
@@ -36,9 +36,9 @@ async function resize({ column, resizeBy }: ResizeArgs) {
 }
 
 async function autoResize(column: Element) {
-  const resizeHandle = getResizeHandle(column);
+  const resizeHandle = page.elementLocator(getResizeHandle(column));
 
-  await userEvent.dblClick(resizeHandle);
+  await resizeHandle.dblClick();
 }
 
 const columns: readonly Column<Row>[] = [

--- a/tsconfig.website.json
+++ b/tsconfig.website.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
+    "skipLibCheck": true
   },
   "include": ["website/**/*"],
   "references": [{ "path": "tsconfig.src.json" }]


### PR DESCRIPTION
I don't think we need `hasDoubleClickedRef` in practice as the double click event happens after `lostpointercapture`, but it does happen before `lostpointercapture` in tests for some reason.