### PR TITLE
Fix focus logic in Firefox

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1196,7 +1196,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       aria-colcount={columns.length}
       aria-rowcount={ariaRowCount}
       // Scrollable containers without tabIndex are keyboard focusable in Chrome only if there is no focusable element inside
-      // whereas they are are always focusable in Firefox. We need to set tabIndex to have a consistent behavior across browsers.
+      // whereas they are always focusable in Firefox. We need to set tabIndex to have a consistent behavior across browsers.
       tabIndex={shouldFocusGrid ? 0 : -1}
       className={clsx(
         rootClassname,

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -663,7 +663,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   function handleFocus(event: React.FocusEvent<HTMLDivElement>) {
     // select the first header cell if the focus event is triggered by the grid
     if (event.target === event.currentTarget) {
-      selectHeaderCell({ idx: 0, rowIdx: headerRowsCount });
+      selectHeaderCell({ idx: minColIdx, rowIdx: headerRowsCount });
     }
   }
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -484,6 +484,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const selectedCellIsWithinViewportBounds = isCellWithinViewportBounds(selectedPosition);
   const scrollHeight =
     headerRowHeight + totalRowHeight + summaryRowsHeight + horizontalScrollbarHeight;
+  const shouldFocusGrid = !selectedCellIsWithinSelectionBounds;
 
   /**
    * The identity of the wrapper function is stable so it won't break memoization
@@ -499,9 +500,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
   const selectCellLatest = useLatestFunc(selectCell);
-  const selectHeaderCellLatest = useLatestFunc(({ idx, rowIdx }: Position) => {
-    selectCell({ rowIdx: minRowIdx + rowIdx - 1, idx });
-  });
+  const selectHeaderCellLatest = useLatestFunc(selectHeaderCell);
 
   /**
    * callbacks
@@ -658,6 +657,13 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       default:
         handleCellInput(event);
         break;
+    }
+  }
+
+  function handleFocus(event: React.FocusEvent<HTMLDivElement>) {
+    // select the first header cell if the focus event is triggered by the grid
+    if (event.target === event.currentTarget) {
+      selectHeaderCell({ idx: 0, rowIdx: headerRowsCount });
     }
   }
 
@@ -865,6 +871,10 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
         column: columns[position.idx]
       });
     }
+  }
+
+  function selectHeaderCell({ idx, rowIdx }: Position) {
+    selectCell({ rowIdx: minRowIdx + rowIdx - 1, idx });
   }
 
   function getNextPosition(key: string, ctrlKey: boolean, shiftKey: boolean): Position {
@@ -1185,6 +1195,9 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       aria-multiselectable={isSelectable ? true : undefined}
       aria-colcount={columns.length}
       aria-rowcount={ariaRowCount}
+      // Scrollable containers without tabIndex are keyboard focusable in Chrome only if there is no focusable element inside
+      // whereas they are are always focusable in Firefox. We need to set tabIndex to have a consistent behavior across browsers.
+      tabIndex={shouldFocusGrid ? 0 : -1}
       className={clsx(
         rootClassname,
         {
@@ -1216,6 +1229,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       }
       dir={direction}
       ref={gridRef}
+      onFocus={shouldFocusGrid ? handleFocus : undefined}
       onScroll={handleScroll}
       onKeyDown={handleKeyDown}
       onCopy={handleCellCopy}
@@ -1252,7 +1266,6 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
                 selectedPosition.rowIdx === mainHeaderRowIdx ? selectedPosition.idx : undefined
               }
               selectCell={selectHeaderCellLatest}
-              shouldFocusGrid={!selectedCellIsWithinSelectionBounds}
               direction={direction}
             />
           </HeaderRowSelectionContext>

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -61,7 +61,6 @@ type SharedHeaderRowProps<R, SR> = Pick<
   | 'selectCell'
   | 'onColumnResize'
   | 'onColumnResizeEnd'
-  | 'shouldFocusGrid'
   | 'direction'
   | 'onColumnsReorder'
 >;
@@ -85,7 +84,6 @@ export default function HeaderCell<R, SR>({
   sortColumns,
   onSortColumnsChange,
   selectCell,
-  shouldFocusGrid,
   direction,
   dragDropKey
 }: HeaderCellProps<R, SR>) {
@@ -152,14 +150,6 @@ export default function HeaderCell<R, SR>({
 
     if (sortable) {
       onSort(event.ctrlKey || event.metaKey);
-    }
-  }
-
-  function handleFocus(event: React.FocusEvent<HTMLDivElement>) {
-    onFocus?.(event);
-    if (shouldFocusGrid) {
-      // Select the first header cell if there is no selected cell
-      selectCell({ idx: 0, rowIdx });
     }
   }
 
@@ -254,14 +244,13 @@ export default function HeaderCell<R, SR>({
       aria-rowspan={rowSpan}
       aria-selected={isCellSelected}
       aria-sort={ariaSort}
-      // set the tabIndex to 0 when there is no selected cell so grid can receive focus
-      tabIndex={shouldFocusGrid ? 0 : tabIndex}
+      tabIndex={tabIndex}
       className={className}
       style={{
         ...getHeaderCellStyle(column, rowIdx, rowSpan),
         ...getCellStyle(column, colSpan)
       }}
-      onFocus={handleFocus}
+      onFocus={onFocus}
       onClick={onClick}
       onKeyDown={onKeyDown}
       {...draggableProps}

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -22,7 +22,6 @@ export interface HeaderRowProps<R, SR, K extends React.Key> extends SharedDataGr
   selectCell: (position: Position) => void;
   lastFrozenColumnIndex: number;
   selectedCellIdx: number | undefined;
-  shouldFocusGrid: boolean;
   direction: Direction;
   headerRowClass: Maybe<string>;
 }
@@ -59,7 +58,6 @@ function HeaderRow<R, SR, K extends React.Key>({
   lastFrozenColumnIndex,
   selectedCellIdx,
   selectCell,
-  shouldFocusGrid,
   direction
 }: HeaderRowProps<R, SR, K>) {
   const dragDropKey = useId();
@@ -85,7 +83,6 @@ function HeaderRow<R, SR, K extends React.Key>({
         onSortColumnsChange={onSortColumnsChange}
         sortColumns={sortColumns}
         selectCell={selectCell}
-        shouldFocusGrid={shouldFocusGrid && index === 0}
         direction={direction}
         dragDropKey={dragDropKey}
       />


### PR DESCRIPTION
https://developer.chrome.com/blog/keyboard-focusable-scrollers
https://bugzilla.mozilla.org/show_bug.cgi?id=1069739

Scrollable containers without tabIndex are keyboard focusable in Chrome only if there is no focusable element inside whereas they are always focusable in Firefox. This causes issues when grid receives focus as FF has an extra tab stop. 

![image](https://github.com/user-attachments/assets/7d2e0fb6-2c36-431f-84d1-b70f379e3896)
![image](https://github.com/user-attachments/assets/74fdf274-c849-4a0c-ab8e-ed391af6c3b7)





