### PR TITLE
Add `columnWidths` and `onColumnWidthsChange` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,26 @@ Height of the header row in pixels.
 
 Height of each summary row in pixels.
 
+###### `columnWidths?: Maybe<ColumnWidths>`
+
+A map of column widths containing both measured and resized widths. If not provided then an internal state is used.
+
+```jsx
+
+const [columnWidths, setColumnWidths] = useState((): ColumnWidths => new Map());
+
+function addNewRow() {
+  setRows(...);
+  setColumnWidths(new Map());
+}
+
+return <DataGrid columnWidths={columnWidths} onColumnWidthsChange={setColumnWidths} ../>
+```
+
+###### `onColumnWidthsChange?: Maybe<(columnWidths: ColumnWidths) => void>`
+
+Callback triggered when column widths change. If not provided then an internal state is used.
+
 ###### `selectedRows?: Maybe<ReadonlySet<K>>`
 
 A set of selected row keys. `rowKeyGetter` is required for row selection to work.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Height of each summary row in pixels.
 
 A map of column widths containing both measured and resized widths. If not provided then an internal state is used.
 
-```jsx
+```tsx
 const [columnWidths, setColumnWidths] = useState((): ColumnWidths => new Map());
 
 function addNewRow() {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ yarn add react-data-grid
 
 Additionally, import the default styles in your application:
 
-```jsx
+```tsx
 import 'react-data-grid/lib/styles.css';
 ```
 
@@ -75,7 +75,7 @@ import 'react-data-grid/lib/styles.css';
 
 Here is a basic example of how to use `react-data-grid` in your React application:
 
-```jsx
+```tsx
 import 'react-data-grid/lib/styles.css';
 
 import { DataGrid } from 'react-data-grid';

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ const [columnWidths, setColumnWidths] = useState((): ColumnWidths => new Map());
 
 function addNewRow() {
   setRows(...);
+  // reset column widths after adding a new row
   setColumnWidths(new Map());
 }
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ Height of each summary row in pixels.
 A map of column widths containing both measured and resized widths. If not provided then an internal state is used.
 
 ```jsx
-
 const [columnWidths, setColumnWidths] = useState((): ColumnWidths => new Map());
 
 function addNewRow() {

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -342,6 +342,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const columnWidths = isColumnWidthsControlled ? columnWidthsRaw : columnWidthsInternal;
   const onColumnWidthsChange = isColumnWidthsControlled
     ? (columnWidths: ColumnWidths) => {
+        // we need to keep the columnWidths state and prop in sync otherwise it leads to bugs like
+        // resize column, auto resize column, and resize column again will use the internal width.
         setColumnWidthsInternal(columnWidths);
         onColumnWidthsChangeRaw(columnWidths);
       }

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -109,6 +109,7 @@ export interface DataGridHandle {
   element: HTMLDivElement | null;
   scrollToCell: (position: PartialPosition) => void;
   selectCell: (position: Position, enableEditor?: Maybe<boolean>) => void;
+  resetMeasuredColumnWidths: () => void;
 }
 
 type SharedDivProps = Pick<
@@ -540,7 +541,10 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
         setScrollToPosition({ idx: scrollToIdx, rowIdx: scrollToRowIdx });
       }
     },
-    selectCell
+    selectCell,
+    resetMeasuredColumnWidths() {
+      setMeasuredColumnWidths(new Map());
+    }
   }));
 
   /**

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -262,8 +262,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     rowHeight: rawRowHeight,
     headerRowHeight: rawHeaderRowHeight,
     summaryRowHeight: rawSummaryRowHeight,
-    columnWidths,
-    onColumnWidthsChange,
+    columnWidths: columnWidthsRaw,
+    onColumnWidthsChange: onColumnWidthsChangeRaw,
     // Feature props
     selectedRows,
     isRowSelectionDisabled,
@@ -326,29 +326,12 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
    */
   const [scrollTop, setScrollTop] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
