### PR TITLE
Switch to `esbuild` minfier for CSS

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,7 +50,9 @@ export default defineConfig(({ command, isPreview }) => ({
   build: {
     modulePreload: { polyfill: false },
     sourcemap: true,
-    reportCompressedSize: false
+    reportCompressedSize: false,
+    // https://github.com/parcel-bundler/lightningcss/issues/873
+    cssMinify: 'esbuild'
   },
   plugins: [
     (!isTest || isPreview) &&


### PR DESCRIPTION
`lightingcss` (default `cssMinify` in `Vite`) has a bug and css bundles are minified incorrectly 
https://adazzle.github.io/react-data-grid/#/ContextMenu