### PR TITLE
Add `editorOptions.closeOnExternalRowChange` prop

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -904,6 +904,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     const { idx, row } = selectedPosition;
     const column = columns[idx];
     const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'ROW', row });
+    const discardOnRowChange = column.editorOptions?.discardOnRowChange !== false;
 
     const closeEditor = (shouldFocusCell: boolean) => {
       setShouldFocusCell(shouldFocusCell);
@@ -925,7 +926,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       }
     };
 
-    if (rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
+    if (discardOnRowChange && rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
       // Discard changes if rows are updated from outside
       closeEditor(false);
     }

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -904,7 +904,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     const { idx, row } = selectedPosition;
     const column = columns[idx];
     const colSpan = getColSpan(column, lastFrozenColumnIndex, { type: 'ROW', row });
-    const discardOnRowChange = column.editorOptions?.discardOnRowChange !== false;
+    const closeOnExternalRowChange = column.editorOptions?.closeOnExternalRowChange ?? true;
 
     const closeEditor = (shouldFocusCell: boolean) => {
       setShouldFocusCell(shouldFocusCell);
@@ -926,7 +926,10 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       }
     };
 
-    if (discardOnRowChange && rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
+    if (
+      closeOnExternalRowChange &&
+      rows[selectedPosition.rowIdx] !== selectedPosition.originalRow
+    ) {
       // Discard changes if rows are updated from outside
       closeEditor(false);
     }

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -57,7 +57,7 @@ export default function EditCell<R, SR>({
   navigate
 }: EditCellProps<R, SR>) {
   const frameRequestRef = useRef<number>(undefined);
-  const commitOnOutsideClick = column.editorOptions?.commitOnOutsideClick !== false;
+  const commitOnOutsideClick = column.editorOptions?.commitOnOutsideClick ?? true;
 
   // We need to prevent the `useEffect` from cleaning up between re-renders,
   // as `onWindowCaptureMouseDown` might otherwise miss valid mousedown events.

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface Column<TRow, TSummaryRow = unknown> {
     /** @default true */
     readonly commitOnOutsideClick?: Maybe<boolean>;
     /** @default true */
-    readonly discardOnRowChange?: Maybe<boolean>;
+    readonly closeOnExternalRowChange?: Maybe<boolean>;
   }>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,8 @@ export interface Column<TRow, TSummaryRow = unknown> {
     readonly displayCellContent?: Maybe<boolean>;
     /** @default true */
     readonly commitOnOutsideClick?: Maybe<boolean>;
+    /** @default true */
+    readonly discardOnRowChange?: Maybe<boolean>;
   }>;
 }
 

--- a/test/browser/column/renderEditCell.test.tsx
+++ b/test/browser/column/renderEditCell.test.tsx
@@ -218,7 +218,7 @@ describe('Editor', () => {
       expect(getCellsAtRowIndex(0)[1]).toHaveTextContent(/^a1bac$/);
     });
 
-    it('should discard when discardOnRowChange is true or undefined and row is changed from outside', async () => {
+    it('should discard when closeOnExternalRowChange is true or undefined and row is changed from outside', async () => {
       page.render(
         <EditorTest
           editorOptions={{
@@ -234,12 +234,12 @@ describe('Editor', () => {
       await expect.element(editor).not.toBeInTheDocument();
     });
 
-    it('should not discard when discardOnRowChange is false and row is changed from outside', async () => {
+    it('should not discard when closeOnExternalRowChange is false and row is changed from outside', async () => {
       page.render(
         <EditorTest
           editorOptions={{
             commitOnOutsideClick: false,
-            discardOnRowChange: false
+            closeOnExternalRowChange: false
           }}
         />
       );

--- a/test/browser/column/renderEditCell.test.tsx
+++ b/test/browser/column/renderEditCell.test.tsx
@@ -234,7 +234,7 @@ describe('Editor', () => {
       await expect.element(editor).not.toBeInTheDocument();
     });
 
-    it('should not discard when closeOnExternalRowChange is false and row is changed from outside', async () => {
+    it('should not close the editor when closeOnExternalRowChange is false and row is changed from outside', async () => {
       page.render(
         <EditorTest
           editorOptions={{

--- a/test/browser/column/renderEditCell.test.tsx
+++ b/test/browser/column/renderEditCell.test.tsx
@@ -408,7 +408,12 @@ function EditorTest({
       <button type="button" onClick={() => onSave?.(rows)}>
         save
       </button>
-      <button type="button" onClick={() => setRows((rows) => rows.map((row) => ({ ...row })))}>
+      <button
+        type="button"
+        onClick={() => {
+          setRows((rows) => rows.map((row) => ({ ...row })));
+        }}
+      >
         update
       </button>
       <DataGrid

--- a/test/browser/column/renderEditCell.test.tsx
+++ b/test/browser/column/renderEditCell.test.tsx
@@ -218,7 +218,7 @@ describe('Editor', () => {
       expect(getCellsAtRowIndex(0)[1]).toHaveTextContent(/^a1bac$/);
     });
 
-    it('should discard when closeOnExternalRowChange is true or undefined and row is changed from outside', async () => {
+    it('should close the editor when closeOnExternalRowChange is true or undefined and row is changed from outside', async () => {
       page.render(
         <EditorTest
           editorOptions={{

--- a/test/browser/column/renderEditCell.test.tsx
+++ b/test/browser/column/renderEditCell.test.tsx
@@ -217,6 +217,38 @@ describe('Editor', () => {
       await userEvent.keyboard('a{arrowleft}b{arrowright}c{arrowdown}'); // should commit changes on arrowdown
       expect(getCellsAtRowIndex(0)[1]).toHaveTextContent(/^a1bac$/);
     });
+
+    it('should discard when discardOnRowChange is true or undefined and row is changed from outside', async () => {
+      page.render(
+        <EditorTest
+          editorOptions={{
+            // needed to prevent editor from closing on update button click
+            commitOnOutsideClick: false
+          }}
+        />
+      );
+      await userEvent.dblClick(getCellsAtRowIndex(0)[1]);
+      const editor = page.getByRole('textbox', { name: 'col2-editor' });
+      await expect.element(editor).toBeInTheDocument();
+      await userEvent.click(page.getByRole('button', { name: 'update' }));
+      await expect.element(editor).not.toBeInTheDocument();
+    });
+
+    it('should not discard when discardOnRowChange is false and row is changed from outside', async () => {
+      page.render(
+        <EditorTest
+          editorOptions={{
+            commitOnOutsideClick: false,
+            discardOnRowChange: false
+          }}
+        />
+      );
+      await userEvent.dblClick(getCellsAtRowIndex(0)[1]);
+      const editor = page.getByRole('textbox', { name: 'col2-editor' });
+      await expect.element(editor).toBeInTheDocument();
+      await userEvent.click(page.getByRole('button', { name: 'update' }));
+      await expect.element(editor).toBeInTheDocument();
+    });
   });
 
   describe('editor focus', () => {
@@ -375,6 +407,9 @@ function EditorTest({
       </div>
       <button type="button" onClick={() => onSave?.(rows)}>
         save
+      </button>
+      <button type="button" onClick={() => setRows((rows) => rows.map((row) => ({ ...row })))}>
+        update
       </button>
       <DataGrid
         columns={columns}


### PR DESCRIPTION
Fixes https://github.com/adazzle/react-data-grid/issues/3205