-  const [resizedColumnWidthsInternal, setResizedColumnWidthsInternal] = useState(
-    (): ReadonlyMap<string, number> => new Map()
-  );
-  const [measuredColumnWidthsInternal, setMeasuredColumnWidthsInternal] = useState(
-    (): ReadonlyMap<string, number> => new Map()
-  );
-  const isColumnWidthsControlled = columnWidths != null;
-  const measuredColumnWidths = isColumnWidthsControlled
-    ? columnWidths.measured
-    : measuredColumnWidthsInternal;
-  const setMeasuredColumnWidths = isColumnWidthsControlled
-    ? (measuredColumnWidths: ReadonlyMap<string, number>) => {
-        onColumnWidthsChange?.({ ...columnWidths, measured: measuredColumnWidths });
-      }
-    : setMeasuredColumnWidthsInternal;
-  const resizedColumnWidths = isColumnWidthsControlled
-    ? columnWidths.resized
-    : resizedColumnWidthsInternal;
-  const setResizedColumnWidths = isColumnWidthsControlled
-    ? (resizedColumnWidths: ReadonlyMap<string, number>) => {
-        onColumnWidthsChange?.({ ...columnWidths, resized: resizedColumnWidths });
-      }
-    : setResizedColumnWidthsInternal;
+  const [columnWidthsInternal, setColumnWidthsInternal] = useState((): ColumnWidths => new Map());
+  const isColumnWidthsControlled = columnWidthsRaw != null && onColumnWidthsChangeRaw != null;
+  const columnWidths = isColumnWidthsControlled ? columnWidthsRaw : columnWidthsInternal;
+  const onColumnWidthsChange = isColumnWidthsControlled
+    ? onColumnWidthsChangeRaw
+    : setColumnWidthsInternal;
 
   const [isDragging, setDragging] = useState(false);
   const [draggedOverRowIdx, setOverRowIdx] = useState<number | undefined>(undefined);
@@ -358,11 +341,9 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
 
   const getColumnWidth = useCallback(
     (column: CalculatedColumn<R, SR>) => {
-      return (
-        resizedColumnWidths.get(column.key) ?? measuredColumnWidths.get(column.key) ?? column.width
-      );
+      return columnWidths.get(column.key)?.width ?? column.width;
     },
-    [measuredColumnWidths, resizedColumnWidths]
+    [columnWidths]
   );
 
   const [gridRef, gridWidth, gridHeight, horizontalScrollbarHeight] = useGridDimensions();
@@ -482,10 +463,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     templateColumns,
     gridRef,
     gridWidth,
-    resizedColumnWidths,
-    measuredColumnWidths,
-    setResizedColumnWidths,
-    setMeasuredColumnWidths,
+    columnWidths,
+    onColumnWidthsChange,
     onColumnResize
   );
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -342,8 +342,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const columnWidths = isColumnWidthsControlled ? columnWidthsRaw : columnWidthsInternal;
   const onColumnWidthsChange = isColumnWidthsControlled
     ? (columnWidths: ColumnWidths) => {
-        // we need to keep the columnWidths state and prop in sync otherwise it leads to bugs like
-        // resize column, auto resize column, and resize column again will use the internal width.
+        // we keep the internal state in sync with the prop but this prevents an extra render
         setColumnWidthsInternal(columnWidths);
         onColumnWidthsChangeRaw(columnWidths);
       }
@@ -1073,6 +1072,11 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   if (selectedPosition.idx > maxColIdx || selectedPosition.rowIdx > maxRowIdx) {
     setSelectedPosition({ idx: -1, rowIdx: minRowIdx - 1, mode: 'SELECT' });
     setDraggedOverRowIdx(undefined);
+  }
+
+  // Keep the state and prop in sync
+  if (isColumnWidthsControlled && columnWidthsInternal !== columnWidthsRaw) {
+    setColumnWidthsInternal(columnWidthsRaw);
   }
 
   let templateRows = `repeat(${headerRowsCount}, ${headerRowHeight}px)`;

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -160,8 +160,9 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * @default 35
    */
   summaryRowHeight?: Maybe<number>;
-  /** */
+  /** A map of column widths */
   columnWidths?: Maybe<ColumnWidths>;
+  /** Callback triggered when column widths change */
   onColumnWidthsChange?: Maybe<(columnWidths: ColumnWidths) => void>;
 
   /**

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -160,6 +160,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * @default 35
    */
   summaryRowHeight?: Maybe<number>;
+  /** */
   columnWidths?: Maybe<ColumnWidths>;
   onColumnWidthsChange?: Maybe<(columnWidths: ColumnWidths) => void>;
 
@@ -326,18 +327,18 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const [scrollTop, setScrollTop] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
   const [resizedColumnWidthsInternal, setResizedColumnWidthsInternal] = useState(
-    (): ReadonlyMap<string, number> => columnWidths?.resized ?? new Map()
+    (): ReadonlyMap<string, number> => new Map()
   );
   const [measuredColumnWidthsInternal, setMeasuredColumnWidthsInternal] = useState(
-    (): ReadonlyMap<string, number> => columnWidths?.measured ?? new Map()
+    (): ReadonlyMap<string, number> => new Map()
   );
-  const isColumnWidthsControlled = columnWidths != null && onColumnWidthsChange != null;
+  const isColumnWidthsControlled = columnWidths != null;
   const measuredColumnWidths = isColumnWidthsControlled
     ? columnWidths.measured
     : measuredColumnWidthsInternal;
   const setMeasuredColumnWidths = isColumnWidthsControlled
     ? (measuredColumnWidths: ReadonlyMap<string, number>) => {
-        onColumnWidthsChange({ ...columnWidths, measured: measuredColumnWidths });
+        onColumnWidthsChange?.({ ...columnWidths, measured: measuredColumnWidths });
       }
     : setMeasuredColumnWidthsInternal;
   const resizedColumnWidths = isColumnWidthsControlled
