### PR TITLE
Make row overscan threshold configurable

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -221,6 +221,9 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   /** @default true */
   enableVirtualization?: Maybe<boolean>;
 
+  /** additional rows to render below the viewport, defaults to 4 */
+  rowOverscanThreshold?: number;
+
   /**
    * Miscellaneous
    */
@@ -284,6 +287,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     onCellPaste,
     // Toggles and modes
     enableVirtualization: rawEnableVirtualization,
+    rowOverscanThreshold = 4,
     // Miscellaneous
     renderers,
     className,
@@ -447,7 +451,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     rowHeight,
     clientHeight,
     scrollTop,
-    enableVirtualization
+    enableVirtualization,
+    overscanThreshold: rowOverscanThreshold
   });
 
   const viewportColumns = useViewportColumns({

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -8,6 +8,7 @@ interface ViewportRowsArgs<R> {
   clientHeight: number;
   scrollTop: number;
   enableVirtualization: boolean;
+  overscanThreshold: number;
 }
 
 export function useViewportRows<R>({
@@ -15,7 +16,8 @@ export function useViewportRows<R>({
   rowHeight,
   clientHeight,
   scrollTop,
-  enableVirtualization
+  enableVirtualization,
+  overscanThreshold
 }: ViewportRowsArgs<R>) {
   const { totalRowHeight, gridTemplateRows, getRowTop, getRowHeight, findRowIdx } = useMemo(() => {
     if (typeof rowHeight === 'number') {
@@ -76,7 +78,6 @@ export function useViewportRows<R>({
   let rowOverscanEndIdx = rows.length - 1;
 
   if (enableVirtualization) {
-    const overscanThreshold = 4;
     const rowVisibleStartIdx = findRowIdx(scrollTop);
     const rowVisibleEndIdx = findRowIdx(scrollTop + clientHeight);
     rowOverscanStartIdx = max(0, rowVisibleStartIdx - overscanThreshold);


### PR DESCRIPTION
 This PR makes the row overscan threshold configurable.
 
Currently the overscan threshold is hard coded at 4, but especially when using rows with lots of elements it can be a performance bottleneck if 4 additional rows are rendered at the bottom