### PR TITLE
Make selectCell use the passed shouldFocusCell parameter even if same position

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -839,6 +839,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       setSelectedPosition({ ...position, mode: 'EDIT', row, originalRow: row });
     } else if (samePosition) {
       // Avoid re-renders if the selected cell state is the same
+      setShouldFocusCell(options?.shouldFocusCell === true);
       scrollIntoView(getCellToScroll(gridRef.current!));
     } else {
       setShouldFocusCell(options?.shouldFocusCell === true);


### PR DESCRIPTION
Working on a project where we need to re-focus a cell after it has lost focus (due to a row being deleted from the grid). Calling `selectCell` with `shouldFocusCell: true` isn’t sufficient, because the cell is already selected but not focused.