### PR TITLE
Tweak publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,10 +66,10 @@ jobs:
 
       # https://docs.npmjs.com/trusted-publishers
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --tag latest
 
-      - name: Push commit and tag
-        run: git push origin main --follow-tags
+      - name: Push tag
+        run: git push origin v${{ inputs.version }}
 
       - name: Create GitHub Release
         run: gh release create v${{ inputs.version }} --title "v${{ inputs.version }}" --generate-notes

--- a/package.json
+++ b/package.json
@@ -47,9 +47,7 @@
     "eslint:fix": "node --run eslint -- --fix",
     "prettier:check": "prettier --check .",
     "prettier:format": "prettier --write .",
-    "typecheck": "tsc --build",
-    "prepublishOnly": "npm install && node --run build",
-    "postpublish": "git push --follow-tags origin HEAD"
+    "typecheck": "tsc --build"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",


### PR DESCRIPTION
[Dry-ran](https://github.com/Comcast/react-data-grid/actions/workflows/publish.yml) the publishing workflow to test things out, and tweaked the following:
- added `--tag latest` to ensure we can publish even pre-release versions
  - in the future it might be nice to add a [choice input](https://stackoverflow.com/questions/69296314/dropdown-for-github-workflows-input-parameters) to confirm which npm dist-tag to publish to
  - for now we only want to push to the latest so this is fine
- because of branch protections, we can't push back to main, so now we'll only push the tag, and we'll have to merge the tag onto `main` manually
- removed `prepublishOnly`/`postpublish` commands from the `package.json`
  - we had these for the manual publishing workflow