@@ -345,7 +346,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     : resizedColumnWidthsInternal;
   const setResizedColumnWidths = isColumnWidthsControlled
     ? (resizedColumnWidths: ReadonlyMap<string, number>) => {
-        onColumnWidthsChange({ ...columnWidths, resized: resizedColumnWidths });
+        onColumnWidthsChange?.({ ...columnWidths, resized: resizedColumnWidths });
       }
     : setResizedColumnWidthsInternal;
 

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -60,6 +60,7 @@ type SharedHeaderRowProps<R, SR> = Pick<
   | 'onSortColumnsChange'
   | 'selectCell'
   | 'onColumnResize'
+  | 'onColumnResizeEnd'
   | 'shouldFocusGrid'
   | 'direction'
   | 'onColumnsReorder'
@@ -79,6 +80,7 @@ export default function HeaderCell<R, SR>({
   rowIdx,
   isCellSelected,
   onColumnResize,
+  onColumnResizeEnd,
   onColumnsReorder,
   sortColumns,
   onSortColumnsChange,
@@ -272,7 +274,12 @@ export default function HeaderCell<R, SR>({
       })}
 
       {resizable && (
-        <ResizeHandle column={column} onColumnResize={onColumnResize} direction={direction} />
+        <ResizeHandle
+          column={column}
+          onColumnResize={onColumnResize}
+          onColumnResizeEnd={onColumnResizeEnd}
+          direction={direction}
+        />
       )}
     </div>
   );
@@ -280,10 +287,15 @@ export default function HeaderCell<R, SR>({
 
 type ResizeHandleProps<R, SR> = Pick<
   HeaderCellProps<R, SR>,
-  'column' | 'onColumnResize' | 'direction'
+  'column' | 'onColumnResize' | 'onColumnResizeEnd' | 'direction'
 >;
 
-function ResizeHandle<R, SR>({ column, onColumnResize, direction }: ResizeHandleProps<R, SR>) {
+function ResizeHandle<R, SR>({
+  column,
+  onColumnResize,
+  onColumnResizeEnd,
+  direction
+}: ResizeHandleProps<R, SR>) {
   const resizingOffsetRef = useRef<number>(undefined);
   const isRtl = direction === 'rtl';
 
@@ -314,6 +326,7 @@ function ResizeHandle<R, SR>({ column, onColumnResize, direction }: ResizeHandle
   }
 
   function onLostPointerCapture() {
+    onColumnResizeEnd();
     resizingOffsetRef.current = undefined;
   }
 

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -275,10 +275,10 @@ export default function HeaderCell<R, SR>({
 
       {resizable && (
         <ResizeHandle
+          direction={direction}
           column={column}
           onColumnResize={onColumnResize}
           onColumnResizeEnd={onColumnResizeEnd}
-          direction={direction}
         />
       )}
     </div>
@@ -287,14 +287,14 @@ export default function HeaderCell<R, SR>({
 
 type ResizeHandleProps<R, SR> = Pick<
   HeaderCellProps<R, SR>,
-  'column' | 'onColumnResize' | 'onColumnResizeEnd' | 'direction'
+  'direction' | 'column' | 'onColumnResize' | 'onColumnResizeEnd'
 >;
 
 function ResizeHandle<R, SR>({
+  direction,
   column,
   onColumnResize,
-  onColumnResizeEnd,
-  direction
+  onColumnResizeEnd
 }: ResizeHandleProps<R, SR>) {
   const resizingOffsetRef = useRef<number>(undefined);
   const isRtl = direction === 'rtl';

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -18,6 +18,7 @@ export interface HeaderRowProps<R, SR, K extends React.Key> extends SharedDataGr
   rowIdx: number;
   columns: readonly CalculatedColumn<R, SR>[];
   onColumnResize: (column: CalculatedColumn<R, SR>, width: ResizedWidth) => void;
+  onColumnResizeEnd: () => void;
   selectCell: (position: Position) => void;
   lastFrozenColumnIndex: number;
   selectedCellIdx: number | undefined;
@@ -51,6 +52,7 @@ function HeaderRow<R, SR, K extends React.Key>({
   rowIdx,
   columns,
   onColumnResize,
+  onColumnResizeEnd,
   onColumnsReorder,
   sortColumns,
   onSortColumnsChange,
@@ -78,6 +80,7 @@ function HeaderRow<R, SR, K extends React.Key>({
         rowIdx={rowIdx}
         isCellSelected={selectedCellIdx === column.idx}
         onColumnResize={onColumnResize}
+        onColumnResizeEnd={onColumnResizeEnd}
         onColumnsReorder={onColumnsReorder}
         onSortColumnsChange={onSortColumnsChange}
         sortColumns={sortColumns}

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -12,7 +12,8 @@ export function useColumnWidths<R, SR>(
   gridWidth: number,
   columnWidths: ColumnWidths,
   onColumnWidthsChange: (columnWidths: ColumnWidths) => void,
-  onColumnResize: DataGridProps<R, SR>['onColumnResize']
+  onColumnResize: DataGridProps<R, SR>['onColumnResize'],
+  setColumnResizing: (isColumnResizing: boolean) => void
 ) {
   const [columnToAutoResize, setColumnToAutoResize] = useState<{
     readonly key: string;
@@ -115,6 +116,8 @@ export function useColumnWidths<R, SR>(
         key: resizingKey,
         width: nextWidth
       });
+
+      setColumnResizing(typeof nextWidth === 'number');
     });
 
     setColumnsToMeasureOnResize(null);

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
 
-import type { CalculatedColumn, ResizedWidth } from '../types';
+import type { CalculatedColumn, ColumnWidths, ResizedWidth } from '../types';
 import type { DataGridProps } from '../DataGrid';
 
 export function useColumnWidths<R, SR>(
@@ -10,10 +10,8 @@ export function useColumnWidths<R, SR>(
   templateColumns: readonly string[],
   gridRef: React.RefObject<HTMLDivElement | null>,
   gridWidth: number,
-  resizedColumnWidths: ReadonlyMap<string, number>,
-  measuredColumnWidths: ReadonlyMap<string, number>,
-  setResizedColumnWidths: (resizedColumnWidths: ReadonlyMap<string, number>) => void,
-  setMeasuredColumnWidths: (measuredColumnWidths: ReadonlyMap<string, number>) => void,
+  columnWidths: ColumnWidths,
+  onColumnWidthsChange: (columnWidths: ColumnWidths) => void,
   onColumnResize: DataGridProps<R, SR>['onColumnResize']
 ) {
   const [columnToAutoResize, setColumnToAutoResize] = useState<{
@@ -33,6 +31,7 @@ export function useColumnWidths<R, SR>(
   const columnsToMeasure: string[] = [];
 
   for (const { key, idx, width } of viewportColumns) {
+    const columnWidth = columnWidths.get(key);
     if (key === columnToAutoResize?.key) {
       newTemplateColumns[idx] =
         columnToAutoResize.width === 'max-content'
@@ -42,10 +41,10 @@ export function useColumnWidths<R, SR>(
     } else if (
       typeof width === 'string' &&
       // If the column is resized by the user, we don't want to measure it again
-      !resizedColumnWidths.has(key) &&
+      columnWidth?.type !== 'resized' &&
       (ignorePreviouslyMeasuredColumnsOnGridWidthChange ||
         columnsToMeasureOnResize?.has(key) === true ||
-        !measuredColumnWidths.has(key))
+        columnWidth === undefined)
     ) {
       newTemplateColumns[idx] = width;
       columnsToMeasure.push(key);
@@ -60,33 +59,35 @@ export function useColumnWidths<R, SR>(
     setPreviousGridWidth(gridWidth);
     if (columnsToMeasure.length === 0) return;
 
-    const newMeasuredColumnWidths = new Map(measuredColumnWidths);
+    const newColumnWidths = new Map(columnWidths);
     let hasChanges = false;
 
     for (const key of columnsToMeasure) {
       const measuredWidth = measureColumnWidth(gridRef, key);
-      hasChanges ||= measuredWidth !== measuredColumnWidths.get(key);
+      hasChanges ||= measuredWidth !== columnWidths.get(key)?.width;
       if (measuredWidth === undefined) {
-        newMeasuredColumnWidths.delete(key);
+        newColumnWidths.delete(key);
       } else {
-        newMeasuredColumnWidths.set(key, measuredWidth);
+        newColumnWidths.set(key, { type: 'measured', width: measuredWidth });
       }
-    }
-
-    if (hasChanges) {
-      setMeasuredColumnWidths(newMeasuredColumnWidths);
     }
 
     if (columnToAutoResize !== null) {
       const resizingKey = columnToAutoResize.key;
-      const oldWidth = resizedColumnWidths.get(resizingKey);
+      const oldWidth = columnWidths.get(resizingKey)?.width;
       const newWidth = measureColumnWidth(gridRef, resizingKey);
       if (newWidth !== undefined && oldWidth !== newWidth) {
-        const newResizedColumnWidths = new Map(resizedColumnWidths);
-        newResizedColumnWidths.set(resizingKey, newWidth);
-        setResizedColumnWidths(newResizedColumnWidths);
+        hasChanges = true;
+        newColumnWidths.set(resizingKey, {
+          type: 'resized',
+          width: newWidth
+        });
       }
       setColumnToAutoResize(null);
+    }
+
+    if (hasChanges) {
+      onColumnWidthsChange(newColumnWidths);
     }
   }
 
@@ -98,7 +99,11 @@ export function useColumnWidths<R, SR>(
         // remeasure all the columns that can flex and are not resized by the user
         const columnsToRemeasure = new Set<string>();
         for (const { key, width } of viewportColumns) {
-          if (resizingKey !== key && typeof width === 'string' && !resizedColumnWidths.has(key)) {
+          if (
+            resizingKey !== key &&
+            typeof width === 'string' &&
+            columnWidths.get(key)?.type !== 'resized'
+          ) {
             columnsToRemeasure.add(key);
           }
         }
@@ -115,7 +120,7 @@ export function useColumnWidths<R, SR>(
     setColumnsToMeasureOnResize(null);
 
     if (onColumnResize) {
-      const previousWidth = resizedColumnWidths.get(resizingKey);
+      const previousWidth = columnWidths.get(resizingKey)?.width;
       const newWidth =
         typeof nextWidth === 'number' ? nextWidth : measureColumnWidth(gridRef, resizingKey);
       if (newWidth !== undefined && newWidth !== previousWidth) {

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -44,7 +44,7 @@ export function useColumnWidths<R, SR>(
       typeof width === 'string' &&
       (ignorePreviouslyMeasuredColumns ||
         (temporaryMeasuredColumnWidths !== null
-          ? temporaryMeasuredColumnWidths.has(key)
+          ? !temporaryMeasuredColumnWidths.has(key)
           : !measuredColumnWidths.has(key))) &&
       !resizedColumnWidths.has(key)
     ) {

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
 
-import type { CalculatedColumn, ResizedWidth, StateSetter } from '../types';
+import type { CalculatedColumn, ResizedWidth } from '../types';
 import type { DataGridProps } from '../DataGrid';
 
 export function useColumnWidths<R, SR>(
@@ -12,8 +12,8 @@ export function useColumnWidths<R, SR>(
   gridWidth: number,
   resizedColumnWidths: ReadonlyMap<string, number>,
   measuredColumnWidths: ReadonlyMap<string, number>,
-  setResizedColumnWidths: StateSetter<ReadonlyMap<string, number>>,
-  setMeasuredColumnWidths: (columnWidths: ReadonlyMap<string, number>) => void,
+  setResizedColumnWidths: (resizedColumnWidths: ReadonlyMap<string, number>) => void,
+  setMeasuredColumnWidths: (measuredColumnWidths: ReadonlyMap<string, number>) => void,
   onColumnResize: DataGridProps<R, SR>['onColumnResize']
 ) {
   const [columnToAutoResize, setColumnToAutoResize] = useState<{
@@ -77,16 +77,13 @@ export function useColumnWidths<R, SR>(
 
     if (columnToAutoResize !== null) {
       const resizingKey = columnToAutoResize.key;
-      setResizedColumnWidths((resizedColumnWidths) => {
-        const oldWidth = resizedColumnWidths.get(resizingKey);
-        const newWidth = measureColumnWidth(gridRef, resizingKey);
-        if (newWidth !== undefined && oldWidth !== newWidth) {
-          const newResizedColumnWidths = new Map(resizedColumnWidths);
-          newResizedColumnWidths.set(resizingKey, newWidth);
-          return newResizedColumnWidths;
-        }
-        return resizedColumnWidths;
-      });
+      const oldWidth = resizedColumnWidths.get(resizingKey);
+      const newWidth = measureColumnWidth(gridRef, resizingKey);
+      if (newWidth !== undefined && oldWidth !== newWidth) {
+        const newResizedColumnWidths = new Map(resizedColumnWidths);
+        newResizedColumnWidths.set(resizingKey, newWidth);
+        setResizedColumnWidths(newResizedColumnWidths);
+      }
       setColumnToAutoResize(null);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type {
   Column,
   ColumnGroup,
   ColumnOrColumnGroup,
+  ColumnWidth,
   ColumnWidths,
   CalculatedColumn,
   CalculatedColumnParent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type {
   Column,
   ColumnGroup,
   ColumnOrColumnGroup,
+  ColumnWidths,
   CalculatedColumn,
   CalculatedColumnParent,
   CalculatedColumnOrColumnGroup,

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,10 +329,13 @@ export interface Renderers<TRow, TSummaryRow> {
   noRowsFallback?: Maybe<ReactNode>;
 }
 
-export interface ColumnWidths {
-  readonly measured: ReadonlyMap<string, number>;
-  readonly resized: ReadonlyMap<string, number>;
-}
+export type ColumnWidths = ReadonlyMap<
+  string,
+  {
+    readonly type: 'resized' | 'measured';
+    readonly width: number;
+  }
+>;
 
 export type Direction = 'ltr' | 'rtl';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,13 +329,12 @@ export interface Renderers<TRow, TSummaryRow> {
   noRowsFallback?: Maybe<ReactNode>;
 }
 
-export type ColumnWidths = ReadonlyMap<
-  string,
-  {
-    readonly type: 'resized' | 'measured';
-    readonly width: number;
-  }
->;
+export interface ColumnWidth {
+  readonly type: 'resized' | 'measured';
+  readonly width: number;
+}
+
+export type ColumnWidths = ReadonlyMap<string, ColumnWidth>;
 
 export type Direction = 'ltr' | 'rtl';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,6 +329,11 @@ export interface Renderers<TRow, TSummaryRow> {
   noRowsFallback?: Maybe<ReactNode>;
 }
 
+export interface ColumnWidths {
+  readonly measured: ReadonlyMap<string, number>;
+  readonly resized: ReadonlyMap<string, number>;
+}
+
 export type Direction = 'ltr' | 'rtl';
 
 export type ResizedWidth = number | 'max-content';

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -241,7 +241,7 @@ test('should remeasure flex columns when resizing a column', async () => {
   expect(onColumnResize).toHaveBeenCalledOnce();
 });
 
-test('should use columnWidths and onColumnWidthChange props when provided', async () => {
+test('should use columnWidths and onColumnWidthsChange props when provided', async () => {
   const onColumnWidthsChange = vi.fn();
   setup<Row, unknown>({
     columns,

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -240,3 +240,26 @@ test('should remeasure flex columns when resizing a column', async () => {
   await expect.element(grid).toHaveStyle({ gridTemplateColumns: '79.1406px 919.422px 919.438px' });
   expect(onColumnResize).toHaveBeenCalledOnce();
 });
+
+test('should use columnWidths and onColumnWidthChange props when provided', async () => {
+  const onColumnWidthsChange = vi.fn();
+  setup<Row, unknown>({
+    columns,
+    rows: [],
+    columnWidths: new Map([
+      ['col1', { width: 101, type: 'measured' }],
+      ['col2', { width: 201, type: 'measured' }]
+    ]),
+    onColumnWidthsChange
+  });
+  const grid = getGrid();
+  await expect.element(grid).toHaveStyle({ gridTemplateColumns: '101px 201px' });
+  const [, col2] = getHeaderCells();
+  await autoResize(col2);
+  expect(onColumnWidthsChange).toHaveBeenCalledExactlyOnceWith(
+    new Map([
+      ['col1', { width: 101, type: 'measured' }],
+      ['col2', { width: 100, type: 'resized' }]
+    ])
+  );
+});

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { commands, page, userEvent } from '@vitest/browser/context';
 
-import { DataGrid, type Column, type ColumnWidths } from '../../../src';
+import { DataGrid, type Column, type ColumnWidth, type ColumnWidths } from '../../../src';
 import { resizeHandleClassname } from '../../../src/HeaderCell';
 import { getGrid, getHeaderCells, setup } from '../utils';
 
@@ -249,7 +249,7 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
   function TestGrid() {
     const [columnWidths, setColumnWidths] = useState(
       (): ColumnWidths =>
-        new Map([
+        new Map<string, ColumnWidth>([
           ['col1', { width: 101, type: 'measured' }],
           ['col2', { width: 201, type: 'measured' }]
         ])
@@ -262,7 +262,7 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
 
     function changedColumnWidths() {
       setColumnWidths(
-        new Map([
+        new Map<string, ColumnWidth>([
           ['col1', { width: 101, type: 'measured' }],
           ['col2', { width: 150, type: 'measured' }]
         ])

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -278,7 +278,7 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
           columns={columns}
           rows={[]}
           columnWidths={columnWidths}
-          onColumnWidthsChange={onColymnWidthsChange}
+          onColumnWidthsChange={onColumnWidthsChange}
           onColumnResize={onColumnResizeSpy}
         />
       </>

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -255,7 +255,7 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
         ])
     );
 
-    function onColymnWidthsChange(newColumnWidths: ColumnWidths) {
+    function onColumnWidthsChange(newColumnWidths: ColumnWidths) {
       setColumnWidths(newColumnWidths);
       onColumnWidthsChangeSpy(newColumnWidths);
     }

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -260,14 +260,28 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
       onColumnWidthsChangeSpy(newColumnWidths);
     }
 
+    function changedColumnWidths() {
+      setColumnWidths(
+        new Map([
+          ['col1', { width: 101, type: 'measured' }],
+          ['col2', { width: 150, type: 'measured' }]
+        ])
+      );
+    }
+
     return (
-      <DataGrid<Row>
-        columns={columns}
-        rows={[]}
-        columnWidths={columnWidths}
-        onColumnWidthsChange={onColymnWidthsChange}
-        onColumnResize={onColumnResizeSpy}
-      />
+      <>
+        <button type="button" onClick={changedColumnWidths}>
+          Change widths
+        </button>
+        <DataGrid<Row>
+          columns={columns}
+          rows={[]}
+          columnWidths={columnWidths}
+          onColumnWidthsChange={onColymnWidthsChange}
+          onColumnResize={onColumnResizeSpy}
+        />
+      </>
     );
   }
 
@@ -301,4 +315,18 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
   expect(onColumnResizeSpy).toHaveBeenNthCalledWith(1, expect.objectContaining(columns[1]), 105);
   expect(onColumnResizeSpy).toHaveBeenNthCalledWith(2, expect.objectContaining(columns[1]), 110);
   expect(onColumnResizeSpy).toHaveBeenNthCalledWith(3, expect.objectContaining(columns[1]), 115);
+  onColumnWidthsChangeSpy.mockClear();
+  onColumnResizeSpy.mockClear();
+
+  await userEvent.click(page.getByRole('button', { name: 'Change widths' }));
+  expect(onColumnWidthsChangeSpy).not.toHaveBeenCalled();
+  expect(onColumnResizeSpy).not.toHaveBeenCalled();
+  await expect.element(grid).toHaveStyle({ gridTemplateColumns: '101px 150px' });
+  await resize({ column: col2, resizeBy: [5, 5] });
+  expect(onColumnWidthsChangeSpy).toHaveBeenCalledExactlyOnceWith(
+    new Map([
+      ['col1', { width: 101, type: 'measured' }],
+      ['col2', { width: 160, type: 'resized' }]
+    ])
+  );
 });

--- a/test/browser/column/resizable.test.tsx
+++ b/test/browser/column/resizable.test.tsx
@@ -263,8 +263,8 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
     function changedColumnWidths() {
       setColumnWidths(
         new Map<string, ColumnWidth>([
-          ['col1', { width: 101, type: 'measured' }],
-          ['col2', { width: 150, type: 'measured' }]
+          ['col1', { width: 120, type: 'measured' }],
+          ['col2', { width: 120, type: 'measured' }]
         ])
       );
     }
@@ -321,12 +321,12 @@ test('should use columnWidths and onColumnWidthsChange props when provided', asy
   await userEvent.click(page.getByRole('button', { name: 'Change widths' }));
   expect(onColumnWidthsChangeSpy).not.toHaveBeenCalled();
   expect(onColumnResizeSpy).not.toHaveBeenCalled();
-  await expect.element(grid).toHaveStyle({ gridTemplateColumns: '101px 150px' });
+  await expect.element(grid).toHaveStyle({ gridTemplateColumns: '120px 120px' });
   await resize({ column: col2, resizeBy: [5, 5] });
   expect(onColumnWidthsChangeSpy).toHaveBeenCalledExactlyOnceWith(
     new Map([
-      ['col1', { width: 101, type: 'measured' }],
-      ['col2', { width: 160, type: 'resized' }]
+      ['col1', { width: 120, type: 'measured' }],
+      ['col2', { width: 130, type: 'resized' }]
     ])
   );
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,10 @@ const isCI = process.env.CI === 'true';
 const isTest = process.env.NODE_ENV === 'test';
 
 // TODO: remove when `userEvent.pointer` is supported
-const resizeColumn: BrowserCommand<[resizeBy: number]> = async (context, resizeBy) => {
+const resizeColumn: BrowserCommand<[resizeBy: number | readonly number[]]> = async (
+  context,
+  resizeBy
+) => {
   const page = context.page;
   const frame = await context.frame();
   const resizeHandle = frame.locator('[role="columnheader"][aria-colindex="2"] div');
@@ -18,7 +21,12 @@ const resizeColumn: BrowserCommand<[resizeBy: number]> = async (context, resizeB
     position: { x: 5, y: 5 }
   });
   await page.mouse.down();
-  await page.mouse.move(x + resizeBy + 5, y);
+  resizeBy = Array.isArray(resizeBy) ? resizeBy : [resizeBy];
+  let newX = x + 5;
+  for (const value of resizeBy) {
+    newX += value;
+    await page.mouse.move(newX, y);
+  }
   await page.mouse.up();
 };
 

--- a/website/routes/ColumnsReordering.tsx
+++ b/website/routes/ColumnsReordering.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { DataGrid } from '../../src';
-import type { Column, SortColumn } from '../../src';
+import type { Column, ColumnWidths, SortColumn } from '../../src';
 import { useDirection } from '../directionContext';
 
 export const Route = createFileRoute('/ColumnsReordering')({
@@ -69,16 +69,17 @@ const columns: Column<Row>[] = [
   }
 ];
 
+const initialColumnsOrder: readonly number[] = columns.map((_, index) => index);
+
 function ColumnsReordering() {
   const direction = useDirection();
   const [rows] = useState(createRows);
-  const [columnsOrder, setColumnsOrder] = useState((): readonly number[] =>
-    columns.map((_, index) => index)
-  );
+  const [columnsOrder, setColumnsOrder] = useState(initialColumnsOrder);
   const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
   const onSortColumnsChange = useCallback((sortColumns: SortColumn[]) => {
     setSortColumns(sortColumns.slice(-1));
   }, []);
+  const [columnWidths, setColumnWidths] = useState((): ColumnWidths => new Map());
 
   const reorderedColumns = useMemo(() => {
     return columnsOrder.map((index) => columns[index]);
@@ -119,15 +120,34 @@ function ColumnsReordering() {
     });
   }
 
+  function resetOrderAndWidths() {
+    setColumnsOrder(initialColumnsOrder);
+    setColumnWidths(new Map());
+  }
+
   return (
-    <DataGrid
-      columns={reorderedColumns}
-      rows={sortedRows}
-      sortColumns={sortColumns}
-      onSortColumnsChange={onSortColumnsChange}
-      direction={direction}
-      defaultColumnOptions={{ width: '1fr' }}
-      onColumnsReorder={onColumnsReorder}
-    />
+    <>
+      <button
+        type="button"
+        onClick={resetOrderAndWidths}
+        style={{
+          width: 150,
+          marginBottom: 16
+        }}
+      >
+        Reset Columns
+      </button>
+      <DataGrid
+        columns={reorderedColumns}
+        rows={sortedRows}
+        sortColumns={sortColumns}
+        onSortColumnsChange={onSortColumnsChange}
+        direction={direction}
+        defaultColumnOptions={{ width: '1fr' }}
+        onColumnsReorder={onColumnsReorder}
+        columnWidths={columnWidths}
+        onColumnWidthsChange={setColumnWidths}
+      />
+    </>
   );
 }

--- a/website/routes/CommonFeatures.tsx
+++ b/website/routes/CommonFeatures.tsx
@@ -323,9 +323,6 @@ function CommonFeatures() {
   const [isExporting, setIsExporting] = useState(false);
   const gridRef = useRef<DataGridHandle>(null);
   const columns = useMemo(() => getColumns(countries, direction), [direction]);
-  const [columnWidths, setColumnWidths] = useState(
-    (): ReadonlyMap<string, number> => new Map<string, number>()
-  );
 
   const summaryRows = useMemo((): readonly SummaryRow[] => {
     return [
@@ -385,9 +382,6 @@ function CommonFeatures() {
         <button type="button" onClick={handleExportToPdf}>
           Export to PDF
         </button>
-        <button type="button" onClick={() => setColumnWidths(new Map())}>
-          Reset Width
-        </button>
       </div>
       <DataGrid
         ref={gridRef}
@@ -408,8 +402,6 @@ function CommonFeatures() {
         className="fill-grid"
         direction={direction}
         enableVirtualization={!isExporting}
-        columnWidths={columnWidths}
-        onColumnWidthsChange={setColumnWidths}
       />
     </>
   );

--- a/website/routes/CommonFeatures.tsx
+++ b/website/routes/CommonFeatures.tsx
@@ -323,6 +323,9 @@ function CommonFeatures() {
   const [isExporting, setIsExporting] = useState(false);
   const gridRef = useRef<DataGridHandle>(null);
   const columns = useMemo(() => getColumns(countries, direction), [direction]);
+  const [columnWidths, setColumnWidths] = useState(
+    (): ReadonlyMap<string, number> => new Map<string, number>()
+  );
 
   const summaryRows = useMemo((): readonly SummaryRow[] => {
     return [
@@ -382,6 +385,9 @@ function CommonFeatures() {
         <button type="button" onClick={handleExportToPdf}>
           Export to PDF
         </button>
+        <button type="button" onClick={() => setColumnWidths(new Map())}>
+          Reset Width
+        </button>
       </div>
       <DataGrid
         ref={gridRef}
@@ -402,6 +408,8 @@ function CommonFeatures() {
         className="fill-grid"
         direction={direction}
         enableVirtualization={!isExporting}
+        columnWidths={columnWidths}
+        onColumnWidthsChange={setColumnWidths}
       />
     </>
   );


### PR DESCRIPTION
Fixes
https://github.com/adazzle/react-data-grid/issues/3725 
https://github.com/adazzle/react-data-grid/issues/3403
https://github.com/adazzle/react-data-grid/issues/3133
https://github.com/adazzle/react-data-grid/issues/2042

These new props can be used to reset widths when needed for example 

```
const [columnWidths, setColumnWidths] = useState((): ColumnWidths => new Map());

function addNewRow() {
  setRows(...);
  setColumnWidths(new Map());
}

...
function toggleColumnVisibility(..) {
  setVisibleColumns(...);
  setColumnWidths(new Map());
}

,,
return <DataGrid columnWidths={columnWidths} onColumnWidthsChange={setColumnWidths} ../>
```

If these props are not provided then the grid uses internal state. `onColumnWidthsChange` at the end of the resize operation whereas `onColumnResize` fires as the column is being resized